### PR TITLE
fix(exe-bootstrap): pin Tailscale + Google Cloud apt-key fingerprints

### DIFF
--- a/exe/coder/templates/dotfiles-devcontainer/main.tf
+++ b/exe/coder/templates/dotfiles-devcontainer/main.tf
@@ -185,46 +185,6 @@ locals {
       echo "${local.linux_user} ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/coder-user
     fi
 
-    # ---- Tailscale --------------------------------------------------
-    # Workspace VMs reach the Coder control-plane VM (exe-coder:7080)
-    # over the tailnet. Without this step, the agent binary download
-    # falls back to the public CF Access URL which returns OIDC
-    # interstitial HTML for unauthenticated requests — bootstrap
-    # would `chmod +x` it and exec, producing
-    # 'syntax error: unexpected newline'.
-    if ! command -v tailscale >/dev/null 2>&1; then
-      install -m 0755 -d /usr/share/keyrings
-      curl -fsSL https://pkgs.tailscale.com/stable/debian/bookworm.noarmor.gpg \
-        > /usr/share/keyrings/tailscale-archive-keyring.gpg
-      curl -fsSL https://pkgs.tailscale.com/stable/debian/bookworm.tailscale-keyring.list \
-        > /etc/apt/sources.list.d/tailscale.list
-      apt-get update -y
-      apt-get install -y --no-install-recommends tailscale
-    fi
-    systemctl enable --now tailscaled
-
-    # gcloud is needed to fetch the auth key from Secret Manager and
-    # to docker-login Artifact Registry below.
-    if ! command -v gcloud >/dev/null 2>&1; then
-      install -m 0755 -d /etc/apt/keyrings
-      curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg \
-        | gpg --dearmor -o /etc/apt/keyrings/cloud.google.gpg
-      echo 'deb [signed-by=/etc/apt/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main' \
-        > /etc/apt/sources.list.d/google-cloud-sdk.list
-      apt-get update -y
-      apt-get install -y --no-install-recommends google-cloud-cli
-    fi
-
-    AUTH_KEY="$(gcloud --quiet --project='${var.project_id}' \
-      secrets versions access latest --secret='${var.workspace_authkey_secret_id}')"
-    tailscale up \
-      --auth-key="$AUTH_KEY" \
-      --hostname='${lower(data.coder_workspace.me.name)}-ws' \
-      --accept-routes=false \
-      --advertise-tags='tag:exe-workspace'
-    unset AUTH_KEY
-
-    # ---- Docker -----------------------------------------------------
     # Helper: import an apt-repo GPG key only after verifying its
     # fingerprint. Without the pin a TOFU fetch from the same TLS
     # endpoint that distributes the package would let a compromised
@@ -251,6 +211,62 @@ locals {
       rm -f /tmp/dotfiles-apt-key.armored /tmp/dotfiles-apt-key.gpg
     }
 
+    # ---- Tailscale --------------------------------------------------
+    # Workspace VMs reach the Coder control-plane VM (exe-coder:7080)
+    # over the tailnet. Without this step, the agent binary download
+    # falls back to the public CF Access URL which returns OIDC
+    # interstitial HTML for unauthenticated requests — bootstrap
+    # would `chmod +x` it and exec, producing
+    # 'syntax error: unexpected newline'.
+    # Tailscale apt-key fingerprint pin. Tailscale does not officially
+    # publish the fingerprint as of 2026-05 (see
+    # github.com/tailscale/tailscale/issues/15221). The value below is
+    # observed via dnf/rpm signature verification and was operator-
+    # verified against the live bookworm.noarmor.gpg endpoint. The
+    # 8-byte suffix matches the NO_PUBKEY 458CA832957F5868 error that
+    # apt would otherwise emit for an un-keyed repo (the same suffix
+    # is documented in the control-plane VM bootstrap at
+    # tofu/exe/coder.tf).
+    if ! command -v tailscale >/dev/null 2>&1; then
+      install -m 0755 -d /usr/share/keyrings
+      import_apt_key_with_fingerprint \
+        https://pkgs.tailscale.com/stable/debian/bookworm.noarmor.gpg \
+        2596A99EAAB33821893C0A79458CA832957F5868 \
+        /usr/share/keyrings/tailscale-archive-keyring.gpg
+      curl -fsSL https://pkgs.tailscale.com/stable/debian/bookworm.tailscale-keyring.list \
+        > /etc/apt/sources.list.d/tailscale.list
+      apt-get update -y
+      apt-get install -y --no-install-recommends tailscale
+    fi
+    systemctl enable --now tailscaled
+
+    # gcloud is needed to fetch the auth key from Secret Manager and
+    # to docker-login Artifact Registry below. Fingerprint published
+    # by Google at https://cloud.google.com/sdk/docs/install#deb;
+    # operator-verified at PR #53 time and reused across all bootstrap
+    # paths (feature install.sh, control-plane coder.tf, and here).
+    if ! command -v gcloud >/dev/null 2>&1; then
+      install -m 0755 -d /etc/apt/keyrings
+      import_apt_key_with_fingerprint \
+        https://packages.cloud.google.com/apt/doc/apt-key.gpg \
+        35BAA0B33E9EB396F59CA838C0BA5CE6DC6315A3 \
+        /etc/apt/keyrings/cloud.google.gpg
+      echo 'deb [signed-by=/etc/apt/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main' \
+        > /etc/apt/sources.list.d/google-cloud-sdk.list
+      apt-get update -y
+      apt-get install -y --no-install-recommends google-cloud-cli
+    fi
+
+    AUTH_KEY="$(gcloud --quiet --project='${var.project_id}' \
+      secrets versions access latest --secret='${var.workspace_authkey_secret_id}')"
+    tailscale up \
+      --auth-key="$AUTH_KEY" \
+      --hostname='${lower(data.coder_workspace.me.name)}-ws' \
+      --accept-routes=false \
+      --advertise-tags='tag:exe-workspace'
+    unset AUTH_KEY
+
+    # ---- Docker -----------------------------------------------------
     # Install docker via the official apt repository in place of
     # the legacy curl-piped convenience script. The fingerprint is
     # published at https://docs.docker.com/engine/install/debian/

--- a/tests/exe/test_startup_script.py
+++ b/tests/exe/test_startup_script.py
@@ -812,3 +812,58 @@ def test_coder_install_attestation_verify_is_best_effort(startup_script: str) ->
         "Bootstrap should attempt gh attestation verify only when gh "
         "is installed and authenticated."
     )
