### PR TITLE
docs(adr): 0005 install path rationalization + 0006 mise pinning

### DIFF
--- a/docs/adr/0005-install-path-rationalization.md
+++ b/docs/adr/0005-install-path-rationalization.md
@@ -1,0 +1,241 @@
+# 0005. Rationalise install paths across Mac host and Coder workspace (Linux)
+
+**Date:** 2026-05-02
+**Status:** Proposed
+
+## Context
+
+`hironow/dotfiles` is consumed from at least three platforms:
+
+1. **Operator's macOS host** — primary daily driver. Uses Homebrew,
+   `gcloud` SDK from Google's installer, and a sprinkling of
+   developer tools that the operator wants on every machine.
+2. **Coder workspace** (Linux container running on a debian-12 VM) —
+   should expose "as much of the Mac toolchain as feasible" so the
+   operator can SSH in and reuse muscle memory.
+3. **CI sandbox** (the same dev container image, run via
+   `devcontainers/ci`) — used by `tests/test_just_sandbox.py` and
+   friends. Must run unattended.
+
+A future Windows host is in mind: `scoop` + `mise` would replace
+`brew` + `mise`. **Out of scope for this ADR; design must not
+preclude it.**
+
+### What "install" currently means
+
+There are **four** install paths, scattered across the repo:
+
+| Layer | File | Target | Trigger | Installs |
+|---|---|---|---|---|
+| (1) | `install.sh` (root) | macOS host (with Linux skip-hatches) | manual on host, or `coder dotfiles` | Homebrew, gcloud SDK, just, then `just add-all` + `just update-all` + `just clean` + `just deploy` |
+| (2) | `.devcontainer/features/dotfiles-tools/install.sh` | dev container BUILD time (Linux) | `devcontainer build` (CI publish, local IDE) | apt: shellcheck/jq/gcloud/mise; tarball-pinned: uv/just/sheldon; mise.toml prebake |
+| (3) | `tofu/exe/coder.tf` startup_script (control plane VM) | debian-12 GCE host VM | tofu apply / VM boot | Coder server, cloudflared, tailscaled |
+| (4) | `exe/coder/templates/.../main.tf` startup_script (workspace VM + agent) | debian-12 GCE host VM + container | `cdr create` | host: tailscale, gcloud, docker; container: re-run (1) via `coder dotfiles` |
+
+### The actual content the operator cares about
+
+`dump/` carries the **declarative source of truth** for what
+should be installed on a fully-set-up Mac host:
+
+- `dump/Brewfile` (531 lines) — every brew formula / cask the
+  operator uses
+- `dump/gcloud` (30 lines) — gcloud component install list
+- `dump/npm-global` (24 lines) — global npm packages
+- `dump/gitignore-global` (66 lines) — git's global ignore
+
+`mise.toml` (8 lines) carries a separate, smaller SoT for tools
+that should follow `latest`-with-quarantine semantics:
+just, markdownlint-cli2, prek, uv, vp.
+
+### Symptoms of the current scattering
+
+- **Mac-oriented core forces hatching for Linux.** install.sh
+  always assumes brew + Google's interactive gcloud installer;
+  Linux callers (Coder workspace, CI) toggle three skip env vars
+  (`INSTALL_SKIP_HOMEBREW`, `INSTALL_SKIP_GCLOUD` — recently
+  retired, `INSTALL_SKIP_ADD_UPDATE`) to make it usable.
+
+- **Duplicate tool lists.** uv/just/sheldon are installed by both
+  (2) [via tarball at devcontainer build time] and indirectly by
+  (1) [via `just add-all` calls or implicit assumptions]. mise.toml
+  is the SoT for workspace runtime but the dev container feature
+  pre-bakes a parallel temporary mise.toml at build time.
+
+- **`coder dotfiles` ties (4) to (1).** The Coder agent's
+  `coder dotfiles -y URL` execs install.sh at the workspace
+  container's `/root/dotfiles/install.sh` after `git clone`. So the
+  Mac-shaped install.sh runs in a Linux container regardless of
+  what (2) already did.
+
+- **Trust boundary drift.** ADR 0001 + 0002 + 0003 set up a strict
+  CI-side trust posture (SHA pinning, GPG fingerprint pin,
+  attestation verify). install.sh runs `curl | bash` for Homebrew
+  and `curl https://sdk.cloud.google.com | bash` for gcloud — both
+  contradict that posture, but only run on the Mac host where
+  attestation/sigstore tooling is harder to enforce.
+
+## Decision
+
+(Pending — three strategies considered.)
+
+### Strategy α — OS dispatch
+
+`install.sh` becomes a thin dispatcher that detects OS and routes:
+
+```sh
+case "$(uname -s)" in
+  Darwin) exec "$DOTPATH/install/mac.sh" "$@" ;;
+  Linux)  exec "$DOTPATH/install/linux.sh" "$@" ;;
+esac
+```
+
+`install/mac.sh` keeps the brew + gcloud SDK + brew-bundle path.
+`install/linux.sh` becomes a small script that does the
+cross-platform parts (symlink + sheldon + mise install) and lets
+the underlying environment provide everything else (apt-installed,
+or pre-baked into the dev container image). Future
+`install/windows.ps1` slots in alongside.
+
+- Pros: simplest mental model. Each OS has one file.
+- Cons: code duplication for shared logic (zgen clone, sheldon
+  setup, just-install fallback).
+
+### Strategy β — Mac-only install.sh, Linux runs nothing
+
+Strip install.sh down to "Mac personal setup". Linux callers
+(Coder, CI) **stop calling install.sh entirely**. The dev container
+image already has every tool the workspace needs; the `coder
+dotfiles` invocation is replaced with a thin `coder dotfiles -y`
+invocation that ONLY does the symlink/sheldon work via a separate
+`bin/dotfiles-deploy` (calling `just clean && just deploy`).
+
+- Pros: **secure-by-default** posture wins — image is the SoT for
+  Linux tools, no runtime install at all.
+- Cons: `coder dotfiles` upstream contract assumes install.sh
+  exists; we'd need a wrapper. Loses the "same install path
+  everywhere" mental model.
+
+### Strategy γ — OS-agnostic core + plugin directories (recommended)
+
+Single `install.sh` at the root that does the **shared work** only:
+
+1. Clone the dotfiles repo into `$DOTPATH` (or fast-forward).
+2. Source `$DOTPATH/install/common.sh` for shared functions
+   (zgen clone, sheldon lock, mise install, just clean+deploy).
+3. Discover and run `$DOTPATH/install/<os>.d/*.sh` in lex order
+   per detected OS, where `<os>` is `mac`, `linux`, or eventually
+   `win`.
+
+Per-OS plugin directories own their own concerns:
+
+```
+install/
+  common.sh         (sourced by install.sh)
+  mac.d/
+    10-homebrew.sh        # brew install + brew bundle dump/Brewfile
+    20-gcloud-installer.sh
+    30-mac-defaults.sh    # macOS defaults write
+  linux.d/
+    10-apt-baseline.sh    # apt update; apt install ca-certs etc.
+    20-no-runtime-network.sh   # marker: dev container already
+                                # provides everything else
+  win.d/                  # future
+    10-scoop.sh
+    20-winget.sh
+```
+
+`mise.toml` stays the canonical tool list (cross-platform) and
+`common.sh` runs `mise install` once. `dump/Brewfile`,
+`dump/gcloud`, `dump/npm-global` move to `install/mac.d/data/` (or
+similar) since they are macOS-specific declarative sources.
+`dump/gitignore-global` is OS-agnostic and stays addressable from
+common.
+
+- Pros: **DRY** core, **clean OS branching**, **future Windows
+  ready**. mise.toml as the genuine cross-platform SoT.
+- Cons: bigger refactor. Risks regressing Mac flow if not careful.
+
+## Open questions to resolve before implementation
+
+1. **`coder dotfiles` integration.** Upstream contract is
+   "execute `install.sh` after clone." Do we keep install.sh as the
+   entrypoint and have it no-op on Linux when the dev container
+   already has everything (γ-friendly)? Or replace `coder dotfiles
+   -y` with `coder dotfiles -y --command "$DOTPATH/bin/dotfiles-deploy"`
+   (β-friendly)? Reading the Coder docs for `dotfiles_command`
+   parameter is the answer.
+
+2. **gcloud installer trust.** Google publishes a Debian apt repo
+   (used in the local feature today) and an interactive `curl
+   https://sdk.cloud.google.com | bash` installer for Mac. The Mac
+   path is currently `curl | bash` against Google's CDN, no SHA
+   verification. Worth replacing with the `--package` install for
+   reproducibility.
+
+3. **Brewfile hygiene.** 531 lines of `tap` + `brew` + `cask`
+   declarations include things the operator may no longer use. A
+   `brew bundle cleanup` + commit pass is a separate cleanup PR
+   but should be flagged so install.sh's runtime is bounded.
+
+4. **`just add-all` semantics.** Currently install.sh calls
+   `just add-all` which re-dumps the host's installed brew/gcloud/
+   pnpm globals back into `dump/` files. This means a pristine
+   install.sh run on a half-set-up machine **mutates the dump/
+   files** and could commit drift. Should `just add-all` move
+   behind a `just sync-dumps` recipe that the operator runs
+   intentionally rather than as part of every install?
+
+5. **mise.toml as SoT for npm-backed tools.** vp + markdownlint-cli2
+   are installed via mise's npm backend, which fails inside the
+   workspace because `--volume /home/hironow:/root` masks the
+   build-time-installed npm. Either (a) accept the WARN +
+   binaries-on-PATH posture (current), (b) rebuild with
+   non-overlapping volume mounts, (c) pull npm-backed tools out of
+   mise.toml and treat them as pure brew (Mac) / apt (Linux).
+
+6. **Windows readiness.** scoop + mise. Concretely: which
+   tools in `dump/Brewfile` have scoop equivalents, and which need
+   alternative installers (e.g. `gcloud` on Windows)?
+
+## Consequences (regardless of chosen strategy)
+
+### Positive
+
+- **One coherent install model** instead of four scattered ones.
+- **Trust boundary becomes documentable.** Each path has a single
+  responsibility and can be tested.
+- **Future Windows on-ramp** is straightforward.
+
+### Negative
+
+- **Refactor cost.** install.sh and the Coder template both touch
+  the install path. PR scope is medium (estimated 200-500 LOC
+  changed across install.sh, dump/, justfile, main.tf, README).
+- **Test coverage.** install.sh has minimal coverage today
+  (`tests/test_just_sandbox.py` indirectly exercises `just deploy`).
+  Strategy γ requires per-OS plugin discovery tests, which is new
+  ground.
+- **Coder dotfiles command override.** May require a per-workspace
+  Coder parameter for the install command, which is a UI change.
+
+### Neutral
+
+- **`mise.toml` stays the canonical cross-platform tool list**
+  under all three strategies. The decision is mostly about where
+  brew/Brewfile/gcloud/npm-global hooks live.
+- **`dump/gitignore-global`** stays where it is or moves to
+  `install/common/`; cross-platform regardless.
+
+## Recommendation
+
+**Strategy γ** (OS-agnostic core + plugin directories) is the
+recommended direction. It keeps the Mac flow intact, gives Linux a
+clear "no-op except sheldon/symlink" path that aligns with the
+secure-by-default posture from ADR 0002, and prepares cleanly for
+Windows.
+
+Implementation should be a separate PR `feat/install-os-plugin-layout`
+that reorganises files, ports the Mac flow into `mac.d/`, drops
+`INSTALL_SKIP_*` env vars from the Coder template (they become
+unnecessary because Linux's `linux.d/` is empty), and adds
+characterization tests using the dev container.

--- a/docs/adr/0005-install-path-rationalization.md
+++ b/docs/adr/0005-install-path-rationalization.md
@@ -52,8 +52,12 @@ just, markdownlint-cli2, prek, uv, vp.
 - **Mac-oriented core forces hatching for Linux.** install.sh
   always assumes brew + Google's interactive gcloud installer;
   Linux callers (Coder workspace, CI) toggle three skip env vars
-  (`INSTALL_SKIP_HOMEBREW`, `INSTALL_SKIP_GCLOUD` — recently
-  retired, `INSTALL_SKIP_ADD_UPDATE`) to make it usable.
+  (`INSTALL_SKIP_HOMEBREW`, `INSTALL_SKIP_GCLOUD`,
+  `INSTALL_SKIP_ADD_UPDATE`) to make it usable. The Coder agent
+  dropped `INSTALL_SKIP_GCLOUD` in PR #54 because gcloud is now
+  baked into the dev container image, but install.sh itself
+  still honours all three so the script remains usable from
+  callers that do not have gcloud pre-installed.
 
 - **Duplicate tool lists.** uv/just/sheldon are installed by both
   (2) [via tarball at devcontainer build time] and indirectly by
@@ -102,18 +106,17 @@ or pre-baked into the dev container image). Future
 
 ### Strategy β — Mac-only install.sh, Linux runs nothing
 
