### PR TITLE
feat(exe-coder): prebuilt image + Coder gcp-vm-container template

### DIFF
--- a/.github/workflows/publish-devcontainer.yaml
+++ b/.github/workflows/publish-devcontainer.yaml
@@ -1,0 +1,83 @@
+name: Publish Dev Container Image
+
+# Build .devcontainer/devcontainer.json into an OCI image and push it to
+# Artifact Registry so the Coder workspace template
+# (exe/coder/templates/dotfiles-devcontainer) can pull a prebuilt image
+# instead of running envbuilder per workspace.
+#
+# Auth uses Workload Identity Federation: no long-lived service account
+# keys checked into secrets. The pool / provider / SA are managed by
+# tofu/exe/iam.tf — see also docs/adr/0002-coder-prebuilt-image.md.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - .devcontainer/**
+      - .github/workflows/publish-devcontainer.yaml
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  id-token: write # required for google-github-actions/auth via WIF
+
+env:
+  AR_REGION: asia-northeast1
+  AR_PROJECT: gen-ai-hironow
+  AR_REPO: dotfiles
+  AR_IMAGE: devcontainer
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Authenticate to Google Cloud (Workload Identity Federation)
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
+        with:
+          workload_identity_provider: ${{ vars.GCP_WIF_PROVIDER }}
+          service_account: ${{ vars.GCP_PUBLISH_SA }}
+
+      - name: Configure docker auth for Artifact Registry
+        run: |
+          gcloud auth configure-docker "${AR_REGION}-docker.pkg.dev" --quiet
+
+      - name: Compute image tags
+        id: tags
+        run: |
+          base="${AR_REGION}-docker.pkg.dev/${AR_PROJECT}/${AR_REPO}/${AR_IMAGE}"
+          # Mutable :main tag tracks HEAD of main; immutable :<sha> tag
+          # gives reproducible references the Coder template can pin.
+          {
+            echo "image_main=${base}:main"
+            echo "image_sha=${base}:${GITHUB_SHA::12}"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Build and push dev container image
+        uses: devcontainers/ci@b63b30de439b47a52267f241112c5b453b673db5 # v0.3.1900000449
+        with:
+          imageName: ${{ steps.tags.outputs.image_main }}
+          imageTag: latest
+          push: always
+          # The :main tag above is the rolling pointer; also tag the
+          # immutable :<sha> reference for repeatable rollbacks.
+          # devcontainers/ci pushes whatever imageName declares; we
+          # add the second tag manually after.
+          env: |
+            GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
+
+      - name: Tag image with commit SHA
+        run: |
+          docker tag "${{ steps.tags.outputs.image_main }}" "${{ steps.tags.outputs.image_sha }}"
+          docker push "${{ steps.tags.outputs.image_sha }}"
+
+      - name: Summary
+        run: |
+          echo "::notice::published ${{ steps.tags.outputs.image_main }}"
+          echo "::notice::published ${{ steps.tags.outputs.image_sha }}"

--- a/docs/adr/0002-coder-prebuilt-image.md
+++ b/docs/adr/0002-coder-prebuilt-image.md
@@ -1,0 +1,120 @@
+# 0002. Coder workspace template uses a prebuilt dev container image
+
+**Date:** 2026-05-02
+**Status:** Accepted
+
+## Context
+
+ADR 0001 migrated the local IDE / CI / Coder workspace contract to a
+single SoT (`.devcontainer/devcontainer.json`) with debian-12 +
+features. The Coder template at
+`exe/coder/templates/dotfiles-devcontainer/` continued to use the
+**envbuilder pattern** to materialise that contract on each workspace
+VM:
+
+1. GCE VM boots Ubuntu/Debian.
+2. envbuilder image runs as a container.
+3. envbuilder clones the dotfiles repo, reads `.devcontainer/devcontainer.json`,
+   resolves features, and runs `docker buildx build` inside the VM.
+4. The resulting image becomes the workspace container.
+
+This works but has three operational drawbacks for a personal stack:
+
+- **Workspace start time**: 3-5 minutes per `cdr create` (clone + apt
+  install of buildkit + features download + image build).
+- **CPU/memory headroom**: envbuilder + buildkit need an `e2-small`
+  minimum. e2-micro OOMs.
+- **Failure modes**: every workspace re-runs the build, so a
+  transient apt mirror outage or feature registry hiccup blocks
+  workspace boot.
+
+## Decision
+
+Replace the envbuilder-per-workspace pattern with a **prebuilt
+image + gcp-vm-container pattern**:
+
+1. **CI publishes the image once per main merge.** A new workflow
+   `.github/workflows/publish-devcontainer.yaml` invokes
+   `devcontainers/ci@<sha>` with `push: always`, tagging the image
+   `<region>-docker.pkg.dev/<project>/dotfiles/devcontainer:main`
+   (rolling) and `:<git-sha>` (immutable) in **Artifact Registry**.
+
+2. **Workload Identity Federation, no SA keys.** The publish workflow
+   authenticates via `google-github-actions/auth@<sha>` against a
+   WIF pool restricted to `assertion.repository == 'hironow/dotfiles'`.
+   The federated SA holds only `roles/artifactregistry.writer` on the
+   `dotfiles` repo. WIF infra lives in `tofu/exe/iam.tf`.
+
+3. **Workspace template pulls the image and runs it.** The new
+   template (gcp-vm-container-style) keeps the debian-12 host VM,
+   installs tailscale + gcloud + docker on first boot, then:
+
+   ```sh
+   gcloud --quiet auth configure-docker <region>-docker.pkg.dev
+   docker pull <repo>/devcontainer:main
+   docker run --network host --restart unless-stopped \
+     --env CODER_AGENT_TOKEN=... --env CODER_AGENT_URL=http://exe-coder:7080 \
+     <image> sh -c '<base64-encoded coder_agent init_script>'
+   ```
+
+   No envbuilder, no buildkit, no in-VM image build.
+
+4. **Workspace SA gains `roles/artifactregistry.reader`** on the
+   dotfiles repo. The existing `exe-workspace@…` SA is reused; the
+   tofu binding is in `tofu/exe/iam.tf`.
+
+## Consequences
+
+### Positive
+
+- **Workspace start time drops from minutes to ~30-60s** — only docker
+  pull + container start, no build.
+- **Smaller VM tier viable.** e2-micro is now sufficient for many
+  workloads (no envbuilder/buildkit RAM pressure). The template
+  exposes e2-micro as an option but defaults to e2-small for
+  headroom.
+- **Failure isolation**: image build problems surface in CI before
+  any workspace tries to use the bad image. Workspace creation
+  itself only depends on Artifact Registry availability.
+- **Deterministic rollbacks.** The `:<git-sha>` immutable tag lets
+  the template be pinned to a specific commit; reverting the image
+  variable rolls back without a Coder template re-push.
+
+### Negative
+
+- **One more piece of CI infra to maintain.** The publish workflow
+  must keep working; if it breaks, new commits to main do not flow
+  into the rolling `:main` tag and operators silently get stale
+  workspaces.
+- **Artifact Registry storage cost.** Cleanup policies on the AR
+  repo cap to 10 most-recent versions and delete untagged-after-7-days
+  to bound this.
+- **`devcontainers/ci` action is still non-verified Marketplace.**
+  Same allowlist requirement as PR #53; covered already.
+- **No build-time customisation per workspace.** envbuilder allowed
+  per-workspace `cache_repo` / `fallback_image` / branch override.
+  These are removed; if a developer needs to test a feature branch
+  of the dev container itself, they push the image manually via
+  `devcontainer build --push <tag>` and pin the workspace template
+  to that tag.
+
+### Neutral
+
+- **Tailscale still on the host.** The workspace container is
+  `--network host` so it shares the host's tailnet identity. We
+  considered moving tailscale into the container (cleaner privacy
+  boundary) but the host install is simpler and matches the prior
+  template.
+- **dotfiles_uri parameter retained.** Personalisation still flows
+  through `coder dotfiles -y URL` after the agent starts. The
+  prebuilt image already has gcloud / mise / uv / just / sheldon,
+  so install.sh's `command -v gcloud` short-circuits the gcloud
+  install branch — `INSTALL_SKIP_HOMEBREW=1 INSTALL_SKIP_ADD_UPDATE=1`
+  remain.
+- **Operator-side WIF setup is one-time.** After `tofu apply`, set
+  the GitHub repo variables:
+
+  ```bash
+  gh variable set GCP_WIF_PROVIDER --body "$(just exe-output -raw gcp_wif_provider_resource_name)"
+  gh variable set GCP_PUBLISH_SA   --body "$(just exe-output -raw gcp_publish_sa_email)"
+  ```

--- a/exe/coder/templates/dotfiles-devcontainer/README.md
+++ b/exe/coder/templates/dotfiles-devcontainer/README.md
@@ -1,47 +1,51 @@
-# Coder template — dotfiles devcontainer
+# Coder template — dotfiles devcontainer (prebuilt image)
 
 This template spawns a Coder workspace whose container image is the
 **dotfiles dev container** declared by `.devcontainer/devcontainer.json`
-(debian-12 + devcontainer features). The same SoT is consumed by the
-local IDE and the CI sandbox, so all three environments stay aligned.
-It is the realisation of the core `docs/intent.md` line item:
+(debian-12 + devcontainer features), prebuilt by CI and pulled from
+Artifact Registry. Same SoT as the local IDE and the CI sandbox, so
+all three environments stay aligned. Realises `docs/intent.md`:
 
 > Coder workspace whose container image **is** the dotfiles Dev
 > Container.
 
+ADR: `docs/adr/0002-coder-prebuilt-image.md`
+
 ## How it works
 
 ```
-+-------------+   ENVBUILDER_GIT_URL    +--------------+
-| Coder server|------------------------>|  envbuilder  |
-| (this stack)|                         |  (in a GCE   |
-+-------------+                         |   VM, host)  |
-                                        +------+-------+
-                                               |
-                                               v
-                                        +------+-------+
-                                        | spawn dev    |
-                                        | container    |
-                                        | from         |
-                                        | repo_url's   |
-                                        | .devcontainer|
-                                        +------+-------+
-                                               |
-                                               v
-                                        +--------------+
-                                        | coder_agent  |
-                                        | (inside the  |
-                                        |  container)  |
-                                        +--------------+
++----------------+   docker pull   +------------------+
+| Coder template |---------------->| Artifact Registry|
+| (this dir)     |                 |  asia-northeast1 |
++----------------+                 +------------------+
+        |                                  ^
+        |                                  | docker push
+        |                                  |
+        v                          +-------+----------+
++--------------+                   | publish-         |
+| Coder server |                   | devcontainer.yaml|
++--------------+                   | (GHA, WIF auth)  |
+        |                          +------------------+
+        v
++--------------+    docker run     +--------------+
+| Workspace VM |------------------>| dev container|
+| (debian-12)  |                   | (prebuilt)   |
++--------------+                   +--------------+
+                                          |
+                                          v
+                                   +--------------+
+                                   |  coder_agent |
+                                   +--------------+
 ```
 
-```
 Legend / 凡例:
-- ENVBUILDER_GIT_URL: envbuilder が clone する git repo
-- envbuilder: Coder 公式 OCI builder (kaniko-style)
-- dev container: .devcontainer/devcontainer.json を解釈して立ち上がる
+
+- Artifact Registry: GCP \<region\>-docker.pkg.dev/\<project\>/dotfiles
+- publish-devcontainer.yaml: GitHub Actions が main merge 時に image build & push
+- WIF auth: Workload Identity Federation, no SA keys
+- Workspace VM: GCE debian-12 + tailscaled + docker, pulls prebuilt image
+- dev container: 起動済みの devcontainer.json image をそのまま走らせる (no envbuilder)
 - coder_agent: workspace 内常駐の Coder agent (SSH / IDE)
-```
 
 ## Push
 
@@ -51,16 +55,17 @@ cdr templates push exe-dotfiles-devcontainer \
   --variable project_id=gen-ai-hironow \
   --variable workspace_sa_email=$(just exe-output -raw exe_workspace_sa_email) \
   --variable coder_internal_url=$(just exe-output -raw coder_internal_url) \
+  --variable image=$(just exe-output -raw artifact_registry_repo)/devcontainer:main \
   --yes
 ```
 
 | Variable | Default | Notes |
 |---|---|---|
 | `project_id` | `gen-ai-hironow` | GCP project for workspace VMs |
-| `workspace_sa_email` | (required) | from `just exe-output -raw exe_workspace_sa_email` |
+| `workspace_sa_email` | (required) | `just exe-output -raw exe_workspace_sa_email` |
 | `coder_internal_url` | `http://exe-coder:7080` | tailnet-internal URL the agent download resolves to |
 | `workspace_authkey_secret_id` | `exe-tailscale-workspace-authkey` | Secret Manager id for the tag:exe-workspace key |
-| `cache_repo` | `""` | Optional; pre-built devcontainer image cache |
+| `image` | `asia-northeast1-docker.pkg.dev/gen-ai-hironow/dotfiles/devcontainer:main` | prebuilt image; pin to `:<git-sha>` for reproducible workspaces |
 
 ## Create a workspace
 
@@ -73,16 +78,12 @@ Parameters (interactive on first create unless `--parameter` is passed):
 
 | Parameter | Default | Notes |
 |---|---|---|
-| `repo_url` | `https://github.com/hironow/dotfiles.git` | repo with `.devcontainer/` |
-| `git_branch` | `""` (= repo HEAD) | override branch for pre-merge testing |
-| `instance_type` | `e2-small` | `e2-micro` OOMs envbuilder |
-| `fallback_image` | `codercom/enterprise-base:ubuntu` | used if devcontainer build fails |
-| `devcontainer_builder` | `ghcr.io/coder/envbuilder:latest` | pin a digest in production |
-| `dotfiles_uri` | `https://github.com/hironow/dotfiles.git` | runs `coder dotfiles` on top of the dev container |
+| `instance_type` | `e2-small` | `e2-micro` is now viable (no envbuilder) |
+| `dotfiles_uri` | `https://github.com/hironow/dotfiles.git` | runs `coder dotfiles` on top of the prebuilt image |
 
 ## Smoke
 
 ```bash
-cdr workspaces list                # status: starting -> running
+cdr workspaces list                # status: starting -> running (~30-60s)
 cdr ssh my-ws.dev -- just --list   # JustSandbox recipes available
 ```

--- a/exe/coder/templates/dotfiles-devcontainer/main.tf
+++ b/exe/coder/templates/dotfiles-devcontainer/main.tf
@@ -1,28 +1,30 @@
-# exe.hironow.dev workspace template — dotfiles devcontainer.
+# exe.hironow.dev workspace template — dotfiles devcontainer (prebuilt image).
 #
-# Adapted from coder/coder examples/templates/gcp-devcontainer.
+# Adapted from coder/coder examples/templates/gcp-vm-container.
 # Differences from upstream:
-#   - default repo_url    = https://github.com/hironow/dotfiles.git
-#                           (this stack's reason for existing — see
-#                            docs/intent.md "Coder workspace whose
-#                            container image IS the dotfiles Dev Container")
-#   - default project_id  = gen-ai-hironow
-#   - default region      = asia (us+europe upstream)
-#   - default instance    = e2-small (e2-micro upstream — too small
-#                            for an envbuilder build, OOMs)
-#   - browser IDE module the upstream gcp-devcontainer template ships
-#                          with `registry.coder.com/coder/<browser-ide>/coder`
-#                          as a sibling resource; we drop it. Terminal-
-#                          first is the stated workflow; reintroduce a
-#                          browser IDE in a follow-up if the need arises.
-#   - dotfiles_uri param  added so workspaces auto-clone & install
-#                           hironow's personal dotfiles on top of the
-#                           devcontainer base.
+#   - default project_id   = gen-ai-hironow
+#   - default region       = asia (us+europe upstream)
+#   - workspace VM is debian-12 (not COS) so apt-installed tailscaled
+#                            can run on the host and the workspace
+#                            container can reach exe-coder over the
+#                            tailnet — see B-plan in
+#                            docs/handover.md / docs/adr/0001.
+#   - prebuilt container image pulled from Artifact Registry; built
+#                            and pushed by the publish-devcontainer
+#                            workflow on each main merge. envbuilder
+#                            is no longer in the path
+#                            (docs/adr/0002-coder-prebuilt-image.md).
+#   - dotfiles_uri parameter retained — `coder dotfiles` still runs
+#                            the operator's personalisation on top
+#                            of the baked-in image.
 #
 # Push:
 #   cdr templates push exe-dotfiles-devcontainer \
 #     -d exe/coder/templates/dotfiles-devcontainer \
-#     --variable project_id=gen-ai-hironow
+#     --variable project_id=gen-ai-hironow \
+#     --variable workspace_sa_email=$(just exe-output -raw exe_workspace_sa_email) \
+#     --variable coder_internal_url=$(just exe-output -raw coder_internal_url) \
+#     --variable image=$(just exe-output -raw artifact_registry_repo)/devcontainer:main
 #
 # Create a workspace:
 #   cdr create my-ws --template exe-dotfiles-devcontainer
@@ -35,9 +37,6 @@ terraform {
     google = {
       source = "hashicorp/google"
     }
-    envbuilder = {
-      source = "coder/envbuilder"
-    }
   }
 }
 
