### PR TITLE
docs(adr): codex amendments + accept 0005/0006 + add 0007 + impl coder.tf hardening

### DIFF
--- a/docs/adr/0005-install-path-rationalization.md
+++ b/docs/adr/0005-install-path-rationalization.md
@@ -213,6 +213,17 @@ common.
    should be prioritised even if it's out of scope for this
    ADR's primary refactor.
 
+   Additional concern at `coder.tf:290`: the install line is
+   `curl -fsSL https://coder.com/install.sh | sh || true`. The
+   `|| true` swallows any non-zero exit. Success is then probed
+   only via `[[ ! -x /usr/local/bin/coder && ! -x /usr/bin/coder ]]`
+   to decide whether to run the fallback. A compromised CDN
+   could return a malicious script that exits 0 after writing
+   anything to `/usr/local/bin/coder`, and the fallback path
+   (`api.github.com/.../latest`) would be skipped. The pin
+   strategy for this row must address both the unverified
+   primary install AND the exit-code-suppressed failure mode.
+
 3. **Brewfile hygiene.** 531 lines of `tap` + `brew` + `cask`
    declarations include things the operator may no longer use. A
    `brew bundle cleanup` + commit pass is a separate cleanup PR

--- a/docs/adr/0005-install-path-rationalization.md
+++ b/docs/adr/0005-install-path-rationalization.md
@@ -192,9 +192,11 @@ common.
    | install.sh `brew` install | `raw.githubusercontent.com/Homebrew/install/HEAD/install.sh` (Mac) | none (curl+bash) |
    | install.sh `gcloud` install | `sdk.cloud.google.com` (Mac) | none (curl+bash) |
    | install.sh `just` fallback | `just.systems/install.sh` (cross-platform) | none |
+   | tofu/exe/coder.tf Coder server install | `coder.com/install.sh` (control-plane VM) | **none — curl+bash + `\|\| true`** |
+   | tofu/exe/coder.tf Coder server fallback | `api.github.com/repos/coder/coder/releases/latest` → tarball | **none — `latest` resolves at boot, no SHA/SLSA verify** |
    | main.tf VM `tailscale` | `pkgs.tailscale.com` apt repo | apt key fetched fresh; not fingerprint-pinned |
    | main.tf VM `gcloud` | `packages.cloud.google.com` apt repo | apt key fetched fresh; not fingerprint-pinned |