+
+
+# ---------- ADR 0005 Open Q2 follow-up: apt key fingerprint pin ----
+
+# Same observed-not-officially-published value documented in
+# tests/test_vm_bootstrap.py.
+TAILSCALE_GPG_FINGERPRINT = "2596A99EAAB33821893C0A79458CA832957F5868"
+GOOGLE_CLOUD_GPG_FINGERPRINT = "35BAA0B33E9EB396F59CA838C0BA5CE6DC6315A3"
+
+
+@pytest.mark.exe
+def test_coder_tf_pins_tailscale_apt_key(startup_script: str) -> None:
+    """Control-plane VM bootstrap must verify the Tailscale apt key
+    fingerprint before adding the apt repo. Same hardening pattern
+    as the workspace VM (main.tf post-PR #57 + this PR)."""
+    assert TAILSCALE_GPG_FINGERPRINT in startup_script, (
+        f"coder.tf must pin Tailscale apt-key fingerprint {TAILSCALE_GPG_FINGERPRINT}."
+    )
+
+
+@pytest.mark.exe
+def test_coder_tf_pins_google_cloud_apt_key(startup_script: str) -> None:
+    """Control-plane VM bootstrap must verify the Google Cloud apt
+    key fingerprint."""
+    assert GOOGLE_CLOUD_GPG_FINGERPRINT in startup_script, (
+        f"coder.tf must pin Google Cloud apt-key fingerprint "
+        f"{GOOGLE_CLOUD_GPG_FINGERPRINT}."
+    )
+
+
+@pytest.mark.exe
+def test_coder_tf_helper_defined(startup_script: str) -> None:
+    """import_apt_key_with_fingerprint must be defined in the
+    control-plane startup_script."""
+    assert re.search(
+        r"^\s*import_apt_key_with_fingerprint\s*\(\s*\)\s*\{",
+        startup_script,
+        re.MULTILINE,
+    ), "coder.tf must define import_apt_key_with_fingerprint helper."
+
+
+@pytest.mark.exe
+def test_coder_tf_no_unverified_apt_key_curls(startup_script: str) -> None:
+    """The pre-PR pattern of `curl ... > /usr/share/keyrings/...gpg`
+    or `curl ... | gpg --dearmor -o /etc/apt/keyrings/...` for
+    Tailscale or Google Cloud must be gone."""
+    forbidden = [
+        r"curl[^\n]+pkgs\.tailscale\.com[^\n]+noarmor\.gpg[^\n]*>\s*/usr/share/keyrings",
+        r"curl[^\n]+packages\.cloud\.google\.com[^\n]+apt-key\.gpg[\s\S]{0,80}gpg\s+--dearmor",
+    ]
+    for pattern in forbidden:
+        assert not re.search(pattern, startup_script), (
+            f"coder.tf startup_script still uses the unverified-curl "
+            f"pattern matching {pattern!r}."
+        )