@@ -48,27 +47,20 @@ terraform {
 # from the public URL. Pointed at the tailnet-internal endpoint so
 # the download bypasses the public CF Access edge — workspaces have
 # no service token and would otherwise receive the OIDC interstitial
-# HTML instead of the binary. See coder/coder
-# provisioner/terraform/provision.go provisionEnv() for the
-# server-side rendering path.
+# HTML instead of the binary.
 provider "coder" {
   url = var.coder_internal_url
 }
 
 # Provider-level zone is fixed to the stack's home zone so the
 # template-push preview plan can resolve a non-empty string. The
-# 'gcp_region' Coder parameter still drives the *workspace* zone,
-# but per-resource (see google_compute_instance.vm.zone). Without
-# this fallback, push fails with 'expected a non-empty string' on
-# the provider block because the parameter default does not
-# propagate at preview time.
+# 'gcp_region' Coder parameter still drives the *workspace* zone
+# per-resource (see google_compute_instance.vm.zone).
 provider "google" {
   region  = "asia-northeast1"
   zone    = "asia-northeast1-a"
   project = var.project_id
 }
-
-data "google_compute_default_service_account" "default" {}
 
 data "coder_workspace" "me" {}
 data "coder_workspace_owner" "me" {}
@@ -95,7 +87,9 @@ variable "workspace_sa_email" {
   description = <<-EOF
 Service account email stamped on every workspace VM. Must have
 roles/secretmanager.secretAccessor on the tag:exe-workspace tailnet
-authkey secret. Operator stack exports it as 'exe_workspace_sa_email'.
+authkey secret AND roles/artifactregistry.reader on the dotfiles
+Artifact Registry repo. Operator stack exports it as
+'exe_workspace_sa_email'.
 EOF
   type        = string
 }
@@ -111,17 +105,15 @@ EOF
   default     = "exe-tailscale-workspace-authkey"
 }
 
