### PR TITLE
feat: ADR 0005 + 0006 implementation — install.sh OS dispatch + mise pin + /opt/mise relocation

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -59,7 +59,11 @@
 
   "containerEnv": {
     "MISE_OFFLINE": "1",
-    "PATH": "/root/.local/bin:/root/.local/share/mise/shims:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin",
+    // mise data dir is relocated to /opt/mise per ADR 0006 so the
+    // Coder workspace `/home/<user>:/root` volume mount cannot mask
+    // the build-time-baked installs. Shims live alongside.
+    "MISE_DATA_DIR": "/opt/mise",
+    "PATH": "/root/.local/bin:/opt/mise/shims:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin",
     // Surfaces the HOST workspace path to processes inside the
     // container. The pytest fixture reads this to bind-mount the
     // workspace into one-shot sub-containers it spins up via

--- a/.devcontainer/features/dotfiles-tools/install.sh
+++ b/.devcontainer/features/dotfiles-tools/install.sh
@@ -185,14 +185,22 @@ cat > /etc/profile.d/dotfiles-mise.sh <<'PROFILE'
 # mise should be scoped tightly.
 export MISE_TRUSTED_CONFIG_PATHS=/root/dotfiles:/root/sandbox/dotfiles-fresh
 
+# Relocate mise's data directory (installs + shims + cache) outside
+# of $HOME per ADR 0006. The Coder workspace template binds
+# `/home/<user>:/root` for operator-state persistence, which masks
+# the build-time-baked $HOME/.local/share/mise. Putting the data
+# dir at /opt/mise keeps the cache out of the bind-mount path so
+# pinned versions are reachable at runtime without re-fetch.
+export MISE_DATA_DIR=/opt/mise
+
 # Add mise's shim directory to PATH so tools managed by mise.toml
 # (prek, markdownlint-cli2, vp, ...) are reachable without a `mise
 # exec` wrapper. Critical for git hooks installed by `prek install`
 # — the pre-commit hook execs `prek` directly and sh -c hooks do
 # not source profile.d again, so PATH must already carry the shim.
 case ":$PATH:" in
-  *":/root/.local/share/mise/shims:"*) ;;
-  *) export PATH="/root/.local/share/mise/shims:$PATH" ;;
+  *":/opt/mise/shims:"*) ;;
+  *) export PATH="/opt/mise/shims:$PATH" ;;
 esac
 PROFILE
 chmod 0644 /etc/profile.d/dotfiles-mise.sh
@@ -211,14 +219,21 @@ git config --system --add safe.directory /root/sandbox/dotfiles-fresh
 
 # ---- pre-install mise.toml tools ------------------------------------
 # Bake mise.toml's tool versions into the saved image so test
-# containers don't re-download every run. Versions pinned to what
-# mise resolves "latest" to today; mise install at runtime can
-# fetch newer versions if mise.toml advances.
-echo "[dotfiles-tools] pre-installing mise.toml tools at build time"
+# containers don't re-download every run. Versions in this prebuild
+# block MUST match the workspace mise.toml; the
+# tests/test_mise_pin_consistency.py check fails the build on
+# drift. Bump these together with mise.toml in dedicated PRs.
+#
+# Per ADR 0006 the data dir is /opt/mise, NOT $HOME/.local/share/mise.
+# The /home/<user>:/root volume mount on Coder workspaces would
+# otherwise mask everything we install here.
+install -d -m 0755 /opt/mise
+export MISE_DATA_DIR=/opt/mise
+echo "[dotfiles-tools] pre-installing mise.toml tools at build time (MISE_DATA_DIR=/opt/mise)"
 mkdir -p /tmp/mise-prebuild
 cat > /tmp/mise-prebuild/mise.toml <<'EOF'
 [tools]
-just = "1.50.0"
+just = "1.40.0"
 markdownlint-cli2 = "0.22.1"
 prek = "0.3.11"
 uv = "0.11.8"

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -10,15 +10,15 @@
 set -euo pipefail
 
 # MISE_OFFLINE=1 is set in containerEnv to keep `just test` runs
-# hermetic. The first `mise install` needs network to resolve
-# `latest` against the GitHub API and download tool binaries — so we
-# explicitly clear the flag for this single invocation. After this
-# script exits, the containerEnv setting carries over to every
-# subsequent process.
-echo "[post-create] mise install (mise.toml tools)"
+# hermetic. Per ADR 0006 the workspace mise.toml is fully pinned
+# and the data dir lives at /opt/mise (outside any bind-mounted
+# overlay), so `mise install` here only needs to verify the
+# already-installed cache matches the pinned versions — no
+# network required.
+echo "[post-create] mise install (mise.toml tools, MISE_OFFLINE=1)"
 cd /root/dotfiles
 mise trust mise.toml >/dev/null 2>&1 || true
 touch mise.lock
-MISE_OFFLINE=0 mise install
+MISE_DATA_DIR=/opt/mise mise install
 
 echo "[post-create] done"

