### PR TITLE
chore: ADRs 0003/0004 + regression tests for publish & cdr

### DIFF
--- a/docs/adr/0003-actions-pin-sha.md
+++ b/docs/adr/0003-actions-pin-sha.md
@@ -1,0 +1,94 @@
+# 0003. Pin GitHub Actions to commit SHAs and add Dependabot updates
+
+**Date:** 2026-05-02
+**Status:** Accepted (recorded retroactively for PR #48)
+
+## Context
+
+The `hironow` GitHub organisation flipped its **Actions permissions
+policy** to require:
+
+1. Allow only verified Marketplace creators OR explicit allowlist.
+2. Pin every `uses:` reference to a **full-length commit SHA** (40
+   chars). Tag and branch references are blocked.
+
+Before PR #48, the workflows in this repo used moving tag refs
+(`@v6`, `@v3`). Even Microsoft- and Docker-published actions get
+their tags moved across releases, so a tag-based pin trusts the
+publisher to never re-tag a compromised commit. The
+`tj-actions/changed-files` incident (March 2025) demonstrated the
+real cost of trusting moving refs.
+
+The repo also had no automated mechanism to keep pinned SHAs
+fresh, so a manual one-off SHA-pin would rot the moment a security
+patch landed upstream.
+
+## Decision
+
+1. **Pin every `uses:` reference to a full-length commit SHA**, with
+   a trailing `# vX.Y.Z` comment for human readability:
+
+   ```yaml
+   - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+   - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+   ```
+
+2. **Allowlist the one non-verified action used in this repo** in
+   the org Actions permissions UI:
+
+   ```
+   jdx/mise-action@*
+   ```
+
+   (devcontainers/ci was added in PR #54 — same allowlist pattern
+   applies and is documented in ADR 0002.)
+
+3. **Add `.github/dependabot.yaml`** with three ecosystems on a
+   weekly cadence:
+
+   - `github-actions` /                     — rotates pinned SHAs
+   - `uv`             /tools/rttm           — Python deps in the rttm tool
+   - `docker`         /tests/docker         — sandbox / install / exe Dockerfiles
+
+   Each ecosystem uses Conventional Commits prefixes (`chore(actions)`,
+   `chore(rttm)`, `chore(docker)`) so commits land cleanly through
+   the prek `conventional-commits` hook.
+
+4. **Bump rttm CVE-affected dependencies** (pytest 9.0.1 → 9.0.3
+   GHSA-6w46-j5rx-g56g, Pygments 2.19.2 → 2.20.0
+   GHSA-5239-wwwm-4pmq) in the same PR so a clean `main` lands
+   without open Dependabot alerts.
+
+## Consequences
+
+### Positive
+
+- **Supply chain hardening.** Even a compromised tag cannot
+  swap the SHA we resolve to. Renovate/Dependabot bumps the SHA +
+  tag-comment together so re-tagging is visible in PR diffs.
+- **Org policy compliance.** Workflows pass the pinned-SHA check
+  rather than failing with `startup_failure`.
+- **Dependabot continues the maintenance.** Manual SHA bumps would
+  rot; the weekly Monday 09:00 JST cadence keeps the pins fresh
+  without the operator remembering.
+- **Conventional Commits compliance.** Per-ecosystem prefix passes
+  the prek pre-commit hook; PRs land without `fix: deps` style
+  noise.
+
+### Negative
+
+- **One non-verified Marketplace dependency** (`jdx/mise-action`)
+  needs a manual UI step to allowlist on the org. A future move to
+  a verified equivalent would remove the step.
+- **First-time setup adds friction.** Bumping versions now requires
+  resolving commit SHAs (Dependabot does it automatically; manual
+  bumps need `gh api repos/<owner>/<repo>/git/refs/tags/<tag>`).
+
+### Neutral
+
+- **rttm CVE bumps were independent of the Actions hardening** but
+  bundled into PR #48 because they shared the dependency-update
+  theme and let `main` close all open Dependabot alerts at once.
+- **Submodules deliberately out of Dependabot scope** (`gitsubmodule`
+  ecosystem). The repo's `scripts/sync_agents.py` flow handles
+  vendored sources separately.

--- a/docs/adr/0004-workspace-tailnet-routing.md
+++ b/docs/adr/0004-workspace-tailnet-routing.md
@@ -1,0 +1,134 @@
+# 0004. Workspace VMs reach the Coder control plane over the tailnet (B-plan)
+
+**Date:** 2026-05-02
+**Status:** Accepted (recorded retroactively for PR #47)
+
+## Context
+
+`exe.hironow.dev` is fronted by Cloudflare Access. Browser sessions
+authenticate via Cloudflare OIDC; the `cdr` CLI authenticates via a
+Cloudflare Access service token. Workspace VMs spawned by the Coder
+template **have neither**: they are headless GCE instances created
+by the Coder server, with no browser session and no service token
+plumbed in.
+
+The first workspace boot under Layer 2 failed because the
+`bootstrap_linux.sh` script that the Coder server injects into the
+workspace VM fetched the Coder agent binary from
+`${CODER_ACCESS_URL}/bin/coder-linux-amd64`. With `CODER_ACCESS_URL`
+set to the public `https://exe.hironow.dev`, the binary download
+hit Cloudflare Access without a service token. CF Access returned
+the OIDC interstitial **HTML** with a 200 status. The bootstrap
+script `chmod +x`-ed the HTML and tried to exec it. Bash interpreted
+the HTML as a shell script and emitted
+
+```
+./coder: line 2: syntax error: unexpected newline
+```
+
+The workspace then never connected.
+
+Two options were considered:
+
+- **A-plan: punch a hole in CF Access for `/bin/*`.** Configure CF
+  Access to allow unauthenticated requests to the agent binary
+  path. Operationally simple but weakens the edge — a URL that was
+  previously private becomes publicly reachable, and the agent
+  binary would be downloadable by anyone who can resolve the
+  public DNS. The agent binary is publicly available from Coder
+  upstream anyway, but the precedent of "punch holes in CF Access
+  for internal traffic" is bad.
+
+- **B-plan: route workspace agent download over the tailnet.**
+  Workspace VMs join the tailnet under a new `tag:exe-workspace`
+  identity and reach the control plane via the tailnet-internal
+  hostname `exe-coder` (resolved by Tailscale MagicDNS). The
+  bootstrap script's `CODER_ACCESS_URL` is overridden per-template
+  to `http://exe-coder:7080`, so the binary download bypasses the
+  public CF Access edge entirely.
+
+## Decision
+
+Adopt B-plan.
+
+### Tailscale layer
+
+- New tag `tag:exe-workspace` (in `exe/tailscale/acl.hujson`) with
+  ACL allow rule `tag:exe-workspace -> tag:exe-coder:7080`.
+- New reusable + ephemeral auth key `tailscale_tailnet_key.exe_workspace`
+  (in `tofu/exe/tailscale.tf`), `depends_on = [tailscale_acl.this]`
+  to avoid issuing a key for a tag that the live ACL has not yet
+  acknowledged (which the API rejects with HTTP 400
+  "requested tags ... are invalid or not permitted").
+- Auth key mirrored to Secret Manager
+  (`exe-tailscale-workspace-authkey`).
+- Workspace SA (`exe-workspace@…`) granted
+  `roles/secretmanager.secretAccessor` on that secret.
+
+### Coder server layer
+
+- `CODER_HTTP_ADDRESS=0.0.0.0:7080` so the listener binds the
+  tailnet interface (tun0) in addition to loopback.
+- Cloudflare Argo Tunnel still terminates the public edge at
+  `exe.hironow.dev`; only the workspace-internal path moves onto
+  the tailnet.
+
+### Coder workspace template layer
+
+- `provider "coder" { url = var.coder_internal_url }` overrides the
+  deployment-wide `CODER_ACCESS_URL`. Coder OSS renders this value
+  into `${ACCESS_URL}` substitutions in `bootstrap_linux.sh` via
+  `metadata.GetCoderUrl()` in `provisioner/terraform/provision.go`
+  `provisionEnv()`.
+- VM startup-script installs tailscale + gcloud, fetches the
+  workspace authkey from Secret Manager, and runs
+  `tailscale up --advertise-tags=tag:exe-workspace` BEFORE any
+  step that depends on the agent binary.
+
+### Auth chain (3-layer)
+
+1. **CF Access edge** — browser OIDC or `cdr` service token
+2. **Coder session** — OAuth or admin password (after edge auth)
+3. **Workspace agent identity** — token issued by Coder, transported
+   over the tailnet (no edge involvement)
+
+## Consequences
+
+### Positive
+
+- **CF Access edge stays intact.** No `/bin/*` bypass; no precedent
+  for poking holes in the edge for internal traffic.
+- **Workspace binaries authenticated by tailnet-membership**, which
+  is itself authenticated by the WireGuard auth key issued from
+  Tailscale's admin plane and stored in Secret Manager.
+- **MagicDNS gives stable hostnames.** `exe-coder` resolves to the
+  control-plane VM's tailnet IP regardless of GCE-side IP changes.
+- **Per-template override.** The `provider "coder" { url = ... }`
+  is template-level, so the public CODER_ACCESS_URL still serves
+  browser / cdr CLI traffic correctly.
+
+### Negative
+
+- **Three Tailscale auth keys to rotate** (`exe-coder`, `exe-workspace`,
+  `agent`). All driven by `time_rotating.tailscale_keys` in
+  `tofu/exe/tailscale.tf` (90-day cadence).
+- **MTU-related warning spam.** GCP default MTU 1460 vs Tailscale's
+  expectation; `magicsock disco: failed to send … sendto: message
+  too long` once per few minutes in agent logs. Cosmetic; can be
+  silenced with `tailscale up --mss-clamping` if desired.
+- **Workspace boot depends on Tailscale + Secret Manager + tag ACL**
+  all being healthy. A Tailscale outage would block new workspace
+  creation; existing connected workspaces are unaffected.
+
+### Neutral
+
+- **Workspace VMs are still on the default VPC**, not exe-vpc. They
+  are reachable to/from the public internet for outbound (for
+  `apt-get`, `docker pull` etc.); ingress is gated by the firewall
+  default-deny + the host running tailscaled.
+- **The B-plan does not change Layer 2 cost characteristics.**
+  Workspace VMs were going to need tailscaled regardless; the Layer
+  2 design already assumes tailnet membership for the control
+  plane.
+- **A-plan is permanently retired.** Reintroducing the `/bin/*`
+  bypass would require explicit ADR superseding this one.

--- a/exe/coder/templates/dotfiles-devcontainer/main.tf
+++ b/exe/coder/templates/dotfiles-devcontainer/main.tf
@@ -315,13 +315,26 @@ resource "coder_agent" "dev" {
   dir                = "/root/dotfiles"
   connection_timeout = 0
 
-  # Personalisation: pull and install the operator's dotfiles on top
-  # of the baked-in image. install.sh honours skip env vars to bypass
-  # Homebrew and the brew/gcloud bundle replays — neither is desired
-  # on a CI-style workspace. With both set, install.sh still runs
-  # `just clean` + `just deploy` (symlink ~/.zshrc, sheldon lock,
-  # starship config, fzf-tab clone, ...). gcloud arrives via the
-  # devcontainer feature so its install path no-ops naturally.
+  # Personalisation + workspace-side mise sync.
+  #
+  # `coder dotfiles` clones the operator's dotfiles repo into
+  # /root/dotfiles and runs install.sh. install.sh honours skip env
+  # vars to bypass Homebrew + brew/gcloud bundle replays — neither
+  # is wanted on a CI-style workspace. With both set, install.sh
+  # still runs `just clean` + `just deploy` (symlink ~/.zshrc,
+  # sheldon lock, starship config, fzf-tab clone, ...).
+  #
+  # Then `mise install` runs against the workspace mise.toml so
+  # mise's install state (`~/.local/share/mise/installs/`) tracks
+  # what mise.toml asks for. The prebuilt image already has the
+  # tools at the same versions (the local devcontainer feature
+  # primes them at build time), but mise tracks installs by config
+  # path, so `mise current` would otherwise warn:
+  #   `mise WARN  just@1.50.0 is specified in ~/dotfiles/mise.toml,
+  #    but not installed`
+  # MISE_OFFLINE=0 is forced because the inherited containerEnv has
+  # MISE_OFFLINE=1 baked in — mise needs the registry to resolve
+  # `latest` before it can match against the cache.
   startup_script = data.coder_parameter.dotfiles_uri.value == "" ? "" : <<-EOT
     set -eu
     export INSTALL_SKIP_HOMEBREW=1
@@ -329,6 +342,13 @@ resource "coder_agent" "dev" {
     if command -v coder >/dev/null 2>&1; then
       coder dotfiles -y "${data.coder_parameter.dotfiles_uri.value}" || \
         echo "[exe] dotfiles install failed; continuing"
+    fi
+    if command -v mise >/dev/null 2>&1 && [ -f /root/dotfiles/mise.toml ]; then
+      (
+        cd /root/dotfiles
+        mise trust mise.toml >/dev/null 2>&1 || true
+        MISE_OFFLINE=0 mise install
+      ) || echo "[exe] mise install failed; tools fall back to baked-in image versions"
     fi
   EOT
 

--- a/tests/test_cdr_wrapper.py
+++ b/tests/test_cdr_wrapper.py
@@ -1,0 +1,295 @@
+"""Tests for exe/scripts/cdr.
+
+The wrapper fetches CF Access service token credentials from
+Secret Manager and feeds them to the upstream `coder` CLI as
+HTTP-Headers. A bug class we hit once already: the secret-refresh
+path used `> "${file}.tmp"` + `chmod` and aborted under `set -e`
+when gcloud failed before writing anything, leaving the next
+invocation to error with `chmod: ...tmp: No such file or directory`.
+
+Tests stub `gcloud` and `coder` so the script can be exercised
+without real GCP / Coder access. We verify:
+
+  - cache hit short-circuit
+  - secret-refresh on stale cache writes the new value
+  - gcloud failure does NOT leave a stranded `.tmp` file
+  - empty payload from gcloud is rejected with a readable err()
+
+The original wrapper requires `coder` (the upstream CLI) to be
+installed; we stub that too so CI does not need it.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import stat
+import subprocess
+import textwrap
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+CDR = ROOT / "exe" / "scripts" / "cdr"
+
+
+def _stub_dir(
+    tmp_path: Path,
+    behaviours: dict[str, str],
+    suffix: str = "stubs",
+) -> Path:
+    """Create a stubs directory with one executable per behaviour
+    entry. `behaviours[name]` is the script body. `suffix` lets a
+    single test create multiple distinct stub dirs."""
+    stubs = tmp_path / suffix
+    stubs.mkdir(exist_ok=True)
+    for name, body in behaviours.items():
+        p = stubs / name
+        p.write_text(textwrap.dedent(body).lstrip("\n"))
+        p.chmod(p.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+    return stubs
+
+
+BASH = shutil.which("bash") or "/bin/bash"
+
+
+def _run(
+    tmp_path: Path,
+    stubs: Path,
+    args: list[str],
+    extra_env: dict[str, str] | None = None,
+) -> subprocess.CompletedProcess:
+    env = os.environ.copy()
+    env["HOME"] = str(tmp_path)
+    env["PATH"] = f"{stubs}:{env['PATH']}"
+    if extra_env:
+        env.update(extra_env)
+    # Use the absolute path to bash so the test's narrowed PATH does
+    # not need to find it. The script under test then sees PATH=stubs
+    # first, where it picks up our stub gcloud / coder.
+    return subprocess.run(
+        [BASH, str(CDR), *args],
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+
+
+@pytest.fixture
+def gcloud_succeeding(tmp_path: Path) -> Path:
+    """A gcloud stub that pretends to fetch one of two known secrets."""
+    return _stub_dir(
+        tmp_path,
+        {
+            "gcloud": """
+                #!/usr/bin/env bash
+                # Match the wrapper's invocation:
+                #   gcloud secrets versions access latest --secret=<name>
+                while [[ $# -gt 0 ]]; do
+                  case "$1" in
+                    --secret=exe-coder-cli-client-id)     echo 'fake-client-id'; exit 0 ;;
+                    --secret=exe-coder-cli-client-secret) echo 'fake-secret-payload'; exit 0 ;;
+                  esac
+                  shift
+                done
+                exit 0
+            """,
+            "coder": """
+                #!/usr/bin/env bash
+                # Echo what we received so the test can inspect.
+                printf 'coder-stub args=%s\\n' "$*"
+                printf 'coder-stub CF_ACCESS_CLIENT_ID=%s\\n' "$CF_ACCESS_CLIENT_ID"
+                printf 'coder-stub CF_ACCESS_CLIENT_SECRET=%s\\n' "$CF_ACCESS_CLIENT_SECRET"
+                exit 0
+            """,
+        },
+    )
+
+
+@pytest.fixture
+def gcloud_failing(tmp_path: Path) -> Path:
+    """A gcloud stub that exits non-zero (auth missing / wrong project)."""
+    return _stub_dir(
+        tmp_path,
+        {
+            "gcloud": """
+                #!/usr/bin/env bash
+                echo 'gcloud-stub: simulated auth failure' >&2
+                exit 1
+            """,
+            "coder": """
+                #!/usr/bin/env bash
+                exit 0
+            """,
+        },
+    )
+
+
+@pytest.fixture
+def gcloud_empty_payload(tmp_path: Path) -> Path:
+    """A gcloud stub that exits 0 but writes no bytes."""
+    return _stub_dir(
+        tmp_path,
+        {
+            "gcloud": """
+                #!/usr/bin/env bash
+                # Successful exit, empty stdout — Secret Manager could
+                # in principle return a secret with no content.
+                exit 0
+            """,
+            "coder": """
+                #!/usr/bin/env bash
+                exit 0
+            """,
+        },
+    )
+
+
+def test_cdr_fetches_secrets_and_invokes_coder(
+    tmp_path: Path, gcloud_succeeding: Path
+) -> None:
+    """Happy path: cache cold, gcloud returns known payloads, the
+    script execs `coder` with the credentials exported."""
+    r = _run(tmp_path, gcloud_succeeding, ["list"])
+    assert r.returncode == 0, f"cdr exited non-zero with succeeding gcloud:\n{r.stderr}"
+    assert "coder-stub args=list" in r.stdout
+    assert "CF_ACCESS_CLIENT_ID=fake-client-id" in r.stdout
+    assert "CF_ACCESS_CLIENT_SECRET=fake-secret-payload" in r.stdout
+
+    cache_dir = tmp_path / ".cache" / "exe-coder-cli"
+    assert (cache_dir / "client_id").read_text() == "fake-client-id\n"
+    assert (cache_dir / "client_secret").read_text() == "fake-secret-payload\n"
+    # Cache files must be 0600.
+    assert (cache_dir / "client_id").stat().st_mode & 0o077 == 0
+
+
+def test_cdr_uses_cached_secret_within_ttl(
+    tmp_path: Path, gcloud_succeeding: Path
+) -> None:
+    """Second invocation within TTL must NOT call gcloud — verify by
+    swapping in a gcloud that always errors and confirming the
+    second call still succeeds (cache hit short-circuits the
+    refresh)."""
+    # First call populates the cache.
+    r1 = _run(tmp_path, gcloud_succeeding, ["list"])
+    assert r1.returncode == 0
+
+    # Replace gcloud with a poisoned stub. If the wrapper re-fetches,
+    # this exits 1 and the subsequent err() trips.
+    poisoned = _stub_dir(
+        tmp_path,
+        {
+            "gcloud": """
+                #!/usr/bin/env bash
+                echo 'should not be called' >&2
+                exit 1
+            """,
+            "coder": """
+                #!/usr/bin/env bash
+                exit 0
+            """,
+        },
+        suffix="poisoned-stubs",
+    )
+    r2 = _run(tmp_path, poisoned, ["list"])
+    assert r2.returncode == 0, (
+        "second cdr call hit the (poisoned) gcloud stub, meaning the "
+        f"cache hit path is broken:\n{r2.stderr}"
+    )
+
+
+def test_cdr_does_not_strand_tmp_when_gcloud_fails(
+    tmp_path: Path, gcloud_failing: Path
+) -> None:
+    """The original bug: gcloud fails, set -e aborts, a zero-byte
+    tmp file is left in the cache dir. The next invocation tries to
+    chmod it and dies with 'No such file or directory' (or similar).
+
+    Post-fix: a clean error message + no stray tmp files."""
+    r = _run(tmp_path, gcloud_failing, ["list"])
+    assert r.returncode != 0, "gcloud failure must propagate"
+    assert "failed to fetch secret" in r.stderr.lower(), (
+        f"err() did not surface a readable failure message:\n{r.stderr}"
+    )
+
+    cache_dir = tmp_path / ".cache" / "exe-coder-cli"
+    if cache_dir.exists():
+        leftover = sorted(p.name for p in cache_dir.iterdir() if p.name.startswith("."))
+        assert not leftover, (
+            f"failed gcloud invocation left stray dot-tmp files in the "
+            f"cache dir: {leftover}. The wrapper must clean up on failure."
+        )
+
+
+def test_cdr_rejects_empty_secret_payload(
+    tmp_path: Path, gcloud_empty_payload: Path
+) -> None:
+    """Secret Manager returning an empty body would otherwise leave a
+    zero-byte cache file that the upstream coder CLI then trusts as
+    a credential. Reject loudly."""
+    r = _run(tmp_path, gcloud_empty_payload, ["list"])
+    assert r.returncode != 0, "empty secret payload must propagate as error"
+    assert "empty payload" in r.stderr.lower(), (
+        f"err() did not surface an empty-payload message:\n{r.stderr}"
+    )
+
+    cache_dir = tmp_path / ".cache" / "exe-coder-cli"
+    if cache_dir.exists():
+        # No partial cache files should remain.
+        for p in cache_dir.iterdir():
+            assert p.stat().st_size > 0, (
+                f"empty cache file {p.name} left behind on empty payload"
+            )
+
+
+def test_cdr_skips_when_required_tools_missing(tmp_path: Path) -> None:
+    """If gcloud or coder is missing from PATH, fail with a readable
+    err(); do not silently exec an empty stub."""
+    empty_stubs = tmp_path / "empty"
+    empty_stubs.mkdir()
+    # Narrowed PATH: only the empty dir + where bash itself lives,
+    # so gcloud / coder are unreachable but `bash` (used internally
+    # by the wrapper, e.g. for command -v) keeps working.
+    bash_dir = str(Path(BASH).parent)
+    r = subprocess.run(
+        [BASH, str(CDR), "list"],
+        env={
+            **os.environ,
+            "PATH": f"{empty_stubs}:{bash_dir}",
+            "HOME": str(tmp_path),
+        },
+        capture_output=True,
+        text=True,
+    )
+    assert r.returncode != 0
+    assert "missing required tool" in r.stderr.lower(), (
+        f"missing-tool error not surfaced:\n{r.stderr}"
+    )
+
+
+def test_cdr_script_is_executable() -> None:
+    """The wrapper is invoked as `cdr ...` from the operator's PATH;
+    its exec bit must be set in the git index OR the Coder workflow
+    will refuse to run it."""
+    import subprocess as sp
+
+    out = sp.run(
+        ["git", "ls-files", "-s", "exe/scripts/cdr"],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    mode = out.stdout.split()[0]
+    assert mode == "100755", (
+        f"exe/scripts/cdr git index mode is {mode}, expected 100755. "
+        "Run: git update-index --chmod=+x exe/scripts/cdr"
+    )
+
+
+def test_cdr_present_for_every_test() -> None:
+    """Sanity check the file we're testing actually exists."""
+    assert CDR.is_file(), f"cdr wrapper missing at {CDR}"
+    assert shutil.which("bash") is not None, "bash required to run cdr"

--- a/tests/test_publish_workflow.py
+++ b/tests/test_publish_workflow.py
@@ -1,0 +1,144 @@
+"""Structural assertions on .github/workflows/publish-devcontainer.yaml.
+
+The publish workflow is what produces the OCI image the Coder
+template (exe/coder/templates/dotfiles-devcontainer/) consumes via
+`var.image`. A subtle bug in this file slipped past local checks
+once already (imageName=`<repo>:main` + imageTag=`latest` produced
+the invalid reference `<repo>:main:latest`); these tests pin the
+shape so the same regression cannot land twice.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW = ROOT / ".github" / "workflows" / "publish-devcontainer.yaml"
+
+
+@pytest.fixture(scope="module")
+def workflow_text() -> str:
+    if not WORKFLOW.exists():
+        pytest.fail(f"missing workflow: {WORKFLOW}")
+    return WORKFLOW.read_text(encoding="utf-8")
+
+
+def test_workflow_authenticates_via_wif(workflow_text: str) -> None:
+    """Image push must use Workload Identity Federation, never a
+    long-lived service account JSON. Catches a future revert that
+    re-introduces a key-based auth path."""
+    assert "google-github-actions/auth" in workflow_text, (
+        "workflow must use google-github-actions/auth for WIF"
+    )
+    assert "workload_identity_provider:" in workflow_text, (
+        "auth step must pass workload_identity_provider"
+    )
+    assert "service_account:" in workflow_text, (
+        "auth step must pass the impersonated service_account"
+    )
+    forbidden = ["credentials_json:", "credentials_file:"]
+    for needle in forbidden:
+        assert needle not in workflow_text, (
+            f"workflow uses {needle!r} (key-based auth). "
+            "Use WIF (workload_identity_provider) instead."
+        )
+
+
+def test_workflow_uses_devcontainers_ci_with_pinned_sha(
+    workflow_text: str,
+) -> None:
+    """devcontainers/ci must be pinned to a 40-char SHA + tag
+    comment, matching org Actions policy."""
+    m = re.search(
+        r"uses:\s*devcontainers/ci@([0-9a-f]+)",
+        workflow_text,
+    )
+    assert m is not None, "publish workflow must use devcontainers/ci"
+    sha = m.group(1)
+    assert len(sha) == 40, (
+        f"devcontainers/ci must be pinned to a full 40-char SHA, got: {sha!r}"
+    )
+
+
+def test_workflow_does_not_double_tag_image(workflow_text: str) -> None:
+    """devcontainers/ci concatenates imageName + ':' + imageTag.
+    If imageName already contains a ':<tag>' segment, the result is
+    a double-tag like '<repo>:main:latest' which docker rejects as
+    'invalid reference format'. Force imageName to be the bare repo
+    path."""
+    # Find the 'with:' block that feeds devcontainers/ci.
+    block = re.search(
+        r"uses:\s*devcontainers/ci@.*?(\n\s*with:.*?)(?=\n\s+- |\Z)",
+        workflow_text,
+        re.DOTALL,
+    )
+    assert block is not None, "could not locate the devcontainers/ci 'with:' block"
+    body = block.group(1)
+    image_name_match = re.search(r"imageName:\s*([^\n]+)", body)
+    assert image_name_match is not None, "with: must declare imageName"
+    image_name_value = image_name_match.group(1).strip()
+    # Strip ${{ ... }} substitutions so we can lint the literal payload.
+    # Anything inside ${{ ... }} resolves to a step output; we still
+    # validate the *output expression* points at a base path, never a
+    # `:tag` reference.
+    if "${{" in image_name_value:
+        # The output is named — the resolution itself is checked by
+        # an output-name convention: any output whose name ends in
+        # `_main`, `_sha`, etc. is suspicious.
+        assert "_main" not in image_name_value and "_sha" not in image_name_value, (
+            f"imageName references a tagged output ({image_name_value}). "
+            "Use the bare-base output and pass the tag via imageTag."
+        )
+    else:
+        # Literal value — must NOT contain ':' after the registry/path
+        # split. The Artifact Registry path itself uses ':' only at the
+        # tag boundary; everything before is path components.
+        # We just guard against any explicit ':<tag>' suffix.
+        assert ":" not in image_name_value.split("/")[-1], (
+            f"imageName has a ':<tag>' suffix on the final segment "
+            f"({image_name_value!r}). devcontainers/ci would concatenate "
+            "with imageTag and produce '<repo>:<a>:<b>' which docker "
+            "rejects as invalid reference format."
+        )
+
+
+def test_workflow_publishes_immutable_sha_tag(workflow_text: str) -> None:
+    """The workflow tags the same image twice: a rolling :main and
+    an immutable :<git-sha>. The Coder template can pin to the SHA
+    for repeatable rollbacks. Both pushes must be present."""
+    assert "GITHUB_SHA" in workflow_text, (
+        "workflow must reference GITHUB_SHA when computing the immutable tag"
+    )
+    # Look for a `docker push` of a SHA-tagged ref.
+    assert re.search(r"docker push .*image_sha", workflow_text), (
+        "workflow must docker push the :<sha> tagged ref after the "
+        "devcontainers/ci step"
+    )
+
+
+def test_workflow_uses_correct_artifact_registry_path(
+    workflow_text: str,
+) -> None:
+    """The image path must match what the Coder template's
+    `var.image` default consumes:
+    asia-northeast1-docker.pkg.dev/gen-ai-hironow/dotfiles/devcontainer.
+    Drift between the two would silently push to one location and
+    pull from another."""
+    assert "asia-northeast1" in workflow_text, "AR_REGION must be asia-northeast1"
+    assert "gen-ai-hironow" in workflow_text, "AR_PROJECT must be gen-ai-hironow"
+    assert "dotfiles" in workflow_text, "AR_REPO must be dotfiles"
+    assert "devcontainer" in workflow_text, "AR_IMAGE must be devcontainer"
+
+
+def test_workflow_passes_github_token_to_action(workflow_text: str) -> None:
+    """devcontainers/ci needs GITHUB_TOKEN (passed via `env:` block)
+    so feature graph resolution against ghcr.io hits the
+    authenticated quota. Without it, the build can fail under load
+    on api.github.com 60/hr anonymous limit."""
+    assert "GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}" in workflow_text, (
+        "devcontainers/ci step must surface GITHUB_TOKEN via env: block"
+    )


### PR DESCRIPTION
## What

Cleanup PR for documentation + test debt left after Layer-1 / Layer-2 / image-pipeline migrations.

### ADRs (record-the-why for already-merged decisions)

| ADR | Captures |
|---|---|
| `docs/adr/0003-actions-pin-sha.md` | PR #48 — full-length SHA pins, `dependabot.yaml`, `jdx/mise-action` allowlist, rttm CVE bumps |
| `docs/adr/0004-workspace-tailnet-routing.md` | PR #47 — B-plan tailnet routing (workspace VM joins tailnet, reaches `exe-coder:7080` over MagicDNS, `provider "coder" { url = ... }` per-template override) |

### Regression tests

| File | Count | Guards |
|---|---|---|
| `tests/test_publish_workflow.py` | 6 | imageName double-tag bug, devcontainers/ci SHA pin, GITHUB_TOKEN surfacing, AR path consistency |
| `tests/test_cdr_wrapper.py` | 7 | cache-hit short-circuit, secret refresh, gcloud failure cleanup (the No-such-file-or-directory bug fix from `4279fcd`), empty payload rejection, missing-tool error, exec bit |

### Why now

The publish workflow tag-concat bug + the cdr wrapper stranded-tmp bug both shipped to main as direct pushes (`3158776`, `4279fcd`) without test coverage. Adding tests now closes the regression window before the next session.

## Out of scope

- `remoteUser=root` → `vscode` (Layer-1 follow-up, separate PR)
- `mise.toml` version pinning (separate decision)
- Retroactive codex review of PR #54