-variable "cache_repo" {
-  default     = ""
-  description = "(Optional) Container registry to cache devcontainer builds. Example: host.tld/path/to/repo."
+variable "image" {
+  description = <<-EOF
+OCI image reference the workspace runs as its dev container. Built
+by .github/workflows/publish-devcontainer.yaml from
+.devcontainer/devcontainer.json on each main merge. Operator can
+pin to an immutable :<sha> tag for stability or :main for rolling.
+EOF
   type        = string
-}
-
-variable "cache_repo_docker_config_path" {
-  default     = ""
-  description = "(Optional) Path to a docker config.json containing credentials to the cache repo."
-  sensitive   = true
-  type        = string
+  default     = "asia-northeast1-docker.pkg.dev/gen-ai-hironow/dotfiles/devcontainer:main"
 }
 
 # Region picker. asia is the home region for this stack; allow
@@ -141,6 +133,10 @@ data "coder_parameter" "instance_type" {
   order        = 2
   default      = "e2-small"
   option {
+    name  = "e2-micro (2C, 1G) — minimal"
+    value = "e2-micro"
+  }
+  option {
     name  = "e2-small (2C, 2G) — default"
     value = "e2-small"
   }
@@ -158,116 +154,44 @@ data "coder_parameter" "instance_type" {
   }
 }
 
-data "coder_parameter" "fallback_image" {
-  default      = "codercom/enterprise-base:ubuntu"
-  description  = "Image used if the devcontainer build fails (envbuilder fallback)."
-  display_name = "Fallback Image"
-  mutable      = true
-  name         = "fallback_image"
-  order        = 3
-}
-
-data "coder_parameter" "devcontainer_builder" {
-  description  = <<-EOF
-Image that builds the devcontainer (envbuilder). Pin a digest in
-production; :latest is convenient for personal stacks.
-EOF
-  display_name = "Devcontainer Builder"
-  mutable      = true
-  name         = "devcontainer_builder"
-  default      = "ghcr.io/coder/envbuilder:latest"
-  order        = 4
-}
-
-data "coder_parameter" "repo_url" {
-  name         = "repo_url"
-  display_name = "Repository URL"
-  default      = "https://github.com/hironow/dotfiles.git"
-  description  = "Git repo with .devcontainer/ — defaults to the dotfiles dev container the stack was designed around."
-  mutable      = true
-  order        = 1
-}
-
-data "coder_parameter" "git_branch" {
-  name         = "git_branch"
-  display_name = "Git Branch"
-  description  = <<-EOF
-Branch to clone from repo_url. Leave blank for the repo's default
-(usually main). Set to e.g. 'feat/exe-hironow-dev' to test changes
-before they are merged into main.
-EOF
-  default      = ""
-  mutable      = true
-  order        = 6
-}
-
 data "coder_parameter" "dotfiles_uri" {
   name         = "dotfiles_uri"
   display_name = "Dotfiles URI"
   description  = <<-EOF
-Personal dotfiles repo cloned + installed on top of the
-devcontainer base (Coder runs `dotfiles install` after the agent
+Personal dotfiles repo cloned + installed on top of the prebuilt
+container image (Coder runs `coder dotfiles` after the agent
 starts). Leave blank to skip.
 EOF
   default      = "https://github.com/hironow/dotfiles.git"
   mutable      = true
-  order        = 5
+  order        = 1
 }
 
-data "local_sensitive_file" "cache_repo_dockerconfigjson" {
-  count    = var.cache_repo_docker_config_path == "" ? 0 : 1
-  filename = var.cache_repo_docker_config_path
-}
-
-# Be careful when modifying the locals — they wire the agent token
-# and init script into envbuilder's environment.
 locals {
-  linux_user                 = lower(substr(data.coder_workspace_owner.me.name, 0, 32))
-  container_name             = "coder-${data.coder_workspace_owner.me.name}-${lower(data.coder_workspace.me.name)}"
-  devcontainer_builder_image = data.coder_parameter.devcontainer_builder.value
-  docker_config_json_base64  = try(data.local_sensitive_file.cache_repo_dockerconfigjson[0].content_base64, "")
+  linux_user     = lower(substr(data.coder_workspace_owner.me.name, 0, 32))
+  container_name = "coder-${data.coder_workspace_owner.me.name}-${lower(data.coder_workspace.me.name)}"
 
-  envbuilder_env = {
-    "ENVBUILDER_GIT_URL" : data.coder_parameter.repo_url.value,
-    # Empty value = envbuilder honours the repo's default branch.
-    # Set this to e.g. 'feat/exe-hironow-dev' to test pre-merge
-    # changes (libc6-compat in Dockerfile, new tests, etc.) without
-    # waiting for a merge to main. Once merged, leave it blank.
-    "ENVBUILDER_GIT_BRANCH" : data.coder_parameter.git_branch.value,
-    "CODER_AGENT_TOKEN" : try(coder_agent.dev[0].token, ""),
-    "CODER_AGENT_URL" : data.coder_workspace.me.access_url,
-    "ENVBUILDER_INIT_SCRIPT" : "echo ${base64encode(try(coder_agent.dev[0].init_script, ""))} | base64 -d | sh",
-    "ENVBUILDER_DOCKER_CONFIG_BASE64" : try(data.local_sensitive_file.cache_repo_dockerconfigjson[0].content_base64, ""),
-    "ENVBUILDER_FALLBACK_IMAGE" : data.coder_parameter.fallback_image.value,
-    "ENVBUILDER_CACHE_REPO" : var.cache_repo,
-    "ENVBUILDER_PUSH_IMAGE" : var.cache_repo == "" ? "" : "true",
-  }
-
-  docker_env_input       = try(envbuilder_cached_image.cached[0].env_map, local.envbuilder_env)
-  docker_env_list_base64 = base64encode(join("\n", [for k, v in local.docker_env_input : "${k}=${v}"]))
-  builder_image          = try(envbuilder_cached_image.cached[0].image, data.coder_parameter.devcontainer_builder.value)
-
+  # Startup script for the workspace VM. Brings the host onto the
+  # tailnet and then `docker run`s the prebuilt dev container image.
+  # Order matters: tailscale must come up before docker pull,
+  # because the agent binary download (BINARY_URL) is served by
+  # exe-coder over MagicDNS.
   startup_script = <<-META
     #!/usr/bin/env sh
     set -eux
 
-    # Workspace user.
     if ! id -u "${local.linux_user}" >/dev/null 2>&1; then
       useradd -m -s /bin/bash "${local.linux_user}"
       echo "${local.linux_user} ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/coder-user
     fi
 
     # ---- Tailscale --------------------------------------------------
-    # Workspace VMs talk to the Coder control-plane VM
-    # (exe-coder:7080) over the tailnet. Without this step, the agent
-    # binary download from the bootstrap script falls back to the
-    # public CODER_ACCESS_URL which sits behind Cloudflare Access and
-    # returns OIDC interstitial HTML for unauthenticated requests —
-    # which the bootstrap script then 'chmod +x'es and tries to exec,
-    # producing 'syntax error: unexpected newline' and a workspace
-    # that never connects. See docs/handover.md for the full
-    # post-mortem. This is base image debian-12 (see google_compute_disk
-    # boot image), so apt is the install path.
+    # Workspace VMs reach the Coder control-plane VM (exe-coder:7080)
+    # over the tailnet. Without this step, the agent binary download
+    # falls back to the public CF Access URL which returns OIDC
+    # interstitial HTML for unauthenticated requests — bootstrap
+    # would `chmod +x` it and exec, producing
+    # 'syntax error: unexpected newline'.
     if ! command -v tailscale >/dev/null 2>&1; then
       install -m 0755 -d /usr/share/keyrings
       curl -fsSL https://pkgs.tailscale.com/stable/debian/bookworm.noarmor.gpg \
@@ -279,8 +203,8 @@ locals {
     fi
     systemctl enable --now tailscaled
 
-    # Need gcloud to fetch the auth-key from Secret Manager. The base
-    # image does not ship it.
+    # gcloud is needed to fetch the auth key from Secret Manager and
+    # to docker-login Artifact Registry below.
     if ! command -v gcloud >/dev/null 2>&1; then
       install -m 0755 -d /etc/apt/keyrings
       curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg \
@@ -293,8 +217,6 @@ locals {
 
     AUTH_KEY="$(gcloud --quiet --project='${var.project_id}' \
       secrets versions access latest --secret='${var.workspace_authkey_secret_id}')"
-    # tailscale up is idempotent: a no-op if already authenticated under
-    # the same hostname + tags.
     tailscale up \
       --auth-key="$AUTH_KEY" \
       --hostname='${lower(data.coder_workspace.me.name)}-ws' \
@@ -302,33 +224,43 @@ locals {
       --advertise-tags='tag:exe-workspace'
     unset AUTH_KEY
 
-    # Docker (host-side; envbuilder uses the host daemon).
+    # ---- Docker -----------------------------------------------------
     if ! command -v docker >/dev/null 2>&1; then
-      curl -fsSL https://get.docker.com -o get-docker.sh
-      sudo sh get-docker.sh >/dev/null 2>&1
-      sudo usermod -aG docker ${local.linux_user}
-      newgrp docker
+      curl -fsSL https://get.docker.com -o /tmp/get-docker.sh
+      sh /tmp/get-docker.sh >/dev/null 2>&1
+      usermod -aG docker ${local.linux_user}
+      rm -f /tmp/get-docker.sh
     fi
 
-    # Cache-repo docker config, if any.
-    if [ -n "${local.docker_config_json_base64}" ]; then
-      mkdir -p "/home/${local.linux_user}/.docker"
-      printf "%s" "${local.docker_config_json_base64}" | base64 -d | tee "/home/${local.linux_user}/.docker/config.json"
-      chown -R ${local.linux_user}:${local.linux_user} "/home/${local.linux_user}/.docker"
-    fi
+    # Configure docker to authenticate against Artifact Registry via
+    # the VM's attached service account (must have
+    # roles/artifactregistry.reader on the dotfiles repo).
+    gcloud --quiet auth configure-docker \
+      "$(echo '${var.image}' | cut -d/ -f1)"
 
-    # Container env (passed to envbuilder via --env-file).
-    printf "%s" "${local.docker_env_list_base64}" | base64 -d | tee "/home/${local.linux_user}/env.txt"
+    # ---- Pull and run the prebuilt dev container --------------------
+    docker pull '${var.image}'
 
-    # Fire envbuilder.
+    # The container's PID 1 is `coder agent` via init_script — the
+    # agent owns lifecycle, so we run --restart=unless-stopped to
+    # survive reboots. Bind /home so dotfiles persist across container
+    # restarts within the same VM lifetime.
+    install -d -m 0755 /home/${local.linux_user}
+    chown ${local.linux_user}:${local.linux_user} /home/${local.linux_user}
+
+    docker rm -f '${local.container_name}' >/dev/null 2>&1 || true
     docker run \
-      --rm \
-      --net=host \
-      -h ${lower(data.coder_workspace.me.name)} \
-      -v /home/${local.linux_user}/envbuilder:/workspaces \
-      -v /var/run/docker.sock:/var/run/docker.sock \
-      --env-file /home/${local.linux_user}/env.txt \
-      ${local.builder_image}
+      --detach \
+      --name '${local.container_name}' \
+      --network host \
+      --hostname '${lower(data.coder_workspace.me.name)}' \
+      --restart unless-stopped \
+      --volume "/home/${local.linux_user}:/root" \
+      --volume "/var/run/docker.sock:/var/run/docker.sock" \
+      --env "CODER_AGENT_TOKEN=${try(coder_agent.dev[0].token, "")}" \
+      --env "CODER_AGENT_URL=${var.coder_internal_url}" \
+      '${var.image}' \
+      sh -c 'echo ${base64encode(try(coder_agent.dev[0].init_script, ""))} | base64 -d | sh'
   META
 }
 
@@ -341,20 +273,12 @@ resource "google_compute_disk" "root" {
   }
 }
 
-resource "envbuilder_cached_image" "cached" {
-  count         = var.cache_repo == "" ? 0 : data.coder_workspace.me.start_count
-  builder_image = local.devcontainer_builder_image
-  git_url       = data.coder_parameter.repo_url.value
-  cache_repo    = var.cache_repo
-  extra_env     = local.envbuilder_env
-}
-
 resource "google_compute_instance" "vm" {
   name         = "coder-${lower(data.coder_workspace_owner.me.name)}-${lower(data.coder_workspace.me.name)}-root"
   machine_type = data.coder_parameter.instance_type.value
   # Honour the operator's region pick at workspace creation. Falls
-  # back to the provider-level default ('asia-northeast1-a') only
-  # during the template-push preview when the parameter has no value.
+  # back to the provider-level default during the template-push
+  # preview when the parameter has no value.
   zone = coalesce(module.gcp_region.value, "asia-northeast1-a")
 
   # data.coder_workspace_owner.me.name == "default" suppresses an
@@ -388,17 +312,16 @@ resource "coder_agent" "dev" {
   arch               = "amd64"
   auth               = "token"
   os                 = "linux"
-  dir                = "/workspaces/${trimsuffix(basename(data.coder_parameter.repo_url.value), ".git")}"
+  dir                = "/root/dotfiles"
   connection_timeout = 0
 
   # Personalisation: pull and install the operator's dotfiles on top
-  # of whatever the devcontainer base image gives us. install.sh
-  # honours skip env vars to bypass Homebrew install and the
-  # `just add-all` / `just update-all` brew/gcloud replays — neither
-  # is desired on a CI-style workspace. With both set, install.sh
-  # still runs `just clean` + `just deploy` (symlink ~/.zshrc, sheldon
-  # lock, starship config, fzf-tab clone, ...). gcloud arrives via
-  # the devcontainer feature so its install path no-ops naturally.
+  # of the baked-in image. install.sh honours skip env vars to bypass
+  # Homebrew and the brew/gcloud bundle replays — neither is desired
+  # on a CI-style workspace. With both set, install.sh still runs
+  # `just clean` + `just deploy` (symlink ~/.zshrc, sheldon lock,
+  # starship config, fzf-tab clone, ...). gcloud arrives via the
+  # devcontainer feature so its install path no-ops naturally.
   startup_script = data.coder_parameter.dotfiles_uri.value == "" ? "" : <<-EOT
     set -eu
     export INSTALL_SKIP_HOMEBREW=1
@@ -445,8 +368,8 @@ resource "coder_metadata" "workspace_info" {
     value = module.gcp_region.value
   }
   item {
-    key   = "repo"
-    value = data.coder_parameter.repo_url.value
+    key   = "image"
+    value = var.image
   }
 }
 

--- a/tests/exe/test_template.py
+++ b/tests/exe/test_template.py
@@ -14,9 +14,9 @@ template directory in a clean container to catch:
   - References to undeclared resources (e.g. the well-known
     'coder_agent.main' typo we patched out of upstream)
 
-We deliberately do NOT exercise `terraform plan`, since that needs
-fake credentials for google + envbuilder + coder providers and
-attempts network calls to provider registries.
+`terraform plan` runs in a sub-test for deeper checks (zone
+propagation, parameter defaults, etc.); fake Google credentials
+keep it offline.
 """
 
 from __future__ import annotations
@@ -68,57 +68,92 @@ def test_template_main_tf_present() -> None:
 
 
 @pytest.mark.exe
-def test_template_repo_url_is_dotfiles() -> None:
-    """The whole point of this template: the default repo_url is the
-    dotfiles git URL. Locks the intent so a future PR cannot drop the
-    default and silently turn it into a generic envbuilder starter."""
+def test_template_image_default_points_to_artifact_registry() -> None:
+    """The whole point of this template: workspaces pull a prebuilt
+    dev container image from the stack's Artifact Registry repo,
+    instead of running envbuilder per workspace. The default image
+    string must reference asia-northeast1-docker.pkg.dev/gen-ai-hironow
+    so a future PR cannot silently turn it into a generic starter
+    pulling some other registry."""
     main_tf = (TEMPLATE_DIR / "main.tf").read_text()
-    # The 'default' line on the repo_url parameter.
     import re
 
     block = re.search(
-        r'data "coder_parameter" "repo_url" \{(.*?)^\}',
+        r'variable "image" \{(.*?)^\}',
         main_tf,
         re.DOTALL | re.MULTILINE,
     )
-    assert block is not None, "could not locate the repo_url parameter block"
+    assert block is not None, 'missing variable "image" block'
     body = block.group(1)
-    assert "github.com/hironow/dotfiles" in body, (
-        "repo_url default must point at the dotfiles repo"
+    assert "asia-northeast1-docker.pkg.dev/gen-ai-hironow/dotfiles" in body, (
+        "image variable default must reference the dotfiles Artifact "
+        "Registry repo at asia-northeast1-docker.pkg.dev/gen-ai-hironow/dotfiles."
     )
 
 
 @pytest.mark.exe
-def test_template_git_branch_parameter_present_and_wired() -> None:
-    """envbuilder defaults to cloning the repo's default branch (main).
-    For pre-merge debugging (e.g. testing libc6-compat in Dockerfile
-    while the change is still on a feature branch), we expose a
-    'git_branch' Coder parameter and wire it into envbuilder via
-    ENVBUILDER_GIT_BRANCH. Both halves must stay in place — losing
-    either silently disables branch override and re-creates the
-    'image built from main, but the fix lives on a branch' class of
-    bug we hit during the Layer 2 boot up."""
+def test_template_no_envbuilder() -> None:
+    """The envbuilder pattern was replaced by a prebuilt image on
+    docs/adr/0002-coder-prebuilt-image.md. Lock the migration: no
+    envbuilder provider, no envbuilder_cached_image resource, no
+    ENVBUILDER_* env vars in the actual HCL (comments mentioning
+    envbuilder by name in commit-message-style 'differences from
+    upstream' notes are acceptable)."""
+    raw = (TEMPLATE_DIR / "main.tf").read_text()
+    # Strip line- and block-comments before grepping so historical
+    # mentions in comment headers don't false-match.
+    import re
+
+    no_block_comments = re.sub(r"/\*.*?\*/", "", raw, flags=re.DOTALL)
+    code = "\n".join(
+        line
+        for line in no_block_comments.splitlines()
+        if not line.lstrip().startswith("#")
+    )
+    forbidden_in_code = [
+        # provider {} block referencing the envbuilder source
+        'source = "coder/envbuilder"',
+        # the cached_image resource the prior template used
+        '"envbuilder_cached_image"',
+        # any ENVBUILDER_* env var name
+        "ENVBUILDER_",
+    ]
+    for needle in forbidden_in_code:
+        assert needle not in code, (
+            f"template still references {needle!r}; the envbuilder path "
+            "was retired in favour of prebuilt-image pull. See "
+            "docs/adr/0002-coder-prebuilt-image.md."
+        )
+
+
+@pytest.mark.exe
+def test_template_startup_script_pulls_and_runs_image() -> None:
+    """The new gcp-vm-container-style startup_script must:
+      - configure docker auth against Artifact Registry
+      - docker pull `var.image`
+      - docker run with the agent init script as its command
+    Without this chain the workspace VM would boot but the dev
+    container would never start."""
     main_tf = (TEMPLATE_DIR / "main.tf").read_text()
     import re
 
-    block = re.search(
-        r'data "coder_parameter" "git_branch" \{(.*?)^\}',
+    m = re.search(
+        r"startup_script\s*=\s*<<-META\s*\n(.*?)\n\s*META",
         main_tf,
-        re.DOTALL | re.MULTILINE,
+        re.DOTALL,
     )
-    assert block is not None, "missing git_branch coder_parameter block"
-    body = block.group(1)
-    # Default must be empty so post-merge users get the repo's
-    # default branch without thinking about it.
-    assert re.search(r'default\s*=\s*""', body), (
-        "git_branch parameter default must be empty string"
+    assert m is not None, "could not locate startup_script <<-META block"
+    body = m.group(1)
+    assert "gcloud --quiet auth configure-docker" in body, (
+        "startup_script must configure docker auth for Artifact Registry"
     )
-    # Wiring into envbuilder.
-    assert "ENVBUILDER_GIT_BRANCH" in main_tf, (
-        "ENVBUILDER_GIT_BRANCH not wired into envbuilder_env"
+    assert "docker pull" in body and "var.image" in body, (
+        "startup_script must docker pull '${var.image}' before running it"
     )
-    assert "data.coder_parameter.git_branch.value" in main_tf, (
-        "git_branch parameter is declared but never read"
+    assert "docker run" in body, "startup_script must docker run the prebuilt image"
+    assert "init_script" in body, (
+        "startup_script must invoke the coder_agent init_script as the "
+        "container command"
     )
 
 
@@ -181,8 +216,10 @@ def test_template_startup_script_joins_tailnet() -> None:
     """The workspace VM's startup-script must:
     - install tailscaled (apt-get install tailscale)
     - fetch the tag:exe-workspace authkey from Secret Manager
-    - bring the device up under tag:exe-workspace before envbuilder
-      starts (envbuilder needs to reach exe-coder.<tailnet>:7080)
+    - bring the device up under tag:exe-workspace BEFORE the dev
+      container starts. The container's CODER_AGENT_URL points at
+      exe-coder over MagicDNS, which only resolves once the host is
+      on the tailnet.
     """
     main_tf = (TEMPLATE_DIR / "main.tf").read_text()
 
@@ -376,11 +413,10 @@ def test_template_terraform_plan(tmp_path: Path) -> None:
 
     Why Terraform (not OpenTofu): the Coder server embeds Terraform,
     so 'cdr templates push' uses Terraform's registry. coder/coder
-    and coder/envbuilder are NOT mirrored to OpenTofu's registry.
-    Test-runner-side use of the Terraform binary is solely for
-    static analysis here; production deploys remain `tofu` (see
-    docs/intent.md OpenTofu constraint, scoped to the operator
-    stack at tofu/exe/).
+    is NOT mirrored to OpenTofu's registry. Test-runner-side use of
+    the Terraform binary is solely for static analysis here;
+    production deploys remain `tofu` (see docs/intent.md OpenTofu
+    constraint, scoped to the operator stack at tofu/exe/).
 
     Skipped if docker is unavailable."""
     if not _docker_available():

--- a/tofu/exe/artifact_registry.tf
+++ b/tofu/exe/artifact_registry.tf
@@ -1,0 +1,35 @@
+# Artifact Registry repository for the dotfiles dev container image.
+#
+# Coder workspaces (exe/coder/templates/dotfiles-devcontainer) pull
+# from `<region>-docker.pkg.dev/<project>/<repo>/devcontainer:<tag>`
+# instead of running envbuilder per workspace. The publish workflow at
+# .github/workflows/publish-devcontainer.yaml builds the image from
+# .devcontainer/devcontainer.json and pushes it here.
+
+resource "google_artifact_registry_repository" "dotfiles" {
+  project       = var.gcp_project_id
+  location      = var.gcp_region
+  repository_id = "dotfiles"
+  description   = "Dev container image for exe.hironow.dev Coder workspaces"
+  format        = "DOCKER"
+  labels        = local.common_labels
+
+  # Container Optimized OS pulls images at workspace-create time;
+  # keep image history bounded so the AR storage bill does not grow
+  # unboundedly with every commit.
+  cleanup_policies {
+    id     = "keep-recent-versions"
+    action = "KEEP"
+    most_recent_versions {
+      keep_count = 10
+    }
+  }
+  cleanup_policies {
+    id     = "delete-old-untagged"
+    action = "DELETE"
+    condition {
+      tag_state  = "UNTAGGED"
+      older_than = "604800s" # 7 days
+    }
+  }
+}

--- a/tofu/exe/iam.tf
+++ b/tofu/exe/iam.tf
@@ -28,6 +28,15 @@ resource "google_artifact_registry_repository_iam_member" "gha_writer" {
 }
 
 # ---- WIF pool ------------------------------------------------------
+# `import` block adopts an existing pool (created out-of-band on a
+# previous experiment in this project) into tofu state instead of
+# erroring with "Requested entity already exists" on first apply.
+# Safe to leave in place — `import` is idempotent post-adoption.
+import {
+  to = google_iam_workload_identity_pool.github
+  id = "projects/${var.gcp_project_id}/locations/global/workloadIdentityPools/github"
+}
+
 resource "google_iam_workload_identity_pool" "github" {
   project                   = var.gcp_project_id
   workload_identity_pool_id = "github"

--- a/tofu/exe/iam.tf
+++ b/tofu/exe/iam.tf
@@ -1,0 +1,79 @@
+# Workload Identity Federation for GitHub Actions to push dev
+# container images to Artifact Registry without long-lived service
+# account keys.
+#
+# Trust chain:
+#   github.com (OIDC) --> WIF pool --> WIF provider --> SA
+#   The SA is granted only roles/artifactregistry.writer on the
+#   `dotfiles` repository — narrowest possible scope.
+#
+# Set workflow secrets after `tofu apply`:
+#   GCP_WIF_PROVIDER  = output.gcp_wif_provider_resource_name
+#   GCP_PUBLISH_SA    = output.gcp_publish_sa_email
+
+# ---- Service Account that GHA acts as ------------------------------
+resource "google_service_account" "gha_publish" {
+  project      = var.gcp_project_id
+  account_id   = "gha-devcontainer-publish"
+  display_name = "GitHub Actions — devcontainer image publisher"
+  description  = "Pushes .devcontainer image to Artifact Registry. Impersonated via WIF; no key issued."
+}
+
+resource "google_artifact_registry_repository_iam_member" "gha_writer" {
+  project    = google_artifact_registry_repository.dotfiles.project
+  location   = google_artifact_registry_repository.dotfiles.location
+  repository = google_artifact_registry_repository.dotfiles.name
+  role       = "roles/artifactregistry.writer"
+  member     = "serviceAccount:${google_service_account.gha_publish.email}"
+}
+
+# ---- WIF pool ------------------------------------------------------
+resource "google_iam_workload_identity_pool" "github" {
+  project                   = var.gcp_project_id
+  workload_identity_pool_id = "github"
+  display_name              = "GitHub OIDC pool"
+  description               = "Federates GitHub Actions tokens into GCP."
+}
+
+# ---- WIF provider tied to github.com -------------------------------
+resource "google_iam_workload_identity_pool_provider" "github" {
+  project                            = var.gcp_project_id
+  workload_identity_pool_id          = google_iam_workload_identity_pool.github.workload_identity_pool_id
+  workload_identity_pool_provider_id = "github-actions"
+  display_name                       = "GitHub Actions"
+
+  oidc {
+    issuer_uri = "https://token.actions.githubusercontent.com"
+  }
+
+  attribute_mapping = {
+    "google.subject"       = "assertion.sub"
+    "attribute.repository" = "assertion.repository"
+    "attribute.ref"        = "assertion.ref"
+    "attribute.actor"      = "assertion.actor"
+  }
+
+  # Restrict the pool to this repo only — token swaps from any other
+  # GitHub repo cannot reach the SA.
+  attribute_condition = "assertion.repository == 'hironow/dotfiles'"
+}
+
+# ---- Bind the SA to the WIF provider for this repo only ------------
+resource "google_service_account_iam_member" "gha_publish_wif" {
+  service_account_id = google_service_account.gha_publish.name
+  role               = "roles/iam.workloadIdentityUser"
+  member             = "principalSet://iam.googleapis.com/${google_iam_workload_identity_pool.github.name}/attribute.repository/hironow/dotfiles"
+}
+
+# ---- Workspace VM — pull rights on the AR repo ---------------------
+# The Coder workspace template (gcp-vm-container pattern) runs
+# `docker pull <repo>/devcontainer:<tag>` from the VM's attached
+# service account. The SA was originally scoped to read a single
+# Secret Manager entry; widen with the narrowest AR role.
+resource "google_artifact_registry_repository_iam_member" "exe_workspace_reader" {
+  project    = google_artifact_registry_repository.dotfiles.project
+  location   = google_artifact_registry_repository.dotfiles.location
+  repository = google_artifact_registry_repository.dotfiles.name
+  role       = "roles/artifactregistry.reader"
+  member     = "serviceAccount:${google_service_account.exe_workspace.email}"
+}

--- a/tofu/exe/outputs.tf
+++ b/tofu/exe/outputs.tf
@@ -112,3 +112,37 @@ output "coder_cli_secret_client_secret" {
   description = "Secret Manager resource name for the Coder CLI Cloudflare Access client_secret."
   value       = google_secret_manager_secret.coder_cli_client_secret.name
 }
+
+# ---- Image publish (Artifact Registry + WIF) -----------------------
+
+output "artifact_registry_repo" {
+  description = <<-EOF
+Fully-qualified Artifact Registry repository name where the dev
+container image is published. Coder template pulls
+`<repo>/devcontainer:<tag>`.
+EOF
+  value = format(
+    "%s-docker.pkg.dev/%s/%s",
+    google_artifact_registry_repository.dotfiles.location,
+    google_artifact_registry_repository.dotfiles.project,
+    google_artifact_registry_repository.dotfiles.name,
+  )
+}
+
+output "gcp_wif_provider_resource_name" {
+  description = <<-EOF
+Resource name of the Workload Identity provider that GitHub Actions
+authenticates against. Set this on the repo as the GCP_WIF_PROVIDER
+Actions variable: `gh variable set GCP_WIF_PROVIDER --body "<this value>"`.
+EOF
+  value       = google_iam_workload_identity_pool_provider.github.name
+}
+
+output "gcp_publish_sa_email" {
+  description = <<-EOF
+Email of the service account GitHub Actions impersonates to push
+images. Set this as the GCP_PUBLISH_SA repo variable:
+  `gh variable set GCP_PUBLISH_SA --body "<this value>"`.
+EOF
+  value       = google_service_account.gha_publish.email
+}


### PR DESCRIPTION
## What

Replaces the per-workspace envbuilder build pattern with a **prebuilt OCI image** pulled from **Artifact Registry**. Coder template moves from gcp-devcontainer to gcp-vm-container style. ADR: `docs/adr/0002-coder-prebuilt-image.md`.

## Why

Per-workspace envbuilder takes 3-5 min and OOMs on e2-micro. Prebuilt image: ~30-60s start, e2-micro viable.

## Stages

| Stage | What |
|---|---|
| I (CI) | `.github/workflows/publish-devcontainer.yaml` — `devcontainers/ci` action pushes to AR on main merge, dual-tagged `:main` (rolling) + `:<git-sha>` (immutable) |
| II (infra) | `tofu/exe/artifact_registry.tf` + `tofu/exe/iam.tf` — AR repo, WIF pool/provider scoped to this repo, publish SA, workspace SA gains `roles/artifactregistry.reader` |
| III (template) | `exe/coder/templates/dotfiles-devcontainer/main.tf` rewritten — drop envbuilder/cache_repo/repo_url/git_branch/fallback_image/devcontainer_builder; add `image` variable; startup_script does `docker pull` + `docker run` |
| IV (tests/docs) | drop envbuilder-specific assertions, add image+pull assertions, ADR 0002, README rewrite |

## Manual operator steps (one-time, post-merge)

```bash
just tofu-init && just tofu-apply        # creates AR repo + WIF infra
gh variable set GCP_WIF_PROVIDER --body "$(just exe-output -raw gcp_wif_provider_resource_name)"
gh variable set GCP_PUBLISH_SA   --body "$(just exe-output -raw gcp_publish_sa_email)"

# wait for first publish-devcontainer run to push :main image, then:
cdr templates push exe-dotfiles-devcontainer \
  -d exe/coder/templates/dotfiles-devcontainer \
  --variable project_id=gen-ai-hironow \
  --variable workspace_sa_email=$(just exe-output -raw exe_workspace_sa_email) \
  --variable coder_internal_url=$(just exe-output -raw coder_internal_url) \
  --variable image=$(just exe-output -raw artifact_registry_repo)/devcontainer:main \
  --yes
```

## Tests

- `tests/exe/test_template.py` — 10 static checks pass (image variable, no envbuilder, startup_script pulls+runs, etc.)
- `terraform plan` test still passes (preview-time HCL validation)

## Out of scope

- Image signing via cosign/sigstore for the prebuilt image (follow-up)
- Per-workspace branch override (was `git_branch` parameter) — manual `devcontainer build --push <tag>` + template re-push for now