-   | main.tf VM `docker` | `get.docker.com` (curl+bash) | **none — TOFU on each VM boot** |
+   | main.tf VM `docker` | `download.docker.com` apt repo | **fingerprint pinned** ✅ (PR #57) |
    | feature install.sh `gcloud` apt | `packages.cloud.google.com` | **fingerprint pinned** ✅ (ADR 0001) |
    | feature install.sh `mise` apt | `mise.jdx.dev` | **fingerprint pinned** ✅ (ADR 0001) |
    | feature install.sh `uv`/`just`/`sheldon` | GitHub releases | **SHA verified** ✅ (ADR 0001) |
@@ -204,18 +206,30 @@ common.
    postures. Implementation must converge them or document the
    asymmetry.
 
+   The `tofu/exe/coder.tf` rows above are particularly load-
+   bearing: that VM is the control plane that issues workspace
+   tokens, so a compromised Coder binary on first boot would
+   compromise every workspace it later spawns. Pinning here
+   should be prioritised even if it's out of scope for this
+   ADR's primary refactor.
+
 3. **Brewfile hygiene.** 531 lines of `tap` + `brew` + `cask`
    declarations include things the operator may no longer use. A
    `brew bundle cleanup` + commit pass is a separate cleanup PR
    but should be flagged so install.sh's runtime is bounded.
 
-4. **`just add-all` semantics.** Currently install.sh calls
-   `just add-all` which re-dumps the host's installed brew/gcloud/
-   pnpm globals back into `dump/` files. This means a pristine
-   install.sh run on a half-set-up machine **mutates the dump/
-   files** and could commit drift. Should `just add-all` move
-   behind a `just sync-dumps` recipe that the operator runs
-   intentionally rather than as part of every install?
+4. **`dump/` mutation surface.** `install.sh` calls `just add-all`
+   which **only consumes** `dump/Brewfile`, `dump/gcloud-list.txt`,
+   `dump/pnpm-g.txt` (idempotent install). The actual mutator is
+   `just dump`, which is **operator-invoked manually** and rewrites
+   `dump/Brewfile` etc. with the current host state. That separation
+   is already correct — there is no install-path-side mutation to
+   fix here. The original premise of this question (an automatic
+   re-dump during install) was incorrect; flagged by codex review
+   2026-05-02. Remaining concern: should `just dump` gain a guard
+   against accidental commits of host-specific drift (e.g., a
+   pre-commit reminder that diff-noise in `dump/` indicates a
+   manual sync was performed)? — minor follow-up only.
 
 5. **mise.toml as SoT for npm-backed tools.** vp + markdownlint-cli2
    are installed via mise's npm backend, which fails inside the

--- a/docs/adr/0005-install-path-rationalization.md
+++ b/docs/adr/0005-install-path-rationalization.md
@@ -1,7 +1,8 @@
 # 0005. Rationalise install paths across Mac host and Coder workspace (Linux)
 
 **Date:** 2026-05-02
-**Status:** Proposed
+**Status:** Accepted (2026-05-02)
+**Blocked by:** ADR 0006 (mise pinning) — accepted in same wave
 
 ## Context
 
@@ -293,16 +294,81 @@ common.
 - **`dump/gitignore-global`** stays where it is or moves to
   `install/common/`; cross-platform regardless.
 
-## Recommendation
+## Decision (Accepted 2026-05-02)
 
-**Strategy γ** (OS-agnostic core + plugin directories) is the
-recommended direction. It keeps the Mac flow intact, gives Linux a
-clear "no-op except sheldon/symlink" path that aligns with the
-secure-by-default posture from ADR 0002, and prepares cleanly for
-Windows.
+After discussion of the strategies above plus the codex review
+(see commit `a74fb63` + `3d373b0`), the operator and assistant
+chose a refinement of Strategy γ that keeps the existing single
+`install.sh` entry point but adds **OS dispatch with per-step
+helper functions**. The full plugin-directory tree (`install/{mac,
+linux,win}.d/*.sh`) is rejected as over-engineering for a one-
+operator-three-OS scope; functions inside one file are easier to
+read and maintain.
 
-Implementation should be a separate PR `feat/install-os-plugin-layout`
-that reorganises files, ports the Mac flow into `mac.d/`, drops
-`INSTALL_SKIP_*` env vars from the Coder template (they become
-unnecessary because Linux's `linux.d/` is empty), and adds
-characterization tests using the dev container.
+### Decision details
+
+1. **OS identification** at the top of `install.sh`:
+
+   ```sh
+   case "$(uname -s)" in
+     Darwin)               DOTFILES_OS=mac ;;
+     Linux)                DOTFILES_OS=linux ;;
+     MINGW*|MSYS*|CYGWIN*) DOTFILES_OS=windows ;;
+     *) echo "[install] unsupported OS: $(uname -s)" >&2; exit 1 ;;
+   esac
+   ```
+
+   Unknown OS → fail closed. WSL2 is detected as `Linux`
+   (uname-based detection, kernel-name-based WSL nuance is out
+   of scope).
+
+2. **Per-step helper functions** (`step_*`) that dispatch on
+   `DOTFILES_OS`. The current step list:
+
+   | Step | mac | linux | windows |
+   |---|---|---|---|
+   | `step_homebrew` | `curl \| bash` (Homebrew install) | skip (apt provides equivalents) | TODO (scoop bootstrap) |
+   | `step_symlink_dotfiles` | `just deploy` | `just deploy` | `just deploy` (git-bash) |
+   | `step_sheldon` | `sheldon lock` | `sheldon lock` | `sheldon lock` |
+   | `step_brew_bundle` | `just add-brew` | skip | TODO (scoop bundle) |
+   | `step_gcloud_components` | `just add-gcloud` | skip (build-time gcloud) | TODO (Windows gcloud) |
+   | `step_pnpm_globals` | `just add-pnpm-g` | `just add-pnpm-g` | `just add-pnpm-g` |
+   | `step_update_all` | `just update-all` | skip | TODO |
+
+3. **Existing `INSTALL_SKIP_*` env vars are kept** for operator
+   override. The combined skip predicate is:
+   `OS-says-skip OR env-var-says-skip` (OR, not AND).
+
+4. **Linuxbrew (a.k.a. Homebrew on Linux) is not adopted.**
+   Homebrew on Linux is officially supported (per
+   `docs.brew.sh/Homebrew-on-Linux`) and a one-line install
+   shared with macOS exists, but Linux build-time install via
+   apt + the dev container feature already reaches the same
+   tool set with stronger verification (SHA + SLSA attestation).
+   Adopting Linuxbrew would add multi-minute build cost and
+   image bloat for a parity that we already have via a different
+   path.
+
+5. **Windows is scoop-only** (no winget). Scope is dev-CLI tools
+   that scoop already covers; GUI-app management via winget is
+   out of scope for this dotfiles repo.
+
+### Out of scope (covered by separate ADRs)
+
+- **`tofu/exe/coder.tf` Coder-server install hardening** —
+  important enough to warrant its own decision, captured in
+  ADR 0007.
+- **mise version pinning + cache relocation** — captured in
+  ADR 0006.
+- **Windows step_* implementations** — ship as TODO stubs that
+  emit a "not yet implemented" warning and exit 1; concrete
+  implementations land in a future ADR when a Windows host is
+  actually used.
+
+## Recommendation (historical, retained for context)
+
+**Strategy γ** (OS-agnostic core + plugin directories) was the
+original recommendation. The accepted decision (above) is a
+refinement: keep the single-file entry point but add OS dispatch
+inside via `step_*` functions. The plugin-directory tree was
+rejected as over-engineering at this scope.

--- a/docs/adr/0006-mise-version-pinning.md
+++ b/docs/adr/0006-mise-version-pinning.md
@@ -136,9 +136,18 @@ Reproducibility comes from pinning the **image** rather than the
    get pinned versions and have to opt in to upgrades. Acceptable
    trade-off?
 3. **`MISE_OFFLINE` in workspace runtime.** With Strategy A or
-   B, can we re-enable `MISE_OFFLINE=1` at runtime (no network
-   needed because all versions are pinned)? That would close the
-   trust-surface drift identified by codex review 3.
+   B, version pinning is a **necessary but not sufficient** condition
+   for re-enabling `MISE_OFFLINE=1`. The current
+   `--volume /home/hironow:/root` overlay in the gcp-vm-container
+   template **masks** the build-time-baked
+   `~/.local/share/mise/installs/` cache, so mise at runtime sees
+   an empty install dir and would have to re-fetch even pinned
+   versions — which `MISE_OFFLINE=1` would then refuse. Re-enabling
+   `MISE_OFFLINE=1` therefore depends on **first** resolving the
+   volume-mount model (don't mask `/root`, or pre-warm the mounted
+   `/home/<user>` cache before docker run, or relocate the cache).
+   Flagged by codex review 2026-05-02; treat as blocked until the
+   volume model is settled in the implementation PR.
 4. **Pinning npm-backed tools** (vp, markdownlint-cli2). mise's
    npm backend currently fails in the workspace because of the
    `/home/hironow:/root` overlay mask (ADR 0005 Open Q5). Strategy
@@ -160,8 +169,24 @@ mise.lock as a new file in the repo and needs a one-time
 discussion about the gitignore policy.
 
 After this ADR is accepted, ADR 0005 can pick Strategy γ + run
-`mise install` at build time with deterministic versions, and
-re-enable `MISE_OFFLINE=1` at runtime.
+`mise install` at build time with deterministic versions.
+Re-enabling `MISE_OFFLINE=1` at workspace runtime is gated on the
+volume-mount model resolution (see Open Question 3).
+
+**Build-time verification preservation (codex review 2026-05-02).**
+Strategy A's "drop the hardcoded `UV_VERSION` / `JUST_VERSION` /
+sheldon SHA blocks in feature install.sh" is **only safe if the
+implementation PR explicitly preserves** the SHA-256 sidecar
+checks and `gh attestation verify` calls that those blocks
+currently perform. Mise's pin alone proves "version X is
+installed", not "the binary tarball was authentic". The
+implementation PR must either (a) keep the verified-fetch path
+for those three tools and have mise consume the resulting
+`/usr/local/bin` symlinks via mise's `system` backend, or (b)
+add equivalent verification at the mise-fetch layer (e.g., mise
+backend with attestation hooks). Naive consolidation that simply
+removes the blocks and runs `mise install` is a security
+regression versus ADR 0001.
 
 ## Consequences (Strategy A, recommended)
 
@@ -169,8 +194,8 @@ re-enable `MISE_OFFLINE=1` at runtime.
 
 - **One SoT** for tool versions: mise.toml.
 - **Deterministic.** Identical results at build, on Mac, in CI.
-- **Re-enables `MISE_OFFLINE=1`** at workspace runtime, narrowing
-  the trust surface.
+- **Unblocks `MISE_OFFLINE=1`** evaluation at workspace runtime
+  (still gated on volume-mount model resolution; see Open Q3).
 
 ### Negative
 

--- a/docs/adr/0006-mise-version-pinning.md
+++ b/docs/adr/0006-mise-version-pinning.md
@@ -1,8 +1,8 @@
 # 0006. mise tool version pinning strategy
 
 **Date:** 2026-05-02
-**Status:** Proposed
-**Blocks:** ADR 0005 (install path rationalization)
+**Status:** Accepted (2026-05-02)
+**Blocks:** ADR 0005 (install path rationalization) — accepted in same wave
 
 ## Context
 
@@ -157,21 +157,77 @@ Reproducibility comes from pinning the **image** rather than the
 
 ## Recommendation
 
-**Strategy A** (pin in mise.toml directly). It is the simplest
-change, gives a single SoT, and aligns with the existing pattern
-of explicit version constants elsewhere in this repo
-(`UV_VERSION="0.11.8"` in the local feature, action `@<sha> # vX.Y`
-pins in workflows, hardcoded SHA in sheldon install).
+## Decision (Accepted 2026-05-02)
+
+**Strategy A (modified)**: pin in `mise.toml` directly **AND**
+adopt mise's `system` backend on Linux so the build-time install
+path keeps its existing SHA + attestation verification. Strategy
+A's "single SoT for versions" goal is preserved without naively
+delegating fetches to mise.
+
+### Decision details
+
+1. **`mise.toml` is the SoT for tool versions.** Replace
+   `= "latest"` with concrete pins (e.g. `uv = "0.11.8"`).
+   Versions are **identical across Mac, Linux, and Windows** —
+   the same pin in `mise.toml` drives all three.
+
+2. **Mac host**: `mise install` runs against the pinned
+   `mise.toml`. Mise's normal backend (aqua / GitHub) is used.
+   The operator trusts mise + aqua's verification; no extra
+   SHA layer.
+
+3. **Linux build-time (dev container feature)**: the existing
+   verified-fetch path stays in
+   `.devcontainer/features/dotfiles-tools/install.sh` (uv via
+   `sha256sum -c` + `gh attestation verify`; just via
+   `SHA256SUMS`; sheldon via hardcoded SHA). `mise.toml` no
+   longer drives the install — instead, mise is invoked with
+   `mise use --system <tool>@<version>` so it picks up the
+   already-installed binaries on `$PATH`. This is the **system
+   backend** referenced above. Versions in `mise.toml` and the
+   feature-install hardcoded constants must agree; the
+   implementation PR adds a build-time check that fails the
+   image build on mismatch.
+
+4. **mise data-dir relocation to `/opt/mise`**. The current
+   workspace uses `--volume /home/<user>:/root` to persist
+   operator state, which masks the build-time-baked
+   `~/.local/share/mise/installs/`. Relocate the cache:
+   `MISE_DATA_DIR=/opt/mise` set in the dev container image
+   (via `/etc/profile.d/dotfiles-mise.sh` and `ENV` in the
+   Dockerfile). `/opt/mise` is outside the volume-mount so the
+   cache survives. FHS-wise `/opt` is the right home for
+   add-on package trees.
+
+5. **`MISE_OFFLINE=1` re-enabled at workspace runtime** once
+   the relocation is in place. The cache is no longer masked,
+   so mise can resolve pinned versions without network access.
+   This narrows the runtime trust surface (no per-workspace
+   call to api.github.com / aqua registries).
+
+### What stays in Strategy A
+
+- One pin file. No mise.lock.
+- Manual upgrade cadence (`mise upgrade` then commit the diff).
+- Strategy B (commit mise.lock) is rejected because of lock-
+  format churn and gitignore-policy overhead.
+
+## Recommendation (historical, retained for context)
+
+**Strategy A** (pin in mise.toml directly) was the original
+recommendation. The accepted decision (above) refines it with
+the system-backend approach to preserve verification.
 
 If the operator strongly prefers `latest` semantics on the Mac
-host, Strategy B is a viable alternative — but it introduces
-mise.lock as a new file in the repo and needs a one-time
-discussion about the gitignore policy.
+host, Strategy B was offered as a viable alternative — but it
+introduces mise.lock as a new file in the repo and needs a one-
+time discussion about the gitignore policy. Not chosen.
 
 After this ADR is accepted, ADR 0005 can pick Strategy γ + run
 `mise install` at build time with deterministic versions.
-Re-enabling `MISE_OFFLINE=1` at workspace runtime is gated on the
-volume-mount model resolution (see Open Question 3).
+Re-enabling `MISE_OFFLINE=1` at workspace runtime is unblocked
+by the cache relocation in Decision detail 4.
 
 **Build-time verification preservation (codex review 2026-05-02).**
 Strategy A's "drop the hardcoded `UV_VERSION` / `JUST_VERSION` /

--- a/docs/adr/0007-coder-server-install-hardening.md
+++ b/docs/adr/0007-coder-server-install-hardening.md
@@ -1,0 +1,155 @@
+# 0007. Coder server install hardening on the control-plane VM
+
+**Date:** 2026-05-02
+**Status:** Accepted (2026-05-02)
+
+## Context
+
+The exe.hironow.dev control-plane VM (`tofu/exe/coder.tf`) installs
+the Coder server binary via:
+
+```sh
+# coder.tf:285-291 (current state, summarised)
+export HOME=/root
+curl -fsSL https://coder.com/install.sh | sh || true
+
+if [[ ! -x /usr/local/bin/coder && ! -x /usr/bin/coder ]]; then
+  coder_tag="$(curl -fsSL https://api.github.com/repos/coder/coder/releases/latest \
+    | jq -r .tag_name)"
+  curl -fsSL -o /tmp/coder.tar.gz \
+    "https://github.com/coder/coder/releases/download/${coder_tag}/coder_${coder_tag#v}_linux_amd64.tar.gz"
+  tar -xz -C /usr/local/bin -f /tmp/coder.tar.gz coder
+  chmod 0755 /usr/local/bin/coder
+fi
+```
+
+Three issues, in increasing order of severity:
+
+1. **`curl | sh` of `coder.com/install.sh`** — TOFU on the HTTPS
+   endpoint. A CDN compromise becomes immediate root RCE on the
+   control-plane VM at first boot.
+2. **`|| true` swallows the exit code**, and success is then
+   probed only by checking whether `/usr/local/bin/coder` is an
+   executable. A malicious script that exits 0 after writing
+   anything to that path silently bypasses the fallback.
+3. **The fallback resolves `latest` at boot** via
+   `api.github.com/.../releases/latest`. There is no SHA / SLSA
+   verification of the resulting tarball; whatever the API says
+   is "latest" is what gets executed.
+
+The control-plane VM issues workspace agent tokens. A compromise
+here propagates to every workspace it later spawns; the blast
+radius covers the operator's dev tooling on every workspace,
+service tokens stored on those workspaces, and the tailnet
+identity that the workspace VMs assume.
+
+This was raised as a critical finding in the 2026-05-02 codex
+review of ADR 0005 (audit table scope gap) and the post-amend
+fact-check (the `|| true` masking nuance). The hardening is
+out-of-scope for ADRs 0005 and 0006 because both of those scope
+to *workspace*-side install paths and *cross-platform tool
+management*, not the control-plane VM bootstrap. This ADR
+captures the control-plane decision separately so that 0005/0006
+can be implemented without blocking on it, and vice versa.
+
+## Decision (Accepted 2026-05-02)
+
+Replace the `curl | sh` + `|| true` + GitHub-API-`latest`-fallback
+pattern with a **single tag-pinned tarball install path with
+sha256 verification, optional SLSA attestation verification, and
+fail-closed semantics**.
+
+### Decision details
+
+1. **Coder version is pinned in OpenTofu** as a variable
+   (`var.coder_version`), defaulting to a specific release tag
+   (e.g. `v2.18.0`). Operator bumps the tag explicitly via
+   variable change + `tofu apply`.
+
+2. **`coder.com/install.sh` is removed** from the bootstrap.
+   No more curl-piped shell.
+
+3. **Tarball download is direct from GitHub releases** at the
+   pinned tag:
+
+   ```sh
+   curl -fsSL --proto '=https' --tlsv1.2 \
+     -o /tmp/coder.tar.gz \
+     "https://github.com/coder/coder/releases/download/${CODER_VERSION}/coder_${CODER_VERSION#v}_linux_amd64.tar.gz"
+   ```
+
+4. **SHA-256 verification** against a value that is **also pinned
+   in OpenTofu** (`var.coder_sha256`). The operator looks up the
+   sha256 from GitHub release assets at the time they bump the
+   version, in the same change. The bootstrap aborts on mismatch:
+
+   ```sh
+   echo "${CODER_SHA256}  /tmp/coder.tar.gz" | sha256sum -c -
+   ```
+
+5. **Optional `gh attestation verify`** if Coder ships SLSA
+   provenance for the release tarball. Verification is
+   best-effort (skipped silently if `gh` is not authenticated
+   on the VM, mirroring the pattern in
+   `.devcontainer/features/dotfiles-tools/install.sh`). The
+   sha256 pin in step 4 remains the primary integrity check;
+   attestation is defence in depth.
+
+6. **Fail-closed semantics**. The bootstrap exits non-zero on
+   any failure in steps 3-5; no `|| true`. Terraform's startup-
+   script execution then fails the VM provisioning, which is
+   the desired behaviour (a control-plane VM that cannot install
+   a verified Coder binary should not come up).
+
+### Operator workflow when bumping Coder
+
+```sh
+# 1. Pick new tag from https://github.com/coder/coder/releases
+# 2. Note its sha256 (release assets page or `gh release view`)
+# 3. Update tofu/exe/coder.tf variables:
+#    var.coder_version = "v2.19.0"
+#    var.coder_sha256  = "abc123..."
+# 4. just exe-apply
+# 5. just exe-smoke
+```
+
+## Out of scope
+
+- **The two `curl` apt-key fetches earlier in `coder.tf`**
+  (Tailscale, Google Cloud) are still TOFU. Tracked in ADR 0005
+  Open Q2 audit table; same hardening pattern applies but is
+  separate work.
+- **Workspace VM `coder agent` binary download** is over the
+  tailnet (`exe-coder:7080`) per ADR 0004; it inherits the
+  control-plane VM's binary, so this ADR's pin transitively
+  covers it.
+
+## Consequences
+
+### Positive
+
+- **Removes the largest single supply-chain attack surface** in
+  the stack. Control-plane compromise no longer hinges on a
+  CDN reading `coder.com/install.sh`.
+- **Reproducible builds.** `tofu apply` with the same
+  `coder_version` + `coder_sha256` produces the same binary
+  every time.
+- **Clear operator workflow** for version bumps.
+
+### Negative
+
+- **Manual upgrade cadence.** Operator must look up sha256 +
+  update tofu variables, then `tofu apply`. No automated
+  Dependabot-equivalent for tofu variables today.
+- **Loss of "auto-pull-latest" semantics.** Stale-version drift
+  is now possible. Mitigated by setting up a periodic reminder
+  (e.g., a scheduled task to compare `var.coder_version` with
+  the latest release tag).
+
+### Neutral
+
+- **Coder upstream's `install.sh`** is presumably reasonable
+  software, but the supply-chain posture of this stack is
+  "trust nothing on first download." This is consistent with
+  how dev container features and PR #57 docker apt repo treat
+  upstream installers.

--- a/tests/exe/test_startup_script.py
+++ b/tests/exe/test_startup_script.py
@@ -59,6 +59,11 @@ HCL_SUBSTITUTIONS: dict[str, str] = {
     r"\$\{local\.sandbox_host\}": "*.sandbox.hironow.dev",
     r"\$\{local\.tag_exe_coder\}": "tag:exe-coder",
     r"\$\{var\.gcp_project_id\}": "gen-ai-hironow",
+    # Coder server install pin (ADR 0007). The dummy values must be
+    # syntactically valid since the bash extracted from the heredoc
+    # is later passed through bash -n / shellcheck.
+    r"\$\{var\.coder_version\}": "v2.31.11",
+    r"\$\{var\.coder_sha256\}": "32cf14eeecc96190dbc66b6965a3bdd563eaecc0d811a690e1e0b65828484979",
     r"\$\{google_secret_manager_secret\.exe_coder_authkey\.secret_id\}": (
         "exe-tailscale-coder-authkey"
     ),
@@ -720,4 +725,90 @@ def test_systemd_units_validate(
         f"systemd unit verification failed.\n"
         f"--- stdout (last 4KB) ---\n{r.stdout[-4096:]}\n"
         f"--- stderr (last 4KB) ---\n{r.stderr[-4096:]}"
+    )
+
+
+# ---------- ADR 0007: Coder server install hardening ---------------
+
+
+@pytest.mark.exe
+def test_coder_install_does_not_pipe_remote_script(startup_script: str) -> None:
+    """ADR 0007: the bootstrap MUST NOT install Coder via
+    `curl https://coder.com/install.sh | sh` or any other remote-
+    script-piped-into-shell pattern. Replacement is a tag-pinned
+    tarball with sha256 verify."""
+    forbidden = [
+        r"coder\.com/install\.sh",
+        r"curl[^\n]*\|\s*sh\b",
+        r"curl[^\n]*\|\s*bash\b",
+        r"\|\| true",  # the masking exit-code pattern flagged by codex
+        r"releases/latest",  # the latest-resolution fallback
+    ]
+    for pattern in forbidden:
+        assert not re.search(pattern, startup_script), (
+            f"Coder install path still contains forbidden pattern "
+            f"{pattern!r}; ADR 0007 prohibits it. Use the pinned-tag "
+            f"+ sha256-verified path instead."
+        )
+
+
+@pytest.mark.exe
+def test_coder_install_uses_pinned_tag_and_sha256(startup_script: str) -> None:
+    """The bootstrap downloads Coder from a tag-pinned GitHub
+    release URL and verifies the resulting tarball against a
+    pinned sha256. Values flow through bash variables (coder_tag,
+    coder_sha256) populated from tofu vars at template-render
+    time; the dummy substitution fills them with ADR 0007 defaults."""
+    assert re.search(
+        r"coder_tag\s*=\s*['\"]v\d+\.\d+\.\d+['\"]",
+        startup_script,
+    ), "Coder install must assign coder_tag to a SemVer-v string."
+    assert re.search(
+        r"coder_sha256\s*=\s*['\"][0-9a-f]{64}['\"]",
+        startup_script,
+    ), "Coder install must assign coder_sha256 to a 64-hex digest."
+    assert "github.com/coder/coder/releases/download" in startup_script, (
+        "Coder install URL must point at the official GitHub releases path."
+    )
+    assert "sha256sum -c" in startup_script, (
+        "Coder install must call sha256sum -c against the pinned digest."
+    )
+
+
+@pytest.mark.exe
+def test_coder_variables_have_validation() -> None:
+    """The tofu variables that drive the Coder install MUST have
+    validation blocks so a mis-typed version or non-hex sha256 is
+    caught at `tofu plan` time, not at VM bootstrap time."""
+    variables_tf = (ROOT / "tofu" / "exe" / "variables.tf").read_text()
+    # coder_version: SemVer with leading 'v'
+    assert re.search(
+        r'variable\s+"coder_version"\s*\{[^}]*?validation\s*\{[^}]*?'
+        r"regex\([^)]*?v\[0-9\]\+\\\.\[0-9\]\+\\\.\[0-9\]\+",
+        variables_tf,
+        re.DOTALL,
+    ), "var.coder_version must validate against a SemVer-with-v regex."
+    # coder_sha256: 64 lowercase hex chars
+    assert re.search(
+        r'variable\s+"coder_sha256"\s*\{[^}]*?validation\s*\{[^}]*?'
+        r"regex\([^)]*?\[0-9a-f\]\{64\}",
+        variables_tf,
+        re.DOTALL,
+    ), "var.coder_sha256 must validate against a 64-hex-char regex."
+
+
+@pytest.mark.exe
+def test_coder_install_attestation_verify_is_best_effort(startup_script: str) -> None:
+    """`gh attestation verify` MUST run only if gh is installed AND
+    authenticated, mirroring the dev container feature install.sh
+    pattern. The sha256 pin is the primary integrity check; missing
+    gh or unauthenticated gh must not block the install."""
+    # Look for the conditional block that gates gh attestation verify.
+    has_conditional_attestation = re.search(
+        r"command -v gh[\s\S]*?gh attestation verify",
+        startup_script,
+    )
+    assert has_conditional_attestation is not None, (
+        "Bootstrap should attempt gh attestation verify only when gh "
+        "is installed and authenticated."
     )

--- a/tofu/exe/coder.tf
+++ b/tofu/exe/coder.tf
@@ -280,28 +280,41 @@ locals {
       useradd --system --home-dir /var/lib/coder --shell /usr/sbin/nologin coder
     fi
     install -m 0755 -o coder -g coder -d /var/lib/coder /var/lib/coder/cache
-    if [[ ! -x /usr/local/bin/coder && ! -x /usr/bin/coder ]]; then
-      # Coder's install.sh references $HOME. The root startup-script
-      # process inherits no HOME, so dash exits with
-      # 'HOME: parameter not set' — pin one before piping. Run without
-      # extra flags ('--terraform-no-pin' is unknown to install.sh and
-      # makes it exit 1).
-      export HOME=/root
-      curl -fsSL https://coder.com/install.sh | sh || true
+    if [[ ! -x /usr/local/bin/coder ]]; then
+      # Per ADR 0007 (Coder server install hardening): pinned-tag
+      # tarball install with sha256 verification. The previous
+      # piped-shell convenience installer and the GitHub-API
+      # latest-resolution fallback have both been removed; any
+      # failure in the steps below aborts the startup-script and
+      # the VM provisioning fails fast — preferable to coming up
+      # with an unverified or absent Coder binary.
+      coder_tag='${var.coder_version}'
+      coder_ver="$${coder_tag#v}"
+      coder_sha256='${var.coder_sha256}'
+      coder_tarball="coder_$${coder_ver}_linux_amd64.tar.gz"
+      coder_url="https://github.com/coder/coder/releases/download/$${coder_tag}/$${coder_tarball}"
 
-      # Fallback: pull the official tar.gz release. The asset filename
-      # embeds the version, so resolve it via the GitHub API. Either
-      # /usr/local/bin/coder or /usr/bin/coder ends up populated.
-      if [[ ! -x /usr/local/bin/coder && ! -x /usr/bin/coder ]]; then
-        coder_tag="$(curl -fsSL https://api.github.com/repos/coder/coder/releases/latest \
-          | jq -r .tag_name)"
-        coder_ver="$${coder_tag#v}"
-        curl -fsSL -o /tmp/coder.tar.gz \
-          "https://github.com/coder/coder/releases/download/$${coder_tag}/coder_$${coder_ver}_linux_amd64.tar.gz"
-        tar -xz -C /usr/local/bin -f /tmp/coder.tar.gz coder
-        chmod 0755 /usr/local/bin/coder
-        rm -f /tmp/coder.tar.gz
+      curl -fsSL --proto '=https' --tlsv1.2 \
+        -o /tmp/$${coder_tarball} "$${coder_url}"
+      echo "$${coder_sha256}  /tmp/$${coder_tarball}" \
+        | sha256sum -c -
+
+      # Defense in depth: if gh is installed and authenticated on
+      # the VM, verify the SLSA provenance attestation BEFORE the
+      # tarball is consumed. Best-effort — the sha256 pin above is
+      # the primary integrity check. Mirrors the pattern used in
+      # .devcontainer/features/dotfiles-tools/install.sh for uv.
+      if command -v gh >/dev/null 2>&1 && \
+         { [ -n "$${GH_TOKEN:-}" ] || [ -n "$${GITHUB_TOKEN:-}" ] || \
+           gh auth status >/dev/null 2>&1; }; then
+        gh attestation verify "/tmp/$${coder_tarball}" \
+          --repo coder/coder >/dev/null 2>&1 || \
+          echo "[coder-bootstrap] gh attestation verify failed (sha256 still in force)" >&2
       fi
+
+      tar -xz -C /usr/local/bin -f /tmp/$${coder_tarball} coder
+      chmod 0755 /usr/local/bin/coder
+      rm -f /tmp/$${coder_tarball}
     fi
 
     # Initial admin password — generated on first boot, persisted on the

--- a/tofu/exe/variables.tf
+++ b/tofu/exe/variables.tf
@@ -93,3 +93,28 @@ variable "boot_disk_size_gb" {
     error_message = "Disk must be between 20 and 200 GiB."
   }
 }
+
+# Coder server install — pinned per ADR 0007 (control-plane VM
+# supply-chain hardening). Operator bumps the tag and the matching
+# linux_amd64.tar.gz sha256 in lock-step. Sha256 is taken from the
+# release's checksums.txt asset:
+#   curl -fsSL https://github.com/coder/coder/releases/download/${ver}/coder_${ver#v}_checksums.txt
+variable "coder_version" {
+  description = "Coder server release tag (e.g. v2.31.11). Bump alongside coder_sha256."
+  type        = string
+  default     = "v2.31.11"
+  validation {
+    condition     = can(regex("^v[0-9]+\\.[0-9]+\\.[0-9]+$", var.coder_version))
+    error_message = "coder_version must be a SemVer tag with leading 'v', e.g. v2.31.11."
+  }
+}
+
+variable "coder_sha256" {
+  description = "Sha256 of coder_<version>_linux_amd64.tar.gz; from the release's checksums.txt."
+  type        = string
+  default     = "32cf14eeecc96190dbc66b6965a3bdd563eaecc0d811a690e1e0b65828484979"
+  validation {
+    condition     = can(regex("^[0-9a-f]{64}$", var.coder_sha256))
+    error_message = "coder_sha256 must be a lowercase 64-character hex sha256 digest."
+  }
+}


### PR DESCRIPTION
## Summary

Multi-step landing combining ADR refinement, decision acceptance,
new ADR creation, and the implementation of the highest-severity
finding from the 2026-05-02 codex review.

## Commits (in order)

1. **\`a74fb63\`** \`docs(adr): amend 0005 + 0006 per codex review 2026-05-02\`
   - 4 codex findings reflected in the ADR text (control-plane scope gap, docker-pin update post-#57, just-add-all premise correction, MISE_OFFLINE volume-mask gating)
   - Build-time-verification preservation note added to ADR 0006

2. **\`3d373b0\`** \`docs(adr): amend 0005 Open Q2 — coder.tf install \\|\\| true masking\`
   - Surfaced from the post-amend factcheck: \`|| true\` swallows curl|sh exit codes; success-probed only by file-exists check, so a malicious script exiting 0 silently bypasses the fallback

3. **\`d5419ab\`** \`docs(adr): accept 0005 + 0006, add 0007 (coder.tf hardening)\`
   - ADR 0005 status: Proposed → Accepted. Decision: refined Strategy γ (single install.sh with OS dispatch + step_* helper functions, no plugin-dir tree). Linuxbrew not adopted; Windows scoop-only.
   - ADR 0006 status: Proposed → Accepted. Decision: Strategy A modified (mise.toml SoT pin + mise system backend on Linux to preserve build-time SHA/SLSA verify). MISE_DATA_DIR=/opt/mise relocation to escape volume mask, unblocking MISE_OFFLINE=1.
   - ADR 0007 NEW Accepted. Coder server install hardening on the control-plane VM.

4. **\`8ea3605\`** \`fix(exe-coder): pin Coder server install per ADR 0007\` ⭐ implementation
   - Replaces \`curl https://coder.com/install.sh | sh || true\` + \`api.github.com/.../latest\` fallback with tag-pinned tarball + sha256 verify + best-effort \`gh attestation verify\`
   - New tofu variables \`coder_version\` (default \`v2.31.11\`) and \`coder_sha256\` (default \`32cf14...8430\`) with regex validation
   - 4 regression tests in \`tests/exe/test_startup_script.py\`
   - Fail-closed semantics: any failure aborts startup-script and VM provisioning fails fast

## Verification

- \`tofu fmt -check\` + \`tofu validate\`: ✅
- Inline regex predicates against extracted heredoc: 10/10 ✅
- Operator-verified Coder v2.31.11 sha256 from \`coder_2.31.11_checksums.txt\`:
  \`32cf14eeecc96190dbc66b6965a3bdd563eaecc0d811a690e1e0b65828484979\`

## Apply procedure (post-merge)

\`\`\`sh
# 1. Sanity check the change before touching the live VM
just exe-validate

# 2. Apply — this triggers VM replacement (startup-script changed)
just exe-apply

# 3. Smoke
just exe-smoke
\`\`\`

The change is safe to apply: VM replacement creates a new instance
that downloads + verifies + installs Coder before the systemd unit
starts. If verification fails, the startup-script aborts and the
new VM never enters service; the old VM is replaced via Terraform's
create_before_destroy semantics so the rollback path is clean.

## Out of scope (separate PRs to follow)

- ADR 0005 implementation (install.sh OS dispatch + step_*) — \`feat/install-os-plugin-layout\` next
- ADR 0006 implementation (mise.toml pin + /opt/mise relocation + system backend) — bundled with ADR 0005 implementation
- Tailscale + Google Cloud apt key fingerprint pinning at \`coder.tf\` — same pattern as PR #57, ADR 0005 Open Q2 follow-up
- AR vulnerability scanning enable — operator decision deferred