-Strip install.sh down to "Mac personal setup". Linux callers
-(Coder, CI) **stop calling install.sh entirely**. The dev container
-image already has every tool the workspace needs; the `coder
-dotfiles` invocation is replaced with a thin `coder dotfiles -y`
-invocation that ONLY does the symlink/sheldon work via a separate
-`bin/dotfiles-deploy` (calling `just clean && just deploy`).
+**WITHDRAWN after codex review.** The strategy hinged on telling
+Coder's `coder dotfiles` to run a custom command instead of
+install.sh. Upstream `coder dotfiles` does NOT expose a
+`--command` flag (per
+<https://coder.com/docs/reference/cli/dotfiles>); the only
+overrides are `--symlink-dir` and `--repo-dir`. Without a
+supported way to point `coder dotfiles` at a different
+entrypoint, β reduces to "rename install.sh and rely on Coder's
+fallback discovery" — which is brittle and undocumented.
 
-- Pros: **secure-by-default** posture wins — image is the SoT for
-  Linux tools, no runtime install at all.
-- Cons: `coder dotfiles` upstream contract assumes install.sh
-  exists; we'd need a wrapper. Loses the "same install path
-  everywhere" mental model.
+Keeping β here as historical context only. Pick α or γ.
 
 ### Strategy γ — OS-agnostic core + plugin directories (recommended)
 
@@ -157,20 +160,49 @@ common.
 
 ## Open questions to resolve before implementation
 
-1. **`coder dotfiles` integration.** Upstream contract is
-   "execute `install.sh` after clone." Do we keep install.sh as the
-   entrypoint and have it no-op on Linux when the dev container
-   already has everything (γ-friendly)? Or replace `coder dotfiles
-   -y` with `coder dotfiles -y --command "$DOTPATH/bin/dotfiles-deploy"`
-   (β-friendly)? Reading the Coder docs for `dotfiles_command`
-   parameter is the answer.
+1. **`coder dotfiles` integration.** Upstream contract per
+   <https://coder.com/docs/reference/cli/dotfiles> is:
 
-2. **gcloud installer trust.** Google publishes a Debian apt repo
-   (used in the local feature today) and an interactive `curl
-   https://sdk.cloud.google.com | bash` installer for Mac. The Mac
-   path is currently `curl | bash` against Google's CDN, no SHA
-   verification. Worth replacing with the `--package` install for
-   reproducibility.
+   ```sh
+   coder dotfiles --repo-dir <path> --symlink-dir <path> <git-url>
+   ```
+
+   - The flags `--symlink-dir` and `--repo-dir` exist; the
+     entrypoint script discovery is **not** overridable. After
+     `git clone`, Coder probes the repo for a known entrypoint
+     (install.sh, bootstrap.sh, etc.) and execs whichever it
+     finds first.
+   - `--repo-dir` defaults to a path relative to
+     `$CODER_CONFIG_DIR` (typically `~/.config/coderv2`), NOT
+     `$HOME/dotfiles` as the current main.tf assumes. The
+     observed clone path of `/root/dotfiles` is incidental
+     (a side-effect of how the agent's HOME and CODER_CONFIG_DIR
+     happen to land on this stack).
+   - Decision needed: pin `--repo-dir=$HOME/dotfiles` explicitly
+     in the agent startup script OR move every consumer to use
+     `$CODER_DOTFILES_REPO_DIR` env var.
+
+2. **Trust boundaries for runtime installers (host AND container).**
+   Open Question 2 is broader than "Mac gcloud installer." Audit
+   every `curl | bash` / `curl | sh` / unsigned tarball pipe in
+   the install paths, on both Mac and Linux:
+
+   | Path | Source | Verification |
+   |---|---|---|
+   | install.sh `brew` install | `raw.githubusercontent.com/Homebrew/install/HEAD/install.sh` (Mac) | none (curl+bash) |
+   | install.sh `gcloud` install | `sdk.cloud.google.com` (Mac) | none (curl+bash) |
+   | install.sh `just` fallback | `just.systems/install.sh` (cross-platform) | none |
+   | main.tf VM `tailscale` | `pkgs.tailscale.com` apt repo | apt key fetched fresh; not fingerprint-pinned |
+   | main.tf VM `gcloud` | `packages.cloud.google.com` apt repo | apt key fetched fresh; not fingerprint-pinned |
+   | main.tf VM `docker` | `get.docker.com` (curl+bash) | **none — TOFU on each VM boot** |
+   | feature install.sh `gcloud` apt | `packages.cloud.google.com` | **fingerprint pinned** ✅ (ADR 0001) |
+   | feature install.sh `mise` apt | `mise.jdx.dev` | **fingerprint pinned** ✅ (ADR 0001) |
+   | feature install.sh `uv`/`just`/`sheldon` | GitHub releases | **SHA verified** ✅ (ADR 0001) |
+
+   The dev container feature is the only path with consistent
+   verification. The other entrypoints inherit different
+   postures. Implementation must converge them or document the
+   asymmetry.
 
 3. **Brewfile hygiene.** 531 lines of `tap` + `brew` + `cask`
    declarations include things the operator may no longer use. A
@@ -196,6 +228,16 @@ common.
 6. **Windows readiness.** scoop + mise. Concretely: which
    tools in `dump/Brewfile` have scoop equivalents, and which need
    alternative installers (e.g. `gcloud` on Windows)?
+
+7. **mise version pinning strategy.** All five tools in mise.toml
+   currently say `= "latest"`. The dev container feature pre-bakes
+   resolved versions at build time (which `mise install` then
+   matches), but workspace runtime resolves "latest" against
+   GitHub fresh. CI reproducibility, supply-chain attestation, and
+   "build-time-only network" posture all depend on what we choose
+   here. Resolved in the follow-up
+   `docs/adr/0006-mise-version-pinning.md`; this ADR is blocked
+   until that one lands.
 
 ## Consequences (regardless of chosen strategy)
 

--- a/docs/adr/0006-mise-version-pinning.md
+++ b/docs/adr/0006-mise-version-pinning.md
@@ -1,0 +1,189 @@
+# 0006. mise tool version pinning strategy
+
+**Date:** 2026-05-02
+**Status:** Proposed
+**Blocks:** ADR 0005 (install path rationalization)
+
+## Context
+
+`mise.toml` is the cross-platform source of truth for the
+operator's developer-tool versions:
+
+```toml
+[tools]
+just = "latest"
+markdownlint-cli2 = "latest"
+prek = "latest"
+uv = "latest"
+vp = "latest"
+```
+
+Three consumers read this file:
+
+1. **Mac host** — operator manually runs `mise install` after
+   updating `mise.toml`. "latest" resolves online to whatever the
+   tool's registry says is current. mise.lock is **not** committed.
+2. **Dev container build (CI)** — the local `dotfiles-tools`
+   feature pre-bakes the same tools at specific pinned versions
+   (`UV_VERSION="0.11.8"`, `JUST_VERSION="1.40.0"`, etc.) hardcoded
+   in `.devcontainer/features/dotfiles-tools/install.sh`. The
+   feature also writes a temporary `mise.toml` at
+   `/tmp/mise-prebuild/mise.toml` with the same pinned versions,
+   runs `mise install` against THAT file, and discards it. The
+   production `mise.toml` (which says "latest") is never consulted
+   during build.
+3. **Coder workspace runtime** — the agent startup script runs
+   `mise install` against the workspace's bind-mounted
+   `/root/dotfiles/mise.toml`, with `MISE_OFFLINE=0` forced so
+   "latest" can resolve. Newer-than-image versions are downloaded
+   live and override the baked-in cache for that workspace
+   lifetime.
+
+This split has known problems:
+
+- **Image / runtime drift.** Two workspace creations the same
+  hour can resolve `just = "latest"` to different versions if
+  upstream pushes a release between them. Reproducibility breaks
+  silently.
+- **Two SoT in two places.** `.devcontainer/features/dotfiles-tools/install.sh`
+  hardcodes versions; `mise.toml` says "latest". The feature
+  versions are the **actually-installed** ones at build time but
+  are invisible to anyone reading the production `mise.toml`.
+- **Trust-boundary leak (per ADR 0005 Open Question 7).** "latest"
+  resolution at runtime is a per-workspace network call to
+  api.github.com. Even with `GITHUB_TOKEN` propagated, this
+  expands the runtime trust surface beyond what build-time
+  attestation has covered.
+- **codex review of ADR 0005** flagged this as a blocker for the
+  install-path rationalization: "γを採る前に pin戦略 を先に決め
+  ないと不安定化"。
+
+## Decision
+
+(Pending — three strategies considered.)
+
+### Strategy A — Pin in mise.toml directly (boring, reproducible)
+
+```toml
+[tools]
+just = "1.40.0"
+markdownlint-cli2 = "0.22.1"
+prek = "0.3.11"
+uv = "0.11.8"
+vp = "0.1.20"
+```
+
+- The dev container feature drops its hardcoded version block;
+  it just runs `mise install` against the workspace mise.toml at
+  build time. Single SoT.
+- Updates are explicit PRs that touch mise.toml.
+- mise's own self-update behaviour (e.g. `mise upgrade`) is the
+  operator's tool for picking the next pin.
+- Pros: simplest to reason about; one number per tool; CI and
+  workspace agree.
+- Cons: every update requires a manual PR; loses mise's
+  "fetch latest" convenience on the Mac host.
+
+### Strategy B — Commit mise.lock (mise's official pin format)
+
+Keep `mise.toml` with `"latest"`. Run `mise install` once, then
+commit the resulting `mise.lock` file. mise reads the lock
+deterministically across machines.
+
+```toml
+# mise.toml
+[tools]
+just = "latest"
+# ...
+
+# mise.lock (committed)
+[tools.just]
+version = "1.40.0"
+backend = "aqua"
+```
+
+- Updates: `mise upgrade` then commit the new mise.lock.
+- The dev container feature reads the same mise.toml + mise.lock
+  pair as the Mac host. Single SoT.
+- Pros: matches mise's own design; allows `latest` semantics in
+  the toml while still being deterministic at install time.
+- Cons: requires un-gitignoring mise.lock (currently ignored
+  per existing convention); mise.lock is a binary-ish format that
+  generates large diffs on update.
+
+### Strategy C — Status quo + image-tag pin only (ad-hoc)
+
+Keep "latest" in mise.toml. Keep the feature install.sh
+hardcoded versions. Rely on the prebuilt image tag (`:main` or
+`:<git-sha>` per ADR 0002) for "this workspace's tool versions
+are whatever the build that produced this image saw."
+Reproducibility comes from pinning the **image** rather than the
+**tools inside it**.
+
+- Pros: zero operator change; image-tag pin is already the unit
+  of rollback for Coder template.
+- Cons: workspace runtime `mise install` still drifts (downloads
+  newer-than-image versions if "latest" advanced). Two SoT
+  remains. Poor surface for reasoning about supply chain.
+
+## Open questions
+
+1. **mise.lock format stability.** Has mise.lock's schema
+   stabilised in 2025/2026 to the point we'd commit it? If lock
+   format breaks across mise versions, Strategy B causes pain.
+2. **Mac operator UX.** The current Mac flow is `mise install`
+   pulls fresh latest. Under Strategy A, the Mac operator would
+   get pinned versions and have to opt in to upgrades. Acceptable
+   trade-off?
+3. **`MISE_OFFLINE` in workspace runtime.** With Strategy A or
+   B, can we re-enable `MISE_OFFLINE=1` at runtime (no network
+   needed because all versions are pinned)? That would close the
+   trust-surface drift identified by codex review 3.
+4. **Pinning npm-backed tools** (vp, markdownlint-cli2). mise's
+   npm backend currently fails in the workspace because of the
+   `/home/hironow:/root` overlay mask (ADR 0005 Open Q5). Strategy
+   A or B do not fix this, but make it more visible — a pinned
+   "vp = 0.1.20" that mise can't actually install at runtime
+   should error rather than warn.
+
+## Recommendation
+
+**Strategy A** (pin in mise.toml directly). It is the simplest
+change, gives a single SoT, and aligns with the existing pattern
+of explicit version constants elsewhere in this repo
+(`UV_VERSION="0.11.8"` in the local feature, action `@<sha> # vX.Y`
+pins in workflows, hardcoded SHA in sheldon install).
+
+If the operator strongly prefers `latest` semantics on the Mac
+host, Strategy B is a viable alternative — but it introduces
+mise.lock as a new file in the repo and needs a one-time
+discussion about the gitignore policy.
+
+After this ADR is accepted, ADR 0005 can pick Strategy γ + run
+`mise install` at build time with deterministic versions, and
+re-enable `MISE_OFFLINE=1` at runtime.
+
+## Consequences (Strategy A, recommended)
+
+### Positive
+
+- **One SoT** for tool versions: mise.toml.
+- **Deterministic.** Identical results at build, on Mac, in CI.
+- **Re-enables `MISE_OFFLINE=1`** at workspace runtime, narrowing
+  the trust surface.
+
+### Negative
+
+- **Manual upgrade cadence.** Operator runs `mise upgrade` and
+  commits the diff to bump versions, instead of mise pulling
+  fresh on each install.
+- **One-time data migration.** The feature install.sh drops the
+  hardcoded `UV_VERSION` / `JUST_VERSION` etc. blocks; they move
+  into mise.toml. Three places that hardcode versions today
+  become one.
+
+### Neutral
+
+- **Tool churn frequency** is low for this set (just / uv / sheldon
+  rotate maybe quarterly). Pinning does not block urgent
+  upgrades; it just requires a PR.


### PR DESCRIPTION
## What

Two planning ADRs (codex-reviewed):

- `docs/adr/0005-install-path-rationalization.md` — design space for fixing four scattered install paths
- `docs/adr/0006-mise-version-pinning.md` — pin strategy for mise.toml; blocks 0005

Status: **Proposed** for both. No implementation yet.

## Why

After the Layer-1 / Layer-2 / image-pipeline migrations the install logic spreads across:

1. `install.sh` (root) — Mac-oriented with Linux skip-hatches
2. `.devcontainer/features/dotfiles-tools/install.sh` — dev container build-time
3. `tofu/exe/coder.tf` startup_script — control-plane VM
4. `exe/coder/templates/.../main.tf` startup_script — workspace VM + agent

Symptoms: brittle skip env vars, duplicate tool lists, trust-boundary drift.

## Strategies

ADR 0005 (install paths):

| | Strategy | Status |
|---|---|---|
| α | OS dispatch (`uname -s` router) | Considered |
| β | Mac-only install.sh | **Withdrawn** — `coder dotfiles` has no `--command` flag |
| γ | OS-agnostic core + plugin dirs | **Recommended** |

ADR 0006 (mise pinning):

| | Strategy | Status |
|---|---|---|
| A | Pin in mise.toml directly | **Recommended** |
| B | Commit mise.lock | Viable |
| C | Status quo + image-tag pin | Documented for completeness |

## codex review (5 critical points, all addressed in-PR)

1. β strategy `--command` doesn't exist → **withdrawn**
2. `coder dotfiles --repo-dir` semantics → **Open Q1 expanded**
3. mise "latest" + runtime install conflicts with reproducibility → **new ADR 0006 blocks 0005**
4. trust-boundary table needs to cover host AND workspace VM → **Open Q2 expanded with full audit table**
5. ADR-vs-implementation drift on `INSTALL_SKIP_GCLOUD` → **Symptoms paragraph clarified**

References:
- [coder dotfiles CLI](https://coder.com/docs/reference/cli/dotfiles)
- [Workspace dotfiles](https://coder.com/docs/user-guides/workspace-dotfiles)

## Operator action

Lock in:
1. ADR 0005: **α or γ** (recommend γ)
2. ADR 0006: **A, B, or C** (recommend A)
3. Pre-implementation answers for Open Q1 / Q4 / Q5 in 0005

After acceptance, implementation PR `feat/install-os-plugin-layout` follows.