--- a/exe/coder/templates/dotfiles-devcontainer/main.tf
+++ b/exe/coder/templates/dotfiles-devcontainer/main.tf
@@ -358,27 +358,24 @@ resource "coder_agent" "dev" {
   # Personalisation + workspace-side mise sync.
   #
   # `coder dotfiles` clones the operator's dotfiles repo into
-  # /root/dotfiles and runs install.sh. install.sh honours skip env
-  # vars to bypass Homebrew + brew/gcloud bundle replays — neither
-  # is wanted on a CI-style workspace. With both set, install.sh
-  # still runs `just clean` + `just deploy` (symlink ~/.zshrc,
-  # sheldon lock, starship config, fzf-tab clone, ...).
+  # /root/dotfiles and runs install.sh. install.sh's OS dispatch
+  # (per ADR 0005) auto-skips the Mac-only steps on Linux; the
+  # legacy INSTALL_SKIP_* env vars are kept here as belt-and-
+  # suspenders for older images that pre-date the OS dispatch.
   #
   # Then `mise install` runs against the workspace mise.toml so
-  # mise's install state (`~/.local/share/mise/installs/`) tracks
-  # what mise.toml asks for. The prebuilt image already has the
-  # tools at the same versions (the local devcontainer feature
-  # primes them at build time), but mise tracks installs by config
-  # path, so `mise current` would otherwise warn:
-  #   `mise WARN  just@1.50.0 is specified in ~/dotfiles/mise.toml,
-  #    but not installed`
-  # MISE_OFFLINE=0 is forced because the inherited containerEnv has
-  # MISE_OFFLINE=1 baked in — mise needs the registry to resolve
-  # `latest` before it can match against the cache.
+  # mise's install state tracks what mise.toml asks for. Per ADR
+  # 0006 the data dir is /opt/mise (set in the image's profile.d),
+  # which sits OUTSIDE the /home/<user>:/root volume mount, so the
+  # build-time-baked cache survives. With pinned versions in
+  # mise.toml + the cache reachable, MISE_OFFLINE=1 is honoured at
+  # workspace runtime — narrowing the trust surface (no per-
+  # workspace api.github.com / aqua-registry calls).
   startup_script = data.coder_parameter.dotfiles_uri.value == "" ? "" : <<-EOT
     set -eu
     export INSTALL_SKIP_HOMEBREW=1
     export INSTALL_SKIP_ADD_UPDATE=1
+    export MISE_DATA_DIR=/opt/mise
     if command -v coder >/dev/null 2>&1; then
       coder dotfiles -y "${data.coder_parameter.dotfiles_uri.value}" || \
         echo "[exe] dotfiles install failed; continuing"
@@ -387,7 +384,7 @@ resource "coder_agent" "dev" {
       (
         cd /root/dotfiles
         mise trust mise.toml >/dev/null 2>&1 || true
-        MISE_OFFLINE=0 mise install
+        MISE_OFFLINE=1 mise install
       ) || echo "[exe] mise install failed; tools fall back to baked-in image versions"
     fi
   EOT

--- a/install.sh
+++ b/install.sh
@@ -1,5 +1,36 @@
 #!/usr/bin/env bash
+# Entry point for `curl ... install.sh | bash` style bootstraps and
+# `coder dotfiles -y`. Routes each install step through a per-OS
+# dispatch (DOTFILES_OS) so the same script handles macOS hosts,
+# Linux Coder workspaces, and (future) Windows scoop hosts.
+#
+# Per ADR 0005 (Accepted 2026-05-02): a single entry point with
+# `step_*` helper functions that branch on DOTFILES_OS. Existing
+# `INSTALL_SKIP_*` env vars are preserved as operator overrides
+# (OR-combined with the OS auto-skip).
 set -eu
+
+# ---- OS identification ---------------------------------------------
+case "$(uname -s)" in
+  Darwin)
+    DOTFILES_OS=mac
+    ;;
+  Linux)
+    DOTFILES_OS=linux
+    ;;
+  MINGW*|MSYS*|CYGWIN*)
+    DOTFILES_OS=windows
+    ;;
+  *)
+    echo "[install] unsupported OS: $(uname -s). Supported: Darwin, Linux, MSYS/MINGW/Cygwin." >&2
+    exit 1
+    ;;
+esac
+export DOTFILES_OS
+
+echo "[install] DOTFILES_OS=${DOTFILES_OS}"
+
+# ---- Helpers --------------------------------------------------------
 
 # shellcheck disable=SC2317
 _eval_brew() {
@@ -22,6 +53,16 @@ _eval_brew() {
   fi
 }
 
+_todo_windows() {
+  # Marker for steps that don't have a Windows implementation yet.
+  # Per ADR 0005 decision the structure is OS-aware now; concrete
+  # Windows logic lands in a future ADR + PR when an actual
+  # Windows host enters the picture.
+  echo "[install] $1: windows TODO (scoop bootstrap to be implemented)"
+}
+
+# ---- Repository bootstrap ------------------------------------------
+
 DOTPATH=${DOTPATH:-$HOME/dotfiles}
 DOTFILES_REPO=${DOTFILES_REPO:-https://github.com/hironow/dotfiles.git}
 
@@ -41,47 +82,207 @@ fi
 
 cd "$DOTPATH"
 
-# install homebrew
-if [ -z "${INSTALL_SKIP_HOMEBREW:-}" ]; then
-  if ! command -v brew >/dev/null 2>&1; then
-    /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-  fi
-  # Ensure brew is initialized even if pre-installed in a non-default path
-  _eval_brew || true
-else
-  echo "[install] Skip Homebrew installation (INSTALL_SKIP_HOMEBREW=1)"
-fi
-# install google cloud sdk
-if [ -z "${INSTALL_SKIP_GCLOUD:-}" ]; then
-  if ! command -v gcloud >/dev/null; then
-    curl https://sdk.cloud.google.com | bash -s -- --disable-prompts --install-dir="$HOME"
-  fi
-else
-  echo "[install] Skip Google Cloud SDK installation (INSTALL_SKIP_GCLOUD=1)"
-fi
+# ---- step_* functions ----------------------------------------------
 
-# ensure just is available
-if ! command -v just >/dev/null 2>&1; then
-  # Try via brew when available
-  if command -v brew >/dev/null 2>&1; then
-    brew list just >/dev/null 2>&1 || brew install just || true
+step_homebrew() {
+  if [ -n "${INSTALL_SKIP_HOMEBREW:-}" ]; then
+    echo "[install] step_homebrew: skip (INSTALL_SKIP_HOMEBREW=1)"
+    return
   fi
+  case "$DOTFILES_OS" in
+    mac)
+      # Homebrew is a prerequisite on Mac, not something install.sh
+      # bootstraps. The canonical Homebrew install path
+      # (curl|bash from raw.githubusercontent.com/Homebrew/install)
+      # is a TOFU pipe-to-shell; we keep it out of this script and
+      # require the operator to install brew once, manually, with
+      # eyes-on, on first machine setup. install.sh thereafter
+      # assumes brew is present and fails fast otherwise.
+      if ! command -v brew >/dev/null 2>&1; then
+        echo "[install] step_homebrew: brew not found on PATH." >&2
+        echo "[install] Install Homebrew manually first: https://brew.sh" >&2
+        echo "[install] Then re-run install.sh." >&2
+        exit 1
+      fi
+      _eval_brew || true
+      ;;
+    linux)
+      echo "[install] step_homebrew: skip (Linux uses apt + dev container feature)"
+      ;;
+    windows)
+      _todo_windows "step_homebrew"
+      ;;
+  esac
+}
 
-  # Fallback: install via official script if still not found
-  if ! command -v just >/dev/null 2>&1; then
-    echo "[install] Installing just via curl..."
-    curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh | bash -s -- --to "$HOME/.local/bin"
-    export PATH="$HOME/.local/bin:$PATH"
+step_gcloud_components() {
+  if [ -n "${INSTALL_SKIP_GCLOUD:-}" ]; then
+    echo "[install] step_gcloud_components: skip (INSTALL_SKIP_GCLOUD=1)"
+    return
   fi
-fi
+  case "$DOTFILES_OS" in
+    mac)
+      # Use the brew cask instead of `curl sdk.cloud.google.com | bash`
+      # (which was a curl-pipe-bash flagged by semgrep). The cask is
+      # signed + the formula is hash-pinned in the Homebrew core
+      # tap; this matches the trust posture of the rest of the
+      # Mac flow.
+      if ! command -v gcloud >/dev/null 2>&1; then
+        if command -v brew >/dev/null 2>&1; then
+          brew install --cask google-cloud-sdk
+        else
+          echo "[install] step_gcloud_components: brew not on PATH; cannot install gcloud safely. Run step_homebrew first or remove INSTALL_SKIP_HOMEBREW." >&2
+          exit 1
+        fi
+      fi
+      ;;
+    linux)
+      echo "[install] step_gcloud_components: skip (gcloud installed at build time via dev container feature)"
+      ;;
+    windows)
+      _todo_windows "step_gcloud_components"
+      ;;
+  esac
+}
 
-# execute commands via just
-if [ -z "${INSTALL_SKIP_ADD_UPDATE:-}" ]; then
-  just add-all
-  just update-all
-else
-  echo "[install] Skip add/update steps (INSTALL_SKIP_ADD_UPDATE=1)"
-fi
+step_just_bootstrap() {
+  # Ensure `just` is on PATH before we hand control over to it.
+  # Linux's dev container feature already installs just at build
+  # time, so this is mostly a Mac path. Mac uses brew exclusively
+  # (no curl-pipe-bash fallback) — if brew failed there's a deeper
+  # problem and we should fail loud instead of papering over it.
+  if command -v just >/dev/null 2>&1; then
+    return
+  fi
+  case "$DOTFILES_OS" in
+    mac)
+      if command -v brew >/dev/null 2>&1; then
+        brew list just >/dev/null 2>&1 || brew install just
+      else
+        echo "[install] step_just_bootstrap: brew not on PATH and just is missing. Run step_homebrew first or install just manually." >&2
+        exit 1
+      fi
+      ;;
+    linux)
+      echo "[install] step_just_bootstrap: just expected to be present from dev container feature; not bootstrapping"
+      ;;
+    windows)
+      _todo_windows "step_just_bootstrap"
+      ;;
+  esac
+}
 
-just clean
-just deploy
+step_brew_bundle() {
+  if [ -n "${INSTALL_SKIP_ADD_UPDATE:-}" ]; then
+    echo "[install] step_brew_bundle: skip (INSTALL_SKIP_ADD_UPDATE=1)"
+    return
+  fi
+  case "$DOTFILES_OS" in
+    mac)
+      just add-brew
+      ;;
+    linux)
+      echo "[install] step_brew_bundle: skip (Linux equivalents covered by apt + dev container feature)"
+      ;;
+    windows)
+      _todo_windows "step_brew_bundle"
+      ;;
+  esac
+}
+
+step_gcloud_bundle() {
+  if [ -n "${INSTALL_SKIP_ADD_UPDATE:-}" ]; then
+    echo "[install] step_gcloud_bundle: skip (INSTALL_SKIP_ADD_UPDATE=1)"
+    return
+  fi
+  case "$DOTFILES_OS" in
+    mac)
+      just add-gcloud
+      ;;
+    linux)
+      echo "[install] step_gcloud_bundle: skip (gcloud components in dev container feature)"
+      ;;
+    windows)
+      _todo_windows "step_gcloud_bundle"
+      ;;
+  esac
+}
+
+step_pnpm_globals() {
+  if [ -n "${INSTALL_SKIP_ADD_UPDATE:-}" ]; then
+    echo "[install] step_pnpm_globals: skip (INSTALL_SKIP_ADD_UPDATE=1)"
+    return
+  fi
+  case "$DOTFILES_OS" in
+    mac|linux)
+      # Linux runs this too: pnpm is provided by the dev container
+      # feature and the operator wants the same npm-globals set
+      # (vp, markdownlint-cli2, etc.) available on workspaces.
+      if command -v pnpm >/dev/null 2>&1; then
+        just add-pnpm-g
+      else
+        echo "[install] step_pnpm_globals: pnpm not on PATH; skipping (dev container feature should install it)"
+      fi
+      ;;
+    windows)
+      _todo_windows "step_pnpm_globals"
+      ;;
+  esac
+}
+
+step_update_all() {
+  if [ -n "${INSTALL_SKIP_ADD_UPDATE:-}" ]; then
+    echo "[install] step_update_all: skip (INSTALL_SKIP_ADD_UPDATE=1)"
+    return
+  fi
+  case "$DOTFILES_OS" in
+    mac)
+      just update-all
+      ;;
+    linux)
+      echo "[install] step_update_all: skip (apt + mise manage updates)"
+      ;;
+    windows)
+      _todo_windows "step_update_all"
+      ;;
+  esac
+}
+
+step_symlink_dotfiles() {
+  # Cross-platform: symlinks the operator's ~/.zshrc etc. to the
+  # tracked dotfiles. Required on every OS.
+  just clean
+  just deploy
+}
+
+step_sheldon() {
+  # Cross-platform: zsh plugin lock. Sheldon is provided by brew on
+  # Mac and by the dev container feature on Linux. Windows path is
+  # TODO until a Windows host actually exists.
+  case "$DOTFILES_OS" in
+    mac|linux)
+      if command -v sheldon >/dev/null 2>&1; then
+        sheldon lock --update >/dev/null || true
+      else
+        echo "[install] step_sheldon: sheldon not on PATH; skipping"
+      fi
+      ;;
+    windows)
+      _todo_windows "step_sheldon"
+      ;;
+  esac
+}
+
+# ---- Drive ----------------------------------------------------------
+
+step_homebrew
+step_gcloud_components
+step_just_bootstrap
+step_brew_bundle
+step_gcloud_bundle
+step_pnpm_globals
+step_update_all
+step_symlink_dotfiles
+step_sheldon
+
+echo "[install] done (DOTFILES_OS=${DOTFILES_OS})"

--- a/mise.toml
+++ b/mise.toml
@@ -1,9 +1,17 @@
 [tools]
-just = "latest"
-markdownlint-cli2 = "latest"
-prek = "latest"
-uv = "latest"
-vp = "latest"
+# Pinned versions per ADR 0006 (Accepted 2026-05-02). One pin
+# applies to Mac, Linux (dev container workspace), and Windows
+# (future scoop host). Bump these by hand in a dedicated PR; the
+# build-time consistency check in tests/test_mise_pin_consistency.py
+# fails the image build if these drift from the SHA-verified
+# constants in .devcontainer/features/dotfiles-tools/install.sh.
+just = "1.40.0"
+markdownlint-cli2 = "0.22.1"
+prek = "0.3.11"
+uv = "0.11.8"
+# `vp` is the mise registry alias for npm:vite-plus (NOT the
+# unrelated `vp` npm package). Pin to vite-plus's actual version.
+vp = "0.1.20"
 
 # `~/.npmrc` may set `min-release-age=7` (7-day quarantine, mirrors
 # uv's `exclude-newer = "7 days"`). That blocks `mise install` of

--- a/tests/test_devcontainer.py
+++ b/tests/test_devcontainer.py
@@ -450,26 +450,38 @@ def test_image_mise_data_dir_is_opt_mise(saved_image: str) -> None:
 
 
 def test_image_mise_offline_install_works(saved_image: str) -> None:
-    """`MISE_OFFLINE=1 mise install` against a copy of the workspace
-    mise.toml must succeed inside the saved image. This proves that
-    the build-time-baked /opt/mise cache covers every pinned tool —
-    the prerequisite for ADR 0006 decision detail 5 (workspace
-    runtime MISE_OFFLINE=1 re-enable).
+    """`MISE_OFFLINE=1 mise install` against the workspace mise.toml
+    must succeed inside the saved image. This proves that the build-
+    time-baked /opt/mise cache covers every pinned tool — the
+    prerequisite for ADR 0006 decision detail 5 (workspace runtime
+    MISE_OFFLINE=1 re-enable).
 
-    We bind in the workspace mise.toml at runtime instead of using
-    the one already at /root/dotfiles, because that path is used by
-    other tests that may run in parallel and we don't want to
-    interfere with their `mise trust` state."""
-    # The image's MISE_TRUSTED_CONFIG_PATHS already trusts
-    # /root/dotfiles, so place our throwaway mise.toml there.
-    result = _run_in_image(
-        ". /etc/profile.d/dotfiles-mise.sh && "
-        "tmpd=$(mktemp -d /root/dotfiles/mise-offline-test.XXXXXX) && "
-        'cp /root/dotfiles/mise.toml "$tmpd/mise.toml" && '
-        'cd "$tmpd" && '
-        "MISE_OFFLINE=1 mise install 2>&1 && "
-        'rm -rf "$tmpd"'
+    The saved image does NOT contain /root/dotfiles (that's a
+    runtime bind-mount when the dev container is up). We synthesise
+    a minimal mise.toml inside /tmp/mise-runtime-check, override
+    MISE_TRUSTED_CONFIG_PATHS to include that path, and run `mise
+    install` against it offline."""
+    # Read the canonical mise.toml from the working tree and embed
+    # it via heredoc so the test stays SoT-aware: any pin change in
+    # the workspace mise.toml is reflected automatically.
+    mise_toml = (Path(__file__).resolve().parents[1] / "mise.toml").read_text(
+        encoding="utf-8"
     )
+    script = (
+        ". /etc/profile.d/dotfiles-mise.sh && "
+        "rm -rf /tmp/mise-runtime-check && "
+        "mkdir -p /tmp/mise-runtime-check && "
+        "cat > /tmp/mise-runtime-check/mise.toml <<'MISE_TOML_EOF'\n"
+        f"{mise_toml}\n"
+        "MISE_TOML_EOF\n"
+        "cd /tmp/mise-runtime-check && "
+        # Override the trusted-paths scope just for this invocation
+        # so mise reads the synthetic mise.toml. The image's default
+        # scope (/root/dotfiles + /root/sandbox/...) is untouched.
+        'MISE_TRUSTED_CONFIG_PATHS="/tmp/mise-runtime-check" '
+        "MISE_OFFLINE=1 mise install 2>&1"
+    )
+    result = _run_in_image(script)
     assert result.returncode == 0, (
         f"`MISE_OFFLINE=1 mise install` failed inside the saved image. "
         f"This means at least one pinned tool is missing from "

--- a/tests/test_devcontainer.py
+++ b/tests/test_devcontainer.py
@@ -413,3 +413,73 @@ def test_image_devcontainer_metadata_smoke(saved_image: str) -> None:
         "pipeline.\n"
         f"labels: {labels_json}"
     )
+
+
+# ---------- ADR 0006 runtime: /opt/mise relocation ----------------
+
+
+def test_image_mise_data_dir_is_opt_mise(saved_image: str) -> None:
+    """A login shell must resolve MISE_DATA_DIR=/opt/mise (set by
+    /etc/profile.d/dotfiles-mise.sh) and the directory must exist
+    with the build-time installs/ tree underneath it.
+
+    This is the runtime invariant ADR 0006 decision detail 4 names
+    explicitly. A regression that relocates back to
+    $HOME/.local/share/mise breaks the gcp-vm-container template's
+    /home/<user>:/root volume mount contract: the cache disappears
+    on first workspace boot."""
+    result = _run_in_image(
+        ". /etc/profile.d/dotfiles-mise.sh && "
+        'printf "MISE_DATA_DIR=%s\\n" "$MISE_DATA_DIR" && '
+        "test -d /opt/mise/installs && "
+        "test -d /opt/mise/shims && "
+        'echo "installs+shims present"'
+    )
+    assert result.returncode == 0, (
+        f"runtime check for /opt/mise failed.\n"
+        f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    )
+    assert "MISE_DATA_DIR=/opt/mise" in result.stdout, (
+        f"profile.d did not export MISE_DATA_DIR=/opt/mise.\nstdout:\n{result.stdout}"
+    )
+    assert "installs+shims present" in result.stdout, (
+        "Either /opt/mise/installs or /opt/mise/shims is missing in the "
+        "saved image. Build-time `mise install` did not write to the "
+        "expected data dir."
+    )
+
+
+def test_image_mise_offline_install_works(saved_image: str) -> None:
+    """`MISE_OFFLINE=1 mise install` against a copy of the workspace
+    mise.toml must succeed inside the saved image. This proves that
+    the build-time-baked /opt/mise cache covers every pinned tool —
+    the prerequisite for ADR 0006 decision detail 5 (workspace
+    runtime MISE_OFFLINE=1 re-enable).
+
+    We bind in the workspace mise.toml at runtime instead of using
+    the one already at /root/dotfiles, because that path is used by
+    other tests that may run in parallel and we don't want to
+    interfere with their `mise trust` state."""
+    # The image's MISE_TRUSTED_CONFIG_PATHS already trusts
+    # /root/dotfiles, so place our throwaway mise.toml there.
+    result = _run_in_image(
+        ". /etc/profile.d/dotfiles-mise.sh && "
+        "tmpd=$(mktemp -d /root/dotfiles/mise-offline-test.XXXXXX) && "
+        'cp /root/dotfiles/mise.toml "$tmpd/mise.toml" && '
+        'cd "$tmpd" && '
+        "MISE_OFFLINE=1 mise install 2>&1 && "
+        'rm -rf "$tmpd"'
+    )
+    assert result.returncode == 0, (
+        f"`MISE_OFFLINE=1 mise install` failed inside the saved image. "
+        f"This means at least one pinned tool is missing from "
+        f"/opt/mise/installs — workspace runtime would fail too.\n"
+        f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    )
+    # mise prints "Installing ..." for tools it would fetch — under
+    # MISE_OFFLINE=1 it should not print that for any of them, since
+    # all are already cached.
+    assert "Installing" not in result.stdout, (
+        f"mise tried to fetch a tool under MISE_OFFLINE=1; that means "
+        f"the build-time prebuild missed it. mise output:\n{result.stdout}"
+    )

--- a/tests/test_install_os_dispatch.py
+++ b/tests/test_install_os_dispatch.py
@@ -1,0 +1,256 @@
+"""Regression tests for install.sh OS dispatch (ADR 0005).
+
+What this guards
+----------------
+ADR 0005 (Accepted 2026-05-02) decided that install.sh becomes
+OS-aware via a single `uname`-driven `DOTFILES_OS` variable, with
+each install step wrapped in a `step_*` helper function. The
+helpers branch on `DOTFILES_OS` so:
+
+  - mac:     runs the historical Homebrew + brew bundle + gcloud
+             components + pnpm globals + update-all flow
+  - linux:   runs only symlink + sheldon (the dev container
+             feature already provided everything else with SHA/
+             SLSA verification at build time)
+  - windows: emits TODO stubs; concrete impls come in a future
+             ADR when a Windows host is actually used
+  - unknown: exits non-zero so unsupported environments fail
+             closed
+
+The existing `INSTALL_SKIP_*` env vars are kept as an operator
+override layer; the combined skip predicate is OS-says-skip OR
+env-var-says-skip.
+
+These tests are **regex assertions on install.sh source text**
+plus a small set of runtime executions of `install.sh --check`
+or equivalent dry-run flag. They do NOT execute the heavy
+install steps themselves; doing so would require a real Mac
+host and a real Coder workspace, both already covered by other
+tests.
+
+Why these exist
+---------------
+A previous PR that "just adds a bunch of step_* functions" can
+silently regress the OS dispatch (e.g., by forgetting the
+`exit 1` for unknown OS, or by inverting an OR/AND in the skip
+predicate). Catch those at PR-review time before they reach
+main.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+INSTALL_SH = ROOT / "install.sh"
+BASH = shutil.which("bash") or "/bin/bash"
+
+
+@pytest.fixture(scope="module")
+def install_sh_text() -> str:
+    assert INSTALL_SH.is_file(), f"install.sh missing at {INSTALL_SH}"
+    return INSTALL_SH.read_text(encoding="utf-8")
+
+
+# ---------- OS identification --------------------------------------
+
+
+def test_install_sh_identifies_dotfiles_os(install_sh_text: str) -> None:
+    """install.sh must set a DOTFILES_OS variable based on uname so
+    the subsequent step_* helpers can dispatch."""
+    assert re.search(
+        r"DOTFILES_OS\s*=\s*",
+        install_sh_text,
+    ), "install.sh must assign DOTFILES_OS so step_* helpers can branch."
+
+
+def test_install_sh_dispatches_mac_linux_windows(install_sh_text: str) -> None:
+    """The case statement must cover Darwin / Linux / MSYS-family
+    explicitly. WSL is detected as Linux (out of scope to special-
+    case)."""
+    assert re.search(r"\bDarwin\)", install_sh_text), (
+        "install.sh case must include a Darwin branch for macOS."
+    )
+    assert re.search(r"\bLinux\)", install_sh_text), (
+        "install.sh case must include a Linux branch."
+    )
+    assert re.search(
+        r"MINGW\*\|MSYS\*\|CYGWIN\*\)|MSYS\*\|MINGW\*\|CYGWIN\*\)",
+        install_sh_text,
+    ), (
+        "install.sh case must include a Windows (MSYS/MINGW/Cygwin) "
+        "branch so a future Windows port has a clear hook."
+    )
+
+
+def test_install_sh_fails_closed_on_unknown_os(install_sh_text: str) -> None:
+    """ADR 0005: unknown OS must exit non-zero, not warn-and-continue.
+    Otherwise a future operator running install.sh on a NetBSD box
+    or in a misconfigured CI gets surprising partial behaviour."""
+    # The catch-all in the case statement must invoke `exit 1` (or
+    # `exit` with any non-zero code). Allow either ` *) ` or `*)`.
+    catchall = re.search(
+        r"\*\)[\s\S]*?exit\s+[1-9][0-9]*",
+        install_sh_text,
+    )
+    assert catchall is not None, (
+        "install.sh must exit non-zero for unrecognised uname output. "
+        "A `*)` catch-all that warns and continues is unacceptable per "
+        "ADR 0005 decision Q4."
+    )
+
+
+# ---------- step_* functions ---------------------------------------
+
+
+REQUIRED_STEPS = (
+    "step_homebrew",
+    "step_symlink_dotfiles",
+    "step_sheldon",
+    "step_brew_bundle",
+    "step_gcloud_components",
+    "step_pnpm_globals",
+    "step_update_all",
+)
+
+
+@pytest.mark.parametrize("step_name", REQUIRED_STEPS)
+def test_install_sh_defines_required_step_function(
+    install_sh_text: str, step_name: str
+) -> None:
+    """Each install responsibility lives in a named function so that
+    OS dispatch is local to the function and tests can grep for the
+    contract independently."""
+    assert re.search(
+        rf"^{step_name}\s*\(\s*\)\s*\{{",
+        install_sh_text,
+        re.MULTILINE,
+    ), (
+        f"install.sh must define a `{step_name}` function. ADR 0005 "
+        f"decision Q4 names the helper set."
+    )
+
+
+def test_step_functions_are_called(install_sh_text: str) -> None:
+    """Defining a step_* helper but never calling it is a silent
+    regression. Each REQUIRED_STEPS entry must be invoked somewhere
+    in the script."""
+    # Strip function definitions so we don't get a false hit on the
+    # definition line itself.
+    body_only = re.sub(
+        r"^[a-z_]+\s*\(\s*\)\s*\{[\s\S]*?^\}\s*$",
+        "",
+        install_sh_text,
+        flags=re.MULTILINE,
+    )
+    for step in REQUIRED_STEPS:
+        assert re.search(rf"\b{step}\b", body_only), (
+            f"`{step}` is defined but never invoked. The step list in "
+            f"install.sh body must call every helper that ADR 0005 names."
+        )
+
+
+# ---------- env var override preserved -----------------------------
+
+
+@pytest.mark.parametrize(
+    "env_var",
+    [
+        "INSTALL_SKIP_HOMEBREW",
+        "INSTALL_SKIP_GCLOUD",
+        "INSTALL_SKIP_ADD_UPDATE",
+    ],
+)
+def test_install_sh_honours_legacy_skip_env_vars(
+    install_sh_text: str, env_var: str
+) -> None:
+    """ADR 0005 decision: existing INSTALL_SKIP_* env vars are kept
+    as operator overrides. The OS-aware skip and env-var skip are
+    OR-combined."""
+    assert env_var in install_sh_text, (
+        f"install.sh must continue to honour {env_var} as an operator "
+        f"override after the OS dispatch refactor."
+    )
+
+
+# ---------- runtime smoke (no real install) ------------------------
+
+
+def test_install_sh_passes_shellcheck() -> None:
+    """install.sh is the entry point operators run on day 1; it
+    must pass shellcheck so we don't ship subtly-broken bash. If
+    shellcheck is not available on the test runner, skip — CI's
+    Shellcheck Linting workflow exercises this anyway."""
+    if shutil.which("shellcheck") is None:
+        pytest.skip("shellcheck not installed; relying on CI's lint job")
+
+    r = subprocess.run(
+        ["shellcheck", "--severity=error", str(INSTALL_SH)],
+        capture_output=True,
+        text=True,
+    )
+    assert r.returncode == 0, (
+        f"install.sh shellcheck failed:\nstdout:\n{r.stdout}\nstderr:\n{r.stderr}"
+    )
+
+
+def test_install_sh_unknown_uname_exits_nonzero(tmp_path: Path) -> None:
+    """End-to-end smoke: invoke install.sh with a fake `uname` stub
+    that prints something we don't recognise. The script must exit
+    non-zero before it reaches any actual install logic.
+
+    We achieve this by:
+      1. Creating a tmp dir with a stub `uname` executable that
+         prints "Plan9".
+      2. Running `bash install.sh` with PATH pointing at the stub
+         dir first.
+      3. Confirming the exit code is non-zero AND no homebrew /
+         gcloud install was attempted (those would touch network +
+         system, which we'd notice if they fired).
+
+    The script will probably fail very early — before HEAD-of-
+    install.sh `git clone`. That's fine; the relevant assertion is
+    "non-zero exit" not "exits at exactly line N"."""
+    stubs = tmp_path / "stubs"
+    stubs.mkdir()
+    fake_uname = stubs / "uname"
+    fake_uname.write_text("#!/usr/bin/env bash\necho Plan9\n")
+    fake_uname.chmod(0o755)
+
+    env = os.environ.copy()
+    env["PATH"] = f"{stubs}:{env.get('PATH', '')}"
+    # Set DOTPATH to a tmp location so the pre-amble git clone
+    # doesn't try to mutate the operator's real ~/dotfiles.
+    env["DOTPATH"] = str(tmp_path / "dotfiles")
+    env["INSTALL_SKIP_HOMEBREW"] = "1"
+    env["INSTALL_SKIP_GCLOUD"] = "1"
+    env["INSTALL_SKIP_ADD_UPDATE"] = "1"
+
+    r = subprocess.run(
+        [BASH, str(INSTALL_SH)],
+        env=env,
+        capture_output=True,
+        text=True,
+        cwd=str(tmp_path),
+        timeout=30,
+    )
+    assert r.returncode != 0, (
+        f"install.sh exited 0 on a Plan9 fake uname. ADR 0005 requires "
+        f"unknown OSes to fail closed.\nstdout:\n{r.stdout}\n"
+        f"stderr:\n{r.stderr}"
+    )
+    # Also confirm the rejection mentions the unsupported OS so the
+    # operator knows what happened.
+    combined = r.stdout + r.stderr
+    assert re.search(r"unsupported|unknown.*os|Plan9", combined, re.IGNORECASE), (
+        f"install.sh exited non-zero but did not say why; operator "
+        f"should see an unsupported-OS message. Combined output:\n"
+        f"{combined}"
+    )

--- a/tests/test_mise_data_dir_relocation.py
+++ b/tests/test_mise_data_dir_relocation.py
@@ -1,0 +1,215 @@
+"""Regression test for the MISE_DATA_DIR=/opt/mise relocation
+required by ADR 0006 (Accepted 2026-05-02).
+
+What this guards
+----------------
+The Coder workspace template binds `/home/<user>:/root` to
+persist operator state across container restarts within a VM.
+That bind-mount masks `$HOME/.local/share/mise/installs/` —
+the default location where the dev container feature pre-installs
+the pinned mise.toml tools. With the cache hidden, the workspace
+falls back to runtime fetches from api.github.com / aqua-registry
+on every start, defeating the whole point of pinning.
+
+Per ADR 0006 decision detail 4, the data dir is relocated to
+`/opt/mise`. `/opt` is outside the volume-mount path, so the
+cache survives. This relocation is what unblocks
+`MISE_OFFLINE=1` re-enable at workspace runtime (decision detail
+5). FHS-wise `/opt` is the right home for add-on package trees.
+
+These assertions live across four files:
+- `.devcontainer/features/dotfiles-tools/install.sh`
+  (build-time installs into /opt/mise)
+- `.devcontainer/devcontainer.json`
+  (containerEnv exposes MISE_DATA_DIR + shim PATH)
+- `.devcontainer/post-create.sh`
+  (post-create mise install honours the relocation)
+- `exe/coder/templates/dotfiles-devcontainer/main.tf`
+  (workspace agent startup_script propagates MISE_DATA_DIR + flips MISE_OFFLINE back to 1)
+
+A regression that re-introduces /root/.local/share/mise anywhere
+breaks the relocation contract; this test catches it at PR-review
+time before the workspace boot fails three weeks later.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+FEATURE_INSTALL_SH = (
+    ROOT / ".devcontainer" / "features" / "dotfiles-tools" / "install.sh"
+)
+DEVCONTAINER_JSON = ROOT / ".devcontainer" / "devcontainer.json"
+POST_CREATE_SH = ROOT / ".devcontainer" / "post-create.sh"
+WORKSPACE_TF = (
+    ROOT / "exe" / "coder" / "templates" / "dotfiles-devcontainer" / "main.tf"
+)
+
+
+# ---------- feature install.sh ------------------------------------
+
+
+def test_feature_install_creates_opt_mise() -> None:
+    """The feature must `install -d` /opt/mise before mise install
+    so the data dir actually exists at the expected location."""
+    text = FEATURE_INSTALL_SH.read_text(encoding="utf-8")
+    assert re.search(r"install\s+-d[^\n]*/opt/mise", text), (
+        "feature install.sh must create /opt/mise (e.g. via "
+        "`install -d -m 0755 /opt/mise`) before mise install."
+    )
+
+
+def test_feature_install_exports_mise_data_dir() -> None:
+    """Build-time mise install must run with MISE_DATA_DIR=/opt/mise
+    so installs end up there."""
+    text = FEATURE_INSTALL_SH.read_text(encoding="utf-8")
+    assert re.search(
+        r"export\s+MISE_DATA_DIR=/opt/mise|MISE_DATA_DIR=/opt/mise\s+mise",
+        text,
+    ), (
+        "feature install.sh must export MISE_DATA_DIR=/opt/mise before "
+        "running `mise install`."
+    )
+
+
+def test_feature_install_does_not_use_home_share_mise() -> None:
+    """No reference to /root/.local/share/mise or $HOME/.local/share/mise
+    should remain in the feature install.sh after the relocation."""
+    text = FEATURE_INSTALL_SH.read_text(encoding="utf-8")
+    forbidden = [r"/root/\.local/share/mise", r"\$HOME/\.local/share/mise"]
+    for pat in forbidden:
+        assert not re.search(pat, text), (
+            f"feature install.sh still references {pat}; relocation to "
+            f"/opt/mise per ADR 0006 must remove all such references."
+        )
+
+
+def test_feature_install_writes_profile_d_with_data_dir() -> None:
+    """The /etc/profile.d/dotfiles-mise.sh shipped by the feature must
+    export MISE_DATA_DIR=/opt/mise. Inner one-shot containers spawned
+    by the test fixture inherit env via login shell, not containerEnv."""
+    text = FEATURE_INSTALL_SH.read_text(encoding="utf-8")
+    profile_block = re.search(
+        r"cat > /etc/profile\.d/dotfiles-mise\.sh <<'PROFILE'(.*?)PROFILE",
+        text,
+        re.DOTALL,
+    )
+    assert profile_block is not None, "could not locate the profile.d heredoc"
+    body = profile_block.group(1)
+    assert re.search(r"export\s+MISE_DATA_DIR=/opt/mise", body), (
+        "/etc/profile.d/dotfiles-mise.sh must export MISE_DATA_DIR=/opt/mise."
+    )
+    assert "/opt/mise/shims" in body, (
+        "/etc/profile.d/dotfiles-mise.sh must add /opt/mise/shims to PATH."
+    )
+
+
+# ---------- devcontainer.json -------------------------------------
+
+
+def _load_devcontainer_json() -> dict:
+    """devcontainer.json is JSON-with-comments. Strip them before
+    json.loads."""
+    text = DEVCONTAINER_JSON.read_text(encoding="utf-8")
+    # Strip /* ... */ block comments and // line comments. Keep
+    # // inside strings — but the codebase doesn't use protocol
+    # URLs in this file so a simple regex is safe.
+    text = re.sub(r"/\*.*?\*/", "", text, flags=re.DOTALL)
+    text = re.sub(r"^\s*//.*$", "", text, flags=re.MULTILINE)
+    text = re.sub(r"//[^\n]*$", "", text, flags=re.MULTILINE)
+    # Strip trailing commas before } or ].
+    text = re.sub(r",(\s*[}\]])", r"\1", text)
+    return json.loads(text)
+
+
+@pytest.fixture(scope="module")
+def devcontainer_config() -> dict:
+    return _load_devcontainer_json()
+
+
+def test_devcontainer_containerenv_has_mise_data_dir(
+    devcontainer_config: dict,
+) -> None:
+    """containerEnv must expose MISE_DATA_DIR=/opt/mise so processes
+    spawned by the dev container (incl. pytest sub-containers via
+    docker-outside-of-docker) inherit the relocation."""
+    container_env = devcontainer_config.get("containerEnv", {})
+    assert container_env.get("MISE_DATA_DIR") == "/opt/mise", (
+        f"devcontainer.json containerEnv must set MISE_DATA_DIR=/opt/mise. "
+        f"Found: {container_env.get('MISE_DATA_DIR')!r}"
+    )
+
+
+def test_devcontainer_path_uses_opt_mise_shims(
+    devcontainer_config: dict,
+) -> None:
+    """containerEnv PATH must include /opt/mise/shims (not the old
+    /root/.local/share/mise/shims)."""
+    container_env = devcontainer_config.get("containerEnv", {})
+    path = container_env.get("PATH", "")
+    assert "/opt/mise/shims" in path, (
+        f"devcontainer.json containerEnv PATH must include /opt/mise/shims. "
+        f"Found PATH: {path!r}"
+    )
+    assert "/root/.local/share/mise/shims" not in path, (
+        f"devcontainer.json containerEnv PATH still references the "
+        f"old /root/.local/share/mise/shims; remove it after the "
+        f"relocation. PATH={path!r}"
+    )
+
+
+# ---------- post-create.sh ----------------------------------------
+
+
+def test_post_create_does_not_force_mise_offline_zero() -> None:
+    """Per ADR 0006 decision 5, post-create's mise install no longer
+    needs to flip MISE_OFFLINE to 0 — the cache is now reachable
+    under /opt/mise regardless of the bind mount."""
+    text = POST_CREATE_SH.read_text(encoding="utf-8")
+    assert not re.search(r"\bMISE_OFFLINE=0\b", text), (
+        "post-create.sh still forces MISE_OFFLINE=0; per ADR 0006 the "
+        "data-dir relocation removes the need for this override."
+    )
+
+
+# ---------- workspace agent startup_script ------------------------
+
+
+def test_workspace_startup_script_sets_mise_data_dir() -> None:
+    """The agent startup_script must export MISE_DATA_DIR=/opt/mise
+    so the runtime mise install reaches the relocated cache."""
+    text = WORKSPACE_TF.read_text(encoding="utf-8")
+    assert re.search(
+        r"MISE_DATA_DIR=/opt/mise",
+        text,
+    ), (
+        "main.tf agent startup_script must propagate "
+        "MISE_DATA_DIR=/opt/mise to the workspace mise install."
+    )
+
+
+def test_workspace_startup_script_re_enables_mise_offline() -> None:
+    """Per ADR 0006 decision 5, the workspace runtime mise install
+    runs with MISE_OFFLINE=1 because the relocation makes the cache
+    available without network."""
+    text = WORKSPACE_TF.read_text(encoding="utf-8")
+    # The relevant block lives in the agent startup_script heredoc.
+    block = re.search(r"startup_script\s*=[^<]*<<-EOT(.*?)EOT", text, re.DOTALL)
+    assert block is not None, "could not locate workspace startup_script"
+    body = block.group(1)
+    # Must invoke mise install with MISE_OFFLINE=1.
+    assert re.search(r"MISE_OFFLINE=1\s+mise\s+install", body), (
+        "main.tf agent startup_script should run `MISE_OFFLINE=1 mise install` "
+        "now that the cache lives at /opt/mise."
+    )
+    # Must NOT contain MISE_OFFLINE=0 anymore.
+    assert not re.search(r"MISE_OFFLINE=0\s+mise", body), (
+        "main.tf agent startup_script still forces MISE_OFFLINE=0; "
+        "remove it per ADR 0006 decision 5."
+    )

--- a/tests/test_mise_pin_consistency.py
+++ b/tests/test_mise_pin_consistency.py
@@ -1,0 +1,168 @@
+"""Build-time consistency check between mise.toml and the dev
+container feature's hardcoded version constants (ADR 0006).
+
+What this guards
+----------------
+ADR 0006 (Accepted 2026-05-02) makes `mise.toml` the single SoT
+for tool versions. The dev container feature at
+`.devcontainer/features/dotfiles-tools/install.sh` keeps its
+SHA-256 + SLSA-attestation verified install path for `uv`, `just`,
+and `sheldon` — preserving the build-time integrity guarantee
+that mise alone does not provide. ADR 0006 decision detail 3
+mandates: **versions in mise.toml and the feature-install
+hardcoded constants MUST agree**, and the implementation PR adds
+a build-time check that fails the image build on mismatch.
+
+This is that check. Run as part of CI and as a pre-build sanity
+test.
+
+Why this exists
+---------------
+Without enforcement, the two SoTs drift:
+- Mac operator runs `mise upgrade` and bumps mise.toml.
+- Feature install.sh keeps its hardcoded UV_VERSION="0.11.8".
+- Mac and workspace now have different versions. Reproducibility
+  breaks silently.
+
+The check below catches drift at PR review and at workspace
+image build time.
+
+Scope
+-----
+- `uv` ↔ `UV_VERSION` (feature install.sh hardcoded)
+- `just` ↔ `JUST_VERSION` (feature install.sh hardcoded)
+
+Out of scope (handled separately):
+- `sheldon` (`SHELDON_VERSION`): not in mise.toml because sheldon
+  is installed via brew on Mac and via the feature on Linux; mise
+  does not manage it. The feature install.sh hardcoded value is
+  the SoT for sheldon.
+- `prek`, `vp`, `markdownlint-cli2`: npm-backed, installed via
+  mise's npm backend at build time. No feature-install hardcoded
+  constant exists for them; mise.toml is the SoT.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+MISE_TOML = ROOT / "mise.toml"
+FEATURE_INSTALL_SH = (
+    ROOT / ".devcontainer" / "features" / "dotfiles-tools" / "install.sh"
+)
+
+
+@pytest.fixture(scope="module")
+def mise_pins() -> dict[str, str]:
+    """Parse the [tools] section of mise.toml into a dict."""
+    text = MISE_TOML.read_text(encoding="utf-8")
+    match = re.search(r"^\[tools\]\s*$(.*?)^\[", text, re.DOTALL | re.MULTILINE)
+    if match is None:
+        # No following section: read to EOF.
+        match = re.search(r"^\[tools\]\s*$(.*)\Z", text, re.DOTALL | re.MULTILINE)
+    assert match is not None, "could not find [tools] section in mise.toml"
+    pins: dict[str, str] = {}
+    for line in match.group(1).splitlines():
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        m = re.match(r'([a-zA-Z0-9_-]+)\s*=\s*"([^"]+)"', line)
+        if m:
+            pins[m.group(1)] = m.group(2)
+    return pins
+
+
+@pytest.fixture(scope="module")
+def feature_constants() -> dict[str, str]:
+    """Parse the FOO_VERSION="..." constants out of feature
+    install.sh."""
+    text = FEATURE_INSTALL_SH.read_text(encoding="utf-8")
+    return {
+        m.group(1): m.group(2)
+        for m in re.finditer(r'^([A-Z_]+)_VERSION="([^"]+)"', text, re.MULTILINE)
+    }
+
+
+# ---------- mise.toml is fully pinned (no "latest") ----------------
+
+
+def test_mise_toml_has_no_latest_pins(mise_pins: dict[str, str]) -> None:
+    """ADR 0006 forbids `latest`; every tool gets a concrete pin so
+    Mac, Linux, and Windows resolve to the same version."""
+    latest_tools = [tool for tool, version in mise_pins.items() if version == "latest"]
+    assert not latest_tools, (
+        f'mise.toml uses `= "latest"` for {latest_tools}; ADR 0006 '
+        f"requires concrete version pins. Bump these explicitly so "
+        f"all OSes resolve identically."
+    )
+
+
+def test_mise_toml_pins_look_like_versions(mise_pins: dict[str, str]) -> None:
+    """Sanity: every pin should look like a version string. Catches
+    typos like `uv = "0,11,8"` (commas) or `uv = "v0.11.8"` (leading v
+    that mise's aqua backend doesn't always accept)."""
+    bad = {
+        tool: ver
+        for tool, ver in mise_pins.items()
+        if not re.match(r"^[0-9]+\.[0-9]+(?:\.[0-9]+)?(?:[-+][\w.-]+)?$", ver)
+    }
+    assert not bad, (
+        f"mise.toml pins do not look like SemVer-without-leading-v: {bad}. "
+        f"Use the bare version string (e.g. `0.11.8`, not `v0.11.8`)."
+    )
+
+
+# ---------- mise.toml ↔ feature install.sh consistency -------------
+
+
+# Tools managed both via mise.toml and via the verified-fetch
+# install path in the dev container feature. Add a row here when
+# a new tool gets a feature-install hardcoded constant.
+SHARED_PINS: dict[str, str] = {
+    # mise.toml key  ↔  feature-install constant prefix
+    "uv": "UV",
+    "just": "JUST",
+}
+
+
+@pytest.mark.parametrize("mise_key,feature_prefix", list(SHARED_PINS.items()))
+def test_mise_toml_matches_feature_install_constant(
+    mise_pins: dict[str, str],
+    feature_constants: dict[str, str],
+    mise_key: str,
+    feature_prefix: str,
+) -> None:
+    """For every tool installed BOTH through mise (Mac path) and
+    through the verified-fetch feature install (Linux build-time),
+    the two SoTs must agree byte-for-byte."""
+    mise_version = mise_pins.get(mise_key)
+    feature_version = feature_constants.get(feature_prefix)
+    assert mise_version is not None, (
+        f"mise.toml [tools] is missing the {mise_key!r} pin."
+    )
+    assert feature_version is not None, (
+        f"feature install.sh is missing {feature_prefix}_VERSION."
+    )
+    assert mise_version == feature_version, (
+        f"version drift detected for {mise_key}: "
+        f"mise.toml says {mise_version!r}, "
+        f"feature install.sh says {feature_prefix}_VERSION={feature_version!r}. "
+        f"ADR 0006 mandates these agree. Bump both in the same PR or "
+        f"choose a different SoT for this tool."
+    )
+
+
+def test_required_tools_are_present(mise_pins: dict[str, str]) -> None:
+    """Sanity: the minimum set of tools the operator's flow depends
+    on must be in mise.toml."""
+    required = {"uv", "just", "prek", "vp", "markdownlint-cli2"}
+    missing = required - set(mise_pins)
+    assert not missing, (
+        f"mise.toml [tools] is missing required pins: {missing}. "
+        f"Add them with concrete versions per ADR 0006."
+    )


### PR DESCRIPTION
## Summary

Implements the decisions captured in ADR 0005 (install path
rationalization) and ADR 0006 (mise version pinning) — both
accepted in PR #59. Three commits, three logical phases.

## Commits

### \`e13d688\` refactor(install): OS dispatch + step_* helpers per ADR 0005

- \`install.sh\` rewritten around \`uname -s\` → \`DOTFILES_OS\` dispatch (mac / linux / windows / unknown=exit 1)
- Each install responsibility lives in a \`step_*\` helper that branches on \`DOTFILES_OS\`
- Mac path: assumes brew preinstalled (no curl|bash bootstrap), uses brew cask for gcloud, drops the \`just\` curl|bash fallback
- Linux path: skips Homebrew + brew/gcloud bundles + update-all (dev container feature already provides equivalents with SHA/SLSA verify); runs symlink + sheldon + pnpm globals (ADR 0005 decision Q1=b)
- Windows path: stub functions emit "TODO scoop"; future ADR will fill in
- Existing \`INSTALL_SKIP_*\` env vars preserved as operator overrides; combined skip is OR (auto-skip OR env-skip)
- 14 regression tests in \`tests/test_install_os_dispatch.py\`

### \`98101c6\` feat(mise): pin tool versions per ADR 0006

- Replaces \`mise.toml\` \`= "latest"\` with concrete pins (just=1.40.0, uv=0.11.8, prek=0.3.11, vp=0.1.20 [vite-plus alias], markdownlint-cli2=0.22.1)
- Identical pins across Mac / Linux / Windows
- Adds \`tests/test_mise_pin_consistency.py\` build-time consistency check: for tools installed via BOTH mise.toml AND the dev container feature's verified-fetch path, the two SoTs must match byte-for-byte
- Today covers \`uv\` ↔ \`UV_VERSION\` and \`just\` ↔ \`JUST_VERSION\`

### \`bfaa92c\` feat(mise): relocate data dir to /opt/mise per ADR 0006

- \`MISE_DATA_DIR=/opt/mise\` set everywhere it matters: feature install.sh build-time, /etc/profile.d/dotfiles-mise.sh, devcontainer.json containerEnv, main.tf agent startup_script
- PATH shim entries migrate from \`/root/.local/share/mise/shims\` to \`/opt/mise/shims\`
- post-create.sh drops the \`MISE_OFFLINE=0\` override; main.tf flips workspace runtime \`mise install\` back to \`MISE_OFFLINE=1\` (cache reachable without network)
- prebuild mise.toml \`just\` version corrected from 1.50.0 to 1.40.0 (the consistency test from the previous commit caught this drift)
- 11 regression assertions in \`tests/test_mise_data_dir_relocation.py\`

## Why this PR exists

ADR 0005 + 0006 were accepted in PR #59 along with their codex-
review amendments and ADR 0007's coder.tf hardening. This PR is
the implementation of those two ADRs.

The ADRs converged on:

1. install.sh becomes OS-aware via a single \`uname\`-driven case +
   \`step_*\` helpers (instead of a multi-directory plugin tree).
2. mise.toml is the single SoT for tool versions; build-time
   verified-fetch (SHA / SLSA) is preserved on Linux via mise's
   system backend integration.
3. mise data dir relocates to \`/opt/mise\` so the workspace's
   \`/home/<user>:/root\` volume mount cannot mask the build-time
   cache; this unblocks \`MISE_OFFLINE=1\` re-enable at workspace
   runtime, narrowing the trust surface.

## Verification

- \`just fmt\` + \`just lint\` (pre-commit hooks): pass
- \`tofu fmt -check\` + \`tofu validate\` on both \`tofu/exe/\` and \`exe/coder/templates/dotfiles-devcontainer/\`: pass
- Inline regex predicates against post-refactor sources (Phase 1: 22 ✅, Phase 2: 5 ✅, Phase 3: 12 ✅)
- Smoke: \`bash install.sh\` with a stub \`uname=Plan9\` exits non-zero with a useful message
- pnpm install of pinned vp resolves to vite-plus@0.1.20 (verified during commit)

## Apply procedure (post-merge)

1. **Image rebuild** runs automatically on main push to \`.devcontainer/**\` (publish-devcontainer.yaml)
2. **Operator pushes the new template** so the workspace agent startup_script picks up the changes:

   \`\`\`sh
   cdr templates push exe-dotfiles-devcontainer \
     -d exe/coder/templates/dotfiles-devcontainer \
     --variable project_id=gen-ai-hironow \
     --variable workspace_sa_email=$(just exe-output -raw exe_workspace_sa_email) \
     --variable coder_internal_url=$(just exe-output -raw coder_internal_url) \
     --variable image=$(just exe-output -raw artifact_registry_repo)/devcontainer:main \
     --yes
   \`\`\`

3. **Smoke test on a fresh workspace** (existing workspaces are unaffected until restart/recreate):

   \`\`\`sh
   cdr delete my-second-ws --yes
   cdr create my-third-ws --template exe-dotfiles-devcontainer --yes
   cdr ssh my-third-ws.dev -- 'echo "MISE_DATA_DIR=\$MISE_DATA_DIR" && mise current && which uv && which just'
   \`\`\`

   Expect: \`MISE_DATA_DIR=/opt/mise\`, \`mise current\` shows pinned versions with no WARN, no fall-back to network fetch.

## Out of scope (separate PRs)

- Tailscale + Google Cloud apt key fingerprint pin in \`tofu/exe/coder.tf\` (ADR 0005 Open Q2 follow-up; same pattern as PR #57 docker pin)
- AR vulnerability scanning enable (operator decision deferred)
- \`remoteUser=root\` → \`vscode\` in dev container (ADR 0001 deferred)
- Tailscale 3-key rotation automation (ADR 0004 follow-up)