--- a/tests/test_vm_bootstrap.py
+++ b/tests/test_vm_bootstrap.py
@@ -141,3 +141,71 @@ def test_main_tf_still_runs_docker_pull_and_run(main_tf_text: str) -> None:
     assert "docker pull" in main_tf_text, "docker pull step missing"
     assert "docker run" in main_tf_text, "docker run step missing"
     assert "auth configure-docker" in main_tf_text, "AR docker login step missing"
+
+
+# Tailscale apt-key fingerprint — observed via dnf/rpm signature
+# verification (Tailscale does not officially publish the fingerprint
+# as of 2026-05; tracked at github.com/tailscale/tailscale/issues/15221).
+# The 8-byte suffix matches NO_PUBKEY 458CA832957F5868 in apt errors.
+TAILSCALE_GPG_FINGERPRINT = "2596A99EAAB33821893C0A79458CA832957F5868"
+
+# Google Cloud apt-key fingerprint — published officially at
+# https://cloud.google.com/sdk/docs/install#deb. Operator-verified
+# at PR #53 time.
+GOOGLE_CLOUD_GPG_FINGERPRINT = "35BAA0B33E9EB396F59CA838C0BA5CE6DC6315A3"
+
+
+def test_main_tf_pins_tailscale_gpg_fingerprint(main_tf_text: str) -> None:
+    """Tailscale apt-key fingerprint must be hardcoded so a
+    compromised pkgs.tailscale.com cannot swap in a different signing
+    key on the workspace VM bootstrap."""
+    assert TAILSCALE_GPG_FINGERPRINT in main_tf_text, (
+        f"Tailscale GPG fingerprint {TAILSCALE_GPG_FINGERPRINT} missing "
+        f"from main.tf. Without the pin the apt key import is TOFU."
+    )
+
+
+def test_main_tf_pins_google_cloud_gpg_fingerprint(main_tf_text: str) -> None:
+    """Google Cloud apt-key fingerprint must be hardcoded; the same
+    value is used in feature install.sh and tofu/exe/coder.tf."""
+    assert GOOGLE_CLOUD_GPG_FINGERPRINT in main_tf_text, (
+        f"Google Cloud GPG fingerprint {GOOGLE_CLOUD_GPG_FINGERPRINT} "
+        f"missing from main.tf."
+    )
+
+
+def test_main_tf_does_not_install_tailscale_or_gcloud_via_unverified_curl(
+    main_tf_text: str,
+) -> None:
+    """The pre-PR pattern was a plain `curl ... > /usr/share/keyrings/...gpg`
+    with no fingerprint check. The post-fix path routes through
+    import_apt_key_with_fingerprint. Catch a regression that drops the
+    helper for either vendor."""
+    forbidden = [
+        # Plain pipe of pkgs.tailscale.com noarmor.gpg into a keyring.
+        r"curl[^\n]+pkgs\.tailscale\.com[^\n]+noarmor\.gpg[^\n]*>\s*/usr/share/keyrings",
+        # Plain dearmor pipe of packages.cloud.google.com apt-key.gpg
+        # into /etc/apt/keyrings.
+        r"curl[^\n]+packages\.cloud\.google\.com[^\n]+apt-key\.gpg[\s\S]{0,80}gpg\s+--dearmor",
+    ]
+    for pattern in forbidden:
+        assert not re.search(pattern, main_tf_text), (
+            f"main.tf still uses the unverified-curl pattern matching "
+            f"{pattern!r}. Replace with import_apt_key_with_fingerprint."
+        )
+
+
+def test_main_tf_helper_defined_once_at_top(main_tf_text: str) -> None:
+    """The import_apt_key_with_fingerprint helper must be defined
+    exactly once in the script (not duplicated per vendor block)."""
+    matches = re.findall(
+        r"^\s*import_apt_key_with_fingerprint\s*\(\s*\)\s*\{",
+        main_tf_text,
+        re.MULTILINE,
+    )
+    assert len(matches) == 1, (
+        f"import_apt_key_with_fingerprint should be defined exactly "
+        f"once in main.tf; found {len(matches)} definitions. "
+        f"Consolidate so all three vendors (tailscale, gcloud, docker) "
+        f"reuse the same helper."
+    )

--- a/tofu/exe/coder.tf
+++ b/tofu/exe/coder.tf
@@ -179,11 +179,42 @@ locals {
     apt-get install -y --no-install-recommends \
       apt-transport-https ca-certificates curl gnupg lsb-release jq
 
+    # Helper: import an apt-repo GPG key only after verifying its
+    # fingerprint. Without the pin a TOFU fetch from the same TLS
+    # endpoint that distributes the package would let a compromised
+    # mirror swap key + package in lock-step. Mirrors the helper at
+    # .devcontainer/features/dotfiles-tools/install.sh and the
+    # workspace template (post-PR #57). Positional args avoid bash
+    # $${var} that would conflict with terraform heredoc interpolation.
+    import_apt_key_with_fingerprint() {
+      # args: <url> <expected-fingerprint> <output-keyring-path>
+      rm -f /tmp/exe-apt-key.armored /tmp/exe-apt-key.gpg
+      curl -fsSL -o /tmp/exe-apt-key.armored "$1"
+      gpg --no-default-keyring --keyring /tmp/exe-apt-key.gpg \
+        --import /tmp/exe-apt-key.armored 2>/dev/null
+      actual=$(gpg --no-default-keyring --keyring /tmp/exe-apt-key.gpg \
+        --list-keys --with-colons | awk -F: '/^fpr:/ { print $10; exit }')
+      if [ "$actual" != "$2" ]; then
+        echo "[coder-bootstrap] GPG fingerprint mismatch for $1" >&2
+        echo "  expected: $2" >&2
+        echo "  actual:   $actual" >&2
+        rm -f /tmp/exe-apt-key.armored /tmp/exe-apt-key.gpg
+        exit 1
+      fi
+      install -m 0644 /tmp/exe-apt-key.gpg "$3"
+      rm -f /tmp/exe-apt-key.armored /tmp/exe-apt-key.gpg
+    }
+
     # ---- Google Cloud CLI (Ubuntu noble) ------------------------------
+    # Fingerprint published by Google at
+    # https://cloud.google.com/sdk/docs/install#deb. Operator-verified
+    # at PR #53 time and reused here.
     if ! command -v gcloud >/dev/null 2>&1; then
       install -m 0755 -d /etc/apt/keyrings
-      curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg \
-        | gpg --dearmor -o /etc/apt/keyrings/cloud.google.gpg
+      import_apt_key_with_fingerprint \
+        https://packages.cloud.google.com/apt/doc/apt-key.gpg \
+        35BAA0B33E9EB396F59CA838C0BA5CE6DC6315A3 \
+        /etc/apt/keyrings/cloud.google.gpg
       echo 'deb [signed-by=/etc/apt/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main' \
         > /etc/apt/sources.list.d/google-cloud-sdk.list
       apt-get update -y
@@ -195,10 +226,18 @@ locals {
     # signed-by=/usr/share/keyrings/tailscale-archive-keyring.gpg, so
     # the keyring MUST be written there. Putting it under
     # /etc/apt/keyrings/tailscale.gpg breaks apt with NO_PUBKEY 458CA832957F5868.
+    #
+    # Fingerprint pin: Tailscale does not officially publish the
+    # apt-key fingerprint as of 2026-05 (see github.com/tailscale/tailscale/issues/15221).
+    # The value below is observed via dnf/rpm signature verification and
+    # was operator-verified against the live noble.noarmor.gpg endpoint.
+    # The 8-byte suffix matches the NO_PUBKEY error documented above.
     if ! command -v tailscale >/dev/null 2>&1; then
       install -m 0755 -d /usr/share/keyrings
-      curl -fsSL https://pkgs.tailscale.com/stable/ubuntu/noble.noarmor.gpg \
-        > /usr/share/keyrings/tailscale-archive-keyring.gpg
+      import_apt_key_with_fingerprint \
+        https://pkgs.tailscale.com/stable/ubuntu/noble.noarmor.gpg \
+        2596A99EAAB33821893C0A79458CA832957F5868 \
+        /usr/share/keyrings/tailscale-archive-keyring.gpg
       curl -fsSL https://pkgs.tailscale.com/stable/ubuntu/noble.tailscale-keyring.list \
         > /etc/apt/sources.list.d/tailscale.list
       apt-get update -y


### PR DESCRIPTION
## Summary

Closes the remaining TOFU rows in ADR 0005 Open Q2 audit table:
Tailscale and Google Cloud apt keys on **both** the control-plane
VM (\`tofu/exe/coder.tf\`) and the workspace VM
(\`exe/coder/templates/dotfiles-devcontainer/main.tf\`) bootstraps.

## Why

Pre-PR pattern: \`curl https://pkgs.tailscale.com/.../noarmor.gpg
> /usr/share/keyrings/tailscale.gpg\` (TOFU on the HTTPS endpoint)
+ \`curl ... | gpg --dearmor -o /etc/apt/keyrings/cloud.google.gpg\`
(also TOFU). A CDN compromise on either vendor would let
malicious packages flow into apt-get install during VM bootstrap.

Same hardening that PR #57 applied to docker, now extended to the
two remaining vendors. Failure mode: fail-closed with a clear
\`GPG fingerprint mismatch\` message.

## What changed

### \`tofu/exe/coder.tf\`

- New inline \`import_apt_key_with_fingerprint\` helper at the top of the bootstrap
- Google Cloud apt key pinned to \`35BAA0...DC6315A3\`
- Tailscale apt key pinned to \`2596A9...957F5868\`

### \`exe/coder/templates/dotfiles-devcontainer/main.tf\`

- Existing helper (introduced for docker in PR #57) **hoisted to script top** so tailscale, gcloud, docker share **one definition**
- Tailscale + Google Cloud blocks switched to the helper
- Docker block unchanged behaviourally (already pinned)

### Tests

- \`tests/test_vm_bootstrap.py\`: 4 new assertions (tailscale FP, gcloud FP, no-unverified-curl, helper-defined-once)
- \`tests/exe/test_startup_script.py\`: 4 new assertions for coder.tf

## Fingerprint provenance

| Vendor | Fingerprint | Source |
|---|---|---|
| Google Cloud | \`35BAA0B33E9EB396F59CA838C0BA5CE6DC6315A3\` | Official: <https://cloud.google.com/sdk/docs/install#deb>. Operator-verified at PR #53 time. |
| Tailscale | \`2596A99EAAB33821893C0A79458CA832957F5868\` | Not officially published as of 2026-05 (see <https://github.com/tailscale/tailscale/issues/15221>). Observed via dnf/rpm signature verification. **Operator-verified against the live \`bookworm.noarmor.gpg\` AND \`noble.noarmor.gpg\` endpoints — both return the same value, expected since Tailscale uses one signing key across distros.** The 8-byte suffix \`458CA832957F5868\` matches the \`NO_PUBKEY\` error already documented as a comment in coder.tf. |

## Verification

- \`tofu fmt -check\` + \`tofu validate\`: ✅ both files
- Inline regex predicates: ✅ 11/11
- Operator-verified fingerprints with:

  \`\`\`sh
  curl -fsSL https://pkgs.tailscale.com/stable/debian/bookworm.noarmor.gpg \
    | gpg --show-keys --with-colons \
    | awk -F: '/^fpr:/{print \$10; exit}'
  # → 2596A99EAAB33821893C0A79458CA832957F5868

  curl -fsSL https://pkgs.tailscale.com/stable/ubuntu/noble.noarmor.gpg \
    | gpg --show-keys --with-colons \
    | awk -F: '/^fpr:/{print \$10; exit}'
  # → 2596A99EAAB33821893C0A79458CA832957F5868
  \`\`\`

## Apply procedure

- **Workspace template** picks up the change after merge → image rebuild → \`cdr templates push\`
- **Control-plane VM** picks up the change after \`just exe-apply\` (replaces the VM via the startup-script change)

ADR 0005 Open Q2 audit table will be marked fully resolved after merge.