### PR TITLE
build(iac): track .terraform.lock.hcl for reproducible provider sets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,8 +19,10 @@ run.log
 .azurite/
 
 # IaC
+# Terraform/OpenTofu lockfiles ARE committed (HashiCorp recommends
+# this for provider reproducibility). The runtime cache dir
+# `.terraform/` and state files stay ignored.
 .terraform
-.terraform.lock.hcl
 *.tfstate
 terraform.tfstate
 terraform.tfstate.backup

--- a/exe/coder/templates/dotfiles-devcontainer/.terraform.lock.hcl
+++ b/exe/coder/templates/dotfiles-devcontainer/.terraform.lock.hcl
@@ -1,0 +1,46 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/coder/coder" {
+  version     = "2.16.0"
+  constraints = ">= 0.11.0"
+  hashes = [
+    "h1:GZ71aeLqkBjTfALHYIf9dWF4WDnRALPDMU5++8GY0Y8=",
+    "zh:04c070bc17816ff4fb785a57c5d217c4c81f0c564cc6634a0c635e079fb68393",
+    "zh:15b70d49e8a1fcab72ec9497ab7af90094a476bee8039a10aecdae2b05e644c1",
+    "zh:24a731d6f94e3711a6f8f88995a0389e4efc96f926fcd97b5eed2c21e0481302",
+    "zh:4ebaa6775c9c8f85e0a121c395cac4f759ecfa01242dc70895023f59eaa30ede",
+    "zh:50ffd0ccfdd9ebc2b4e98316ba89178200d2a0beb58b557c29ebc7d63b7bb8a6",
+    "zh:5b8b30e28e1cecff15b1c5311d091b0d9d932ce91b8e49962a6b9ef4dd330f4f",
+    "zh:6255fabf82a4baf50eab6c5f90f60daaeb22f522338ae0fcfa1b28eff3386ddc",
+    "zh:8eeb2c74e804087c3959d37c5cf773ec00beba431d3a312518aea5934bc8c73b",
+    "zh:9d68e6aa6a26a320113e269b116c7e376e5de873c1bd152ef74460c0d3b22f44",
+    "zh:b28ee23e53c98b948d211c7cf78a628cf513f84e5b340b882fa519098466fb94",
+    "zh:b2a5df2dc02db5da8b08b18237f748c1b9ef9c0d67061847667c9999dcfa7f1a",
+    "zh:b38f6b2abb2b860b31528546bc8beae00dcd95ba35a7db851abee77ad5d252d8",
+    "zh:ea90af990761df5687b35a3e3f981d773a67d02e342fb836ec68375df5c2ba08",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}
+
+provider "registry.opentofu.org/hashicorp/google" {
+  version = "7.30.0"
+  hashes = [
+    "h1:2mAHvc+HqgNNfvOZKQO8L1x1YulF8j5iIeDBQV8O7xE=",
+    "zh:04362f6e3fdd9b71087c1552b0a4e0dc9f4e3e8949de27a67080010a1c772f21",
+    "zh:0e419af463fb047e4e6deb27b81267099811f759f5afef40ff3e79830af29195",
+    "zh:4940a4f7a7c51f0f6b3343ff560ecc539cacbf0eb211f6f67180df2f72db3f97",
+    "zh:582d4e7251cb24434cf6fa28b250f5705bd05478f1ea706725897fa370aae82f",
+    "zh:5c51e2aff19c189311939fc78646f59c7133a830e77f154f39f60e6e7a438fbd",
+    "zh:753df288a21089cab24f94ca585080bd9df104218becdf3878355c778652e713",
+    "zh:972fab3f530bdad40c1113e608a449628ea93d3e2c636e239263758b19887bc1",
+    "zh:9a4293467560207c1e75714efebcc977e58b2597825291be233f2a7a6b437409",
+    "zh:a5735edd6465f60c3eee8b430f01ff90066bd6d28f435cee9022deb14e8f25cf",
+    "zh:b6789320374378401630528bec4159a3cfe2fe8d0282158acb229e9162d0e3b5",
+    "zh:b83098ea7a849e416094331b9658e6ec738ee428ce5665d74fa28560cfd08cfa",
+    "zh:cee6e1c5bdd31c93ed5b03ea85efaf6f09510450eeb26ea5d8171e75b5e2fa57",
+    "zh:d41572c299f2494a283c082bcd9ab5ae2cfce3ba6ed0f4c0741e9ab7d9342df1",
+    "zh:eaa47323d4dd429f265c333fc9d05f89f5d9c7bc2b0c317b172b292e7e9f4d1f",
+    "zh:f71ab50ccbdece9c8cf20bac7bb1e79603ced01a7c4a537d0cb993d306d20bc2",
+  ]
+}

--- a/tofu/exe/.gitignore
+++ b/tofu/exe/.gitignore
@@ -1,9 +1,13 @@
 # Stack-local — root .gitignore already covers most of this, but keep
 # it scoped here too so accidental edits in this dir stay safe.
+# .terraform.lock.hcl is intentionally NOT ignored: HashiCorp
+# recommends committing it for provider reproducibility, and Coder's
+# `coder templates push` includes it in the upload tar by design
+# (provisionersdk/archive.go) so a tracked lockfile gives all
+# operator machines the same provider plugin set.
 terraform.tfvars
 *.auto.tfvars
 .terraform/
-.terraform.lock.hcl
 *.tfstate
 *.tfstate.backup
 *.tfplan

--- a/tofu/exe/.terraform.lock.hcl
+++ b/tofu/exe/.terraform.lock.hcl
@@ -1,0 +1,94 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/cloudflare/cloudflare" {
+  version     = "5.19.1"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:HkKPMZ/n+QiExkRUSLjGMTGnuIaph+k932LiTp7CKZM=",
+    "zh:0651618000db705564dab5a25322b9d76ea54b7dd78931ed3565497b559babeb",
+    "zh:1a7847e9479fb6d21a65ef933ffae1416b1e4b44ca940c0d6c50fc4248cc4a0d",
+    "zh:5597cee5854131045eb9f201ae3a70b59c51955d31a647d9616863c746d902cb",
+    "zh:580786830d93e35b957754fd4c62d4681a3b19abc28b757e41acba26455663b1",
+    "zh:83c4bdfb0e74fd50e56fff3c461d76c1c1ec61af3f679e4de1aa70b5ed05a09f",
+    "zh:abb4d1052cee61d80f9cb51e5421e3c118312403afb7104b98bd7e310ac736ee",
+    "zh:b0aeeb3d66ea4d719989875e778c477065ba941e3a76e9a8caacc3be08208dd9",
+    "zh:e43b4b2dfcec1ce2115f5a5c86042d432deb49bee8eae103eb56d97ea02e2e3b",
+    "zh:f809ab383cca0a5f83072981c64208cbd7fa67e986a86ee02dd2c82333221e32",
+  ]
+}
+
+provider "registry.opentofu.org/hashicorp/google" {
+  version     = "6.50.0"
+  constraints = "~> 6.0"
+  hashes = [
+    "h1:MAAe4zFFdqS9M5rpmJK/vKgdb6ZMD/s/0Xd97yTDipA=",
+    "zh:1d4695f807d998f11fcdcfa174766287b82a8093513af857bcdad2d81c642480",
+    "zh:3173ac5df0294624d113812e49e2a55714aff7db617488168cecdf4168df9e29",
+    "zh:34d2b3d44c23bd6354fc4ab5917b302872ea1ab8de107034567f955b1717fa5b",
+    "zh:3a77f3cc2f3664cd5aaeeef4d044e6ec1695a079588fffec3ca03953664e5f04",
+    "zh:6b444e4b629ea8dc8cb112a39dde098dc5584d26d6de4177558f556a9a226696",
+    "zh:96545c8cd4d3a57069c5d1799eab5aedd887e16d98b5559a195f6d2c2d9bc674",
+    "zh:ba464caafde95ee16671d6b5ec90f053ed77a9d06c567456db6efd9160fa3165",
+    "zh:d876938e5b0d3f57a984d9be72467995f87fef6569968623415dc51d9f54d30b",
+    "zh:dfd908d873e314ab807d0abc9cfd42d2611cd06dc1b9ec719ebdbb738e8e68d6",
+    "zh:f9f16819a7738d564afd45fd169ba61004ec4e4e7089d2a4950cb8895be1fe1f",
+  ]
+}
+
+provider "registry.opentofu.org/hashicorp/random" {
+  version     = "3.8.1"
+  constraints = "~> 3.6"
+  hashes = [
+    "h1:LsYuJLZcYl1RiH7Hd3w90Ra5+k5cNqfdRUQXItkTI8Y=",
+    "zh:25c458c7c676f15705e872202dad7dcd0982e4a48e7ea1800afa5fc64e77f4c8",
+    "zh:2edeaf6f1b20435b2f81855ad98a2e70956d473be9e52a5fdf57ccd0098ba476",
+    "zh:44becb9d5f75d55e36dfed0c5beabaf4c92e0a2bc61a3814d698271c646d48e7",
+    "zh:7699032612c3b16cc69928add8973de47b10ce81b1141f30644a0e8a895b5cd3",
+    "zh:86d07aa98d17703de9fbf402c89590dc1e01dbe5671dd6bc5e487eb8fe87eee0",
+    "zh:8c411c77b8390a49a8a1bc9f176529e6b32369dd33a723606c8533e5ca4d68c1",
+    "zh:a5ecc8255a612652a56b28149994985e2c4dc046e5d34d416d47fa7767f5c28f",
+    "zh:aea3fe1a5669b932eda9c5c72e5f327db8da707fe514aaca0d0ef60cb24892f9",
+    "zh:f56e26e6977f755d7ae56fa6320af96ecf4bb09580d47cb481efbf27f1c5afff",
+  ]
+}
+
+provider "registry.opentofu.org/hashicorp/time" {
+  version     = "0.13.1"
+  constraints = "~> 0.12"
+  hashes = [
+    "h1:3X1jTAlLJV6G9AylC+BgX7WrKFcZYHqA+Z4JwB+v7as=",
+    "zh:10f32af8b544a039f19abd546e345d056a55cb7bdd69d5bbd7322cbc86883848",
+    "zh:35dd5beb34a9f73de8d0fed332814c69acae69397c9c065ce63ccd8315442bef",
+    "zh:56545d1dd5f2e7262e0c0c124264974229ec9cc234d0d7a0e36e14b869590f4a",
+    "zh:8d7259c3f819fd3470ff933c904b6a549502a8351feb1b5c040a4560decaf7e0",
+    "zh:a40f26878826b142e26fe193f7e3e14fc97f615cd6af140e88ce5bc25f3fcf50",
+    "zh:b2e82f25fecff172a9a9e24ea37d37e4fc630ee9245617cb40b10e66a6b979c8",
+    "zh:d4b699850a40ed07ef83c6b827605d24050b2732646ee017bda278e4ddf01c91",
+    "zh:e4e6a5e5614b6a54557400aabb748ebd57e947cdbd21ad1c7602c51368a80559",
+    "zh:eb78fb97bca22931e730487a20a90f5a6221ddfb3138aaf070737ea2b7c9c885",
+    "zh:faba366a1352ee679bba2a5b09c073c6854721db94b191d49b620b60946a065f",
+  ]
+}
+
+provider "registry.opentofu.org/tailscale/tailscale" {
+  version     = "0.28.0"
+  constraints = "~> 0.18"
+  hashes = [
+    "h1:Cquej+BY4u2GJ90N1l7CCwP4aukIYHUvnlgQIkpLFbU=",
+    "zh:26dc44b865b055069fbada06d8fcf0d44c32a365823219db1c122458c377a2f0",
+    "zh:335d4d4e6293647ff1b9dd828aef14e8b3cdf6ffae22e63084308a0b051d5e23",
+    "zh:40e78f96ac9af15060a0b0fb2eee8d51b61b8d160f063e75c3af7b855d85367e",
+    "zh:410d0d11cf2abbb6b8a7117d833a4326b52ba0a0eb9717e623f3703bc6c6ebc1",
+    "zh:49b90c658eabfb26559704dcc4a4da3bc1895f1724b8ea80d031ee22826e9426",
+    "zh:511d87ece288524ed3601c636838f041dcb4bf5aa7cef532677b65767ae0dda3",
+    "zh:55cedf481b4a357f625ed785f685e46e3087955bd66750eeaf631836e992a6f4",
+    "zh:5f58fcbe3980e64e3423f851cf2b7efad06df7382a813b21c4c3d7ce6c41b378",
+    "zh:a831d89d7b0b8e9d609c68e026d2beb8aa2173831de0baee6739745e94b70aa6",
+    "zh:a91ee9291198b358e1e57772e55d3e5bd882d676be0238a21d39f26980d26a5d",
+    "zh:bbf1c42927b62bb787bf624dc6d2089b422e3fe28bb02f27d10da1b184904279",
+    "zh:e6c2116f2d9140e7d1487ab48f5fa55e53e8251018155ee59d867b54f8713a4d",
+    "zh:ebfd3caf5feda0b5251a9ba62be54456a257b4d1ac237d9cccee6487a3ba7581",
+    "zh:f39ceae695cac365708e9f0e866801322723c00a1447c398d6eba376817afbcf",
+  ]
+}


### PR DESCRIPTION
## Summary

Track the OpenTofu/Terraform lockfiles in git so all operator
machines and CI runs resolve to the same provider plugin
checksums.

## Why

HashiCorp's official guidance is to commit \`.terraform.lock.hcl\`
for reproducibility. Two stack-specific reasons reinforce this:

1. **Coder template push includes the lockfile by design.**
   \`provisionersdk/archive.go\` \`Tar()\` is hardcoded to **include**
   \`.terraform.lock.hcl\` in the template upload (it's used for
   provider plugin caching on the Coder server). When the
   lockfile is gitignored, each operator's local \`cdr templates
   push\` uploads a *different* lockfile depending on what their
   last \`tofu init\` produced. Tracking the file removes that
   drift surface.

2. **Audit visibility.** Anyone reviewing the repo can verify
   provider plugin checksums independently of operator-machine
   state.

## What changed

| File | Change |
|---|---|
| \`.gitignore\` | drop global \`.terraform.lock.hcl\` rule; keep \`.terraform\` cache dir ignored |
| \`tofu/exe/.gitignore\` | drop the local \`.terraform.lock.hcl\` rule; add comment explaining why it's intentionally tracked |
| \`tofu/exe/.terraform.lock.hcl\` | NEW (94 lines, control-plane stack) |
| \`exe/coder/templates/dotfiles-devcontainer/.terraform.lock.hcl\` | NEW (46 lines, workspace template) |

State files (\`*.tfstate*\`) and the runtime cache dir
(\`.terraform/\`) remain ignored.

## Verification

- \`git check-ignore -v\` confirms both lockfile paths are no
  longer matched by any rule
- File contents are the canonical "maintained automatically by
  tofu init" form

## Apply procedure

No infra apply needed. Future operators / CI / \`cdr templates
push\` will pick up the tracked lockfile automatically.

## Follow-up (out of scope here)

After this lands, I'll attempt \`cdr templates push\` from my
side as a smoke check; the previous attempt was blocked because
the local lockfile was a per-machine artifact rather than a
tracked one.