### PR TITLE
docs: refresh README architecture overview + exe/docs (post-#60..#62)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,60 @@
 
 My configuration for Zsh, Mise, Just, and more.
 
+## Architecture overview
+
+Three environments share one source of truth (`mise.toml` +
+`.devcontainer/devcontainer.json` + `install.sh`). Each runs the
+same tools at the same versions; only the install path per OS
+differs.
+
+```
+   +---------------+     +-----------------+     +------------------+
+   |   Mac host    |     |  Dev container  |     |  Coder workspace |
+   |  (daily       |     |  (CI sandbox    |     |  (exe.hironow.   |
+   |   driver)     |     |   + IDE)        |     |   dev)           |
+   +-------+-------+     +--------+--------+     +---------+--------+
+           |                      |                        |
+   brew + mise          devcontainer.json         docker pull prebuilt
+   (just deploy)        + features/                image (Artifact Reg.)
+                        dotfiles-tools             then docker run
+                                                   (--volume /home:/root)
+           |                      |                        |
+           +----------+-----------+------------+-----------+
+                                              |
+                                              v
+                          +-----------------------------------+
+                          |  Single source of truth (this repo) |
+                          |                                     |
+                          |  - install.sh        (OS dispatch)  |
+                          |  - mise.toml         (tool pins)    |
+                          |  - .devcontainer/    (image SoT)    |
+                          |  - dump/             (brew/gcloud)  |
+                          +-----------------------------------+
+```
+
+```
+Legend / 凡例:
+
+- Mac host: operator のメインマシン (Homebrew 前提)
+- Dev container: .devcontainer/devcontainer.json + features/dotfiles-tools をビルドした image (CI とローカル IDE で同一)
+- Coder workspace: exe.hironow.dev で立ち上がる cloud dev 環境。Artifact Registry 上の prebuilt image を docker pull する
+- install.sh OS dispatch: uname → mac / linux / windows で step_* 関数を切り替える (ADR 0005)
+- mise.toml: just / uv / prek / vp / markdownlint-cli2 を 3 OS 同一バージョンに pin (ADR 0006)
+- .devcontainer/: dev container 仕様の SoT (debian-12 + Microsoft-curated features + ローカル feature)
+- Artifact Registry: GitHub Actions が main merge 時に WIF 認証で image push、Coder workspace VM が docker pull
+```
+
+詳細は以下を参照:
+
+- [`docs/intent.md`](./docs/intent.md) — リクエスト元の意図
+- [`docs/adr/`](./docs/adr/) — Architecture Decision Records (0001–0007、debian-12 / prebuilt image / Actions 強化 / tailnet routing / install path / mise pin / Coder server hardening)
+- [`exe/docs/architecture.md`](./exe/docs/architecture.md) — exe.hironow.dev 全体図 (Cloudflare + Tailscale + Coder + GCP)
+- [`exe/docs/runbook.md`](./exe/docs/runbook.md) — 運用手順 (operator workflow)
+- [`exe/coder/templates/dotfiles-devcontainer/README.md`](./exe/coder/templates/dotfiles-devcontainer/README.md) — Coder template の push / create
+- [`exe/scripts/README.md`](./exe/scripts/README.md) — `cdr` wrapper (CF Access service token 経由で `coder` CLI を実行)
+- [`tools/README.md`](./tools/README.md) — RTTM converter / simple server などの補助ツール
+
 ## Installation
 
 Requires `curl` and `git`.
@@ -11,7 +65,8 @@ bash -c "$(curl -fsSL https://raw.githubusercontent.com/hironow/dotfiles/main/in
 ```
 
 > [!NOTE]
-> Mac, Linux, Windows([WSL](https://learn.microsoft.com/en-us/windows/wsl/)内Linux)へ対応
+> Mac, Linux, Windows([WSL](https://learn.microsoft.com/en-us/windows/wsl/)内Linux)へ対応。Windows native (scoop) は OS dispatch hook のみで実装は TODO。
+> Mac は Homebrew が前提条件 (操作者が手動で先にインストール)、それ以降は install.sh が自動。
 
 ## usage
 
@@ -89,11 +144,14 @@ sudo mise x -- go run main.go
 ## Dev Container
 
 This repo ships a [Dev Container](https://containers.dev/) declared in
-`.devcontainer/devcontainer.json` (debian-12 + features). The same file
-drives CI (`devcontainers/ci` action) and the Coder workspace template
-(via envbuilder), so all three environments stay aligned. Open it to get
-an isolated environment with `just`, `mise`, `prek`, `ruff`, `shellcheck`,
-and `markdownlint-cli2` already provisioned — useful as an AI agent
+`.devcontainer/devcontainer.json` (debian-12 + Microsoft-curated
+features + local `dotfiles-tools` feature). The same file drives CI
+(`devcontainers/ci` action) and the Coder workspace template
+(prebuilt image pulled from Artifact Registry — no envbuilder per
+[ADR 0002](./docs/adr/0002-coder-prebuilt-image.md)), so all three
+environments stay aligned. Open it to get an isolated environment
+with `just`, `mise`, `prek`, `ruff`, `shellcheck`, and
+`markdownlint-cli2` already provisioned — useful as an AI agent
 sandbox for `just fmt|lint|check|test`.
 
 - **Claude Code**: run `/devcontainer`

--- a/exe/README.md
+++ b/exe/README.md
@@ -16,18 +16,19 @@ agent's environment matches CI exactly.
 
 | Path | Purpose |
 |---|---|
-| `coder/` | Coder workspace template (Terraform) |
-| `cloudflared/` | Tunnel ingress config (cert + credentials live in Secret Manager) |
-| `tailscale/` | ACL (`acl.hujson`), tag definitions for `tag:owner` / `tag:agent` |
-| `scripts/` | Bootstrap, teardown, smoke-test scripts |
-| `docs/` | Architecture and runbook |
+| [`coder/`](./coder/) | Coder workspace template (gcp-vm-container, prebuilt image) |
+| [`cloudflared/`](./cloudflared/) | Tunnel ingress doc (rules live in OpenTofu) |
+| [`tailscale/`](./tailscale/) | ACL (`acl.hujson`), tag definitions for the four-tag Pattern A model |
+| [`scripts/`](./scripts/) | `cdr` CF-Access wrapper + bootstrap / teardown / smoke shell |
+| [`docs/`](./docs/) | [Architecture](./docs/architecture.md) + [Runbook](./docs/runbook.md) |
 
 ## Provisioning
 
-Infrastructure (GCE, IAM, Secret Manager, Cloudflare DNS, Tailscale auth
-keys) is declared in [`tofu/exe/`](../tofu/exe/) and applied with
-OpenTofu. This directory holds the artifacts the running stack consumes
-at runtime.
+Infrastructure (GCE, IAM, Secret Manager, Cloudflare DNS, Tailscale
+auth keys, Artifact Registry, Workload Identity Federation) is
+declared in [`../tofu/exe/`](../tofu/exe/) and applied with
+OpenTofu. This directory holds the runtime artifacts the stack
+consumes (template HCL, ACL, scripts).
 
 ## Architecture
 
@@ -56,3 +57,13 @@ Legend / 凡例:
 - Cloudflare Access: 認証付きリバースプロキシ
 - Zero Trust: ゼロトラストアクセス
 - dotfiles repo: 本リポジトリ
+
+## Related docs
+
+- [`docs/architecture.md`](./docs/architecture.md) — full
+  architecture with trust boundary table
+- [`docs/runbook.md`](./docs/runbook.md) — operator playbook
+- [`../docs/intent.md`](../docs/intent.md) — requester intent
+  (why this stack exists)
+- [`../docs/adr/`](../docs/adr/) — Architecture Decision Records
+- [`../tofu/exe/README.md`](../tofu/exe/README.md) — IaC overview

--- a/exe/cloudflared/README.md
+++ b/exe/cloudflared/README.md
@@ -2,10 +2,31 @@
 
 Cloudflare Tunnel ingress configuration for `exe.hironow.dev`.
 
-- `config.yaml` — ingress rules (added in subsequent commits)
-- `cert.pem` / `*.json` — credentials, never committed (gitignored).
-  The real values live in GCP Secret Manager; the tunnel daemon
-  retrieves them at startup.
+The tunnel and its ingress rules are managed entirely by OpenTofu
+(see [`../../tofu/exe/cloudflare.tf`](../../tofu/exe/cloudflare.tf))
+— there are no static config files in this directory. Tunnel
+credentials live in GCP Secret Manager
+(`exe-cloudflared-credentials`); the `cloudflared` daemon on the
+control-plane VM fetches them at startup via `gcloud secrets
+versions access`.
 
-Tunnel routing target: the Coder workspace's HTTP/SSH ports, exposed
-only to identities authenticated by Cloudflare Access (Zero Trust).
+## Ingress rules
+
+Defined in `cloudflare_zero_trust_tunnel_cloudflared_config.exe`:
+
+| Hostname | Origin | Notes |
+|---|---|---|
+| `exe.hironow.dev` | `http://localhost:7080` | Coder UI, gated by Cloudflare Access OIDC; only `var.owner_email` is admitted |
+| catch-all | `http_status:404` | Returns 404 for anything not matched (incl. accidental `*.sandbox.hironow.dev` until P-mode lands) |
+
+Both real routes use `http2_origin = true` and
+`no_tls_verify = true` (loopback origin, TLS terminates at the CF
+edge).
+
+## Related docs
+
+- [`../docs/architecture.md`](../docs/architecture.md) — full edge / tunnel diagram and trust boundary table
+- [`../docs/runbook.md`](../docs/runbook.md) — operator workflow
+  (tunnel credential rotation, debugging tunnel state)
+- [`../../tofu/exe/cloudflare.tf`](../../tofu/exe/cloudflare.tf)
+  — actual IaC

--- a/exe/coder/README.md
+++ b/exe/coder/README.md
@@ -1,13 +1,31 @@
 # exe/coder/
 
-Coder workspace template for `exe.hironow.dev`.
+Coder workspace templates for `exe.hironow.dev`.
 
-The template is based on
+The active template is based on
 [`coder/coder/examples/templates/gcp-vm-container`](https://github.com/coder/coder/tree/main/examples/templates/gcp-vm-container)
-and references this repository's `.devcontainer/devcontainer.json` so
-that workspace == CI environment.
+(per [ADR 0002](../../docs/adr/0002-coder-prebuilt-image.md)) and
+runs the prebuilt dev container image from Artifact Registry.
+Workspace == CI environment because the same
+`.devcontainer/devcontainer.json` drives both.
 
-Files (added in subsequent commits):
+## Layout
 
-- `template.tf` — Coder template definition
-- `startup.sh` — VM startup script (mise install, just install-hooks)
+| Path | Purpose |
+|---|---|
+| [`templates/dotfiles-devcontainer/`](./templates/dotfiles-devcontainer/) | Active workspace template (`main.tf` + lockfile + README) |
+
+## Related docs
+
+- [`../docs/architecture.md`](../docs/architecture.md) — full
+  `exe.hironow.dev` architecture (Cloudflare + Tailscale + Coder + GCP)
+- [`../docs/runbook.md`](../docs/runbook.md) — operator workflow
+  (`cdr templates push`, smoke, key rotation)
+- [`../scripts/`](../scripts/) — `cdr` wrapper used by this
+  template's push procedure
+- [`../../tofu/exe/coder.tf`](../../tofu/exe/coder.tf) — control-
+  plane VM that hosts the Coder server this template registers with
+- [`../../docs/adr/0002-coder-prebuilt-image.md`](../../docs/adr/0002-coder-prebuilt-image.md)
+  — why prebuilt image instead of envbuilder
+- [`../../docs/adr/0007-coder-server-install-hardening.md`](../../docs/adr/0007-coder-server-install-hardening.md)
+  — Coder server install pinning

--- a/exe/coder/templates/dotfiles-devcontainer/README.md
+++ b/exe/coder/templates/dotfiles-devcontainer/README.md
@@ -87,3 +87,24 @@ Parameters (interactive on first create unless `--parameter` is passed):
 cdr workspaces list                # status: starting -> running (~30-60s)
 cdr ssh my-ws.dev -- just --list   # JustSandbox recipes available
 ```
+
+## Related docs
+
+- [`../../README.md`](../../README.md) — `exe/coder/` overview
+- [`../../../README.md`](../../../README.md) — `exe/` overview
+- [`../../../docs/architecture.md`](../../../docs/architecture.md)
+  — full exe.hironow.dev architecture and trust boundary table
+- [`../../../docs/runbook.md`](../../../docs/runbook.md)
+  — `cdr templates push` / pre-merge image-tag testing
+- [`../../../../README.md`](../../../../README.md) — top-level
+  repo README (architecture overview + doc tree)
+- [`../../../../docs/adr/0002-coder-prebuilt-image.md`](../../../../docs/adr/0002-coder-prebuilt-image.md)
+  — why prebuilt image instead of envbuilder
+- [`../../../../docs/adr/0004-workspace-tailnet-routing.md`](../../../../docs/adr/0004-workspace-tailnet-routing.md)
+  — why workspace VMs reach Coder over the tailnet (B-plan)
+- [`../../../../docs/adr/0005-install-path-rationalization.md`](../../../../docs/adr/0005-install-path-rationalization.md)
+  — install.sh OS dispatch + step\_\* helpers
+- [`../../../../docs/adr/0006-mise-version-pinning.md`](../../../../docs/adr/0006-mise-version-pinning.md)
+  — mise.toml pins + `MISE_DATA_DIR=/opt/mise` relocation
+- [`../../../../docs/adr/0007-coder-server-install-hardening.md`](../../../../docs/adr/0007-coder-server-install-hardening.md)
+  — Coder server install pinning

--- a/exe/docs/README.md
+++ b/exe/docs/README.md
@@ -1,9 +1,23 @@
 # exe/docs/
 
-Documentation for `exe.hironow.dev` (added in subsequent commits):
+Documentation for `exe.hironow.dev`.
 
-- `architecture.md` — components, data flow, security boundaries
-- `runbook.md` — operational playbook (rotate keys, restart tunnel, scale VM)
+| File | Scope |
+|---|---|
+| [`architecture.md`](./architecture.md) | Components, data flow, security boundaries (Cloudflare + Tailscale + Coder + GCP) |
+| [`runbook.md`](./runbook.md) | Operational playbook (apply, smoke, rotate keys, push template, bump Coder) |
 
-Architectural decisions go in [`docs/adr/`](../../docs/adr/) at the
-repository root, not here.
+Architectural decisions go in [`../../docs/adr/`](../../docs/adr/)
+at the repository root — current state lives here, the "why" of
+each decision lives there. See
+[`docs-guidelines`](../../README.md) and
+[`adr-guidelines`](../../docs/adr/) in the project conventions.
+
+## Related docs
+
+- [`../README.md`](../README.md) — `exe/` directory layout
+- [`../coder/README.md`](../coder/README.md) — Coder template
+- [`../scripts/README.md`](../scripts/README.md) — `cdr` wrapper
+- [`../tailscale/README.md`](../tailscale/README.md) — ACL + tags
+- [`../cloudflared/README.md`](../cloudflared/README.md) — Tunnel
+- [`../../tofu/exe/README.md`](../../tofu/exe/README.md) — IaC

--- a/exe/docs/architecture.md
+++ b/exe/docs/architecture.md
@@ -40,10 +40,11 @@ This document describes the components currently provisioned by
                       | default VPC          |
                       | debian-12, e2-small  |
                       | tag:exe-workspace    |
-                      | tailscaled           |
-                      | envbuilder image     |
-                      | -> debian devcontainer|
-                      |    + Coder agent     |
+                      | tailscaled, docker   |
+                      | docker run prebuilt  |
+                      | dev container image  |
+                      | (from Artifact Reg)  |
+                      |   + Coder agent      |
                       +----------------------+
 ```
 
@@ -57,7 +58,7 @@ Legend / 凡例:
 - tag:exe-coder / tag:exe-workspace: Tailscale tag (ACL で関係を限定)
 - tailnet (WireGuard): exe-coder と workspace 間の internal channel
 - MagicDNS: tailnet 内 hostname 解決 (exe-coder → 100.x.x.x)
-- envbuilder image: dotfiles devcontainer (debian-12 + features)
+- prebuilt dev container image: GitHub Actions が main merge 時に build + push (Artifact Registry)、workspace VM は docker pull のみ。envbuilder は ADR 0002 で廃止
 - debian-12: VM ホスト OS / dev container ベース (共通)
 ```
 
@@ -154,7 +155,11 @@ loopback).
 ## Coder server
 
 Started by the VM startup-script as a background process (cos lacks
-systemd). Configuration is purely env-var driven:
+systemd). The Coder binary is fetched at the pinned
+`var.coder_version` and verified against `var.coder_sha256`
+(ADR 0007 supply-chain hardening — replaces the curl-piped install
+script and the GitHub-API `latest` fallback). Configuration is
+purely env-var driven:
 
 | Variable | Value | Purpose |
 |---|---|---|
@@ -169,10 +174,13 @@ systemd). Configuration is purely env-var driven:
 | `CODER_STRICT_TRANSPORT_SECURITY` | `31536000` | One-year HSTS |
 | `CODER_STRICT_TRANSPORT_SECURITY_OPTIONS` | `includeSubDomains;preload` | Cover sandbox subdomains and qualify for HSTS preload |
 
-Binary lives at `/var/lib/coder/coder` (downloaded from the GitHub
-release on first boot) and is symlinked to `/usr/local/bin/coder`.
-Embedded postgres state and Coder data live under `/var/lib/coder/`,
-which is on the boot disk (auto-deletes only on `tofu destroy`).
+Binary lives at `/usr/local/bin/coder` (extracted from the pinned
+release tarball at first boot, sha256-verified before extraction;
+`gh attestation verify` runs as defence-in-depth when gh is
+authenticated). Embedded postgres state and Coder data live under
+`/var/lib/coder/`, which is on the boot disk (auto-deletes only on
+`tofu destroy`). Bumping Coder is `var.coder_version` +
+`var.coder_sha256` + `just exe-apply` in lock-step.
 
 The first-boot admin password is generated to
 `/var/lib/coder/.admin_password` (mode 0600). Change it via the Coder
@@ -187,15 +195,26 @@ project's `default` VPC and joins the tailnet as `tag:exe-workspace`.
 - `provider "coder" { url = "http://exe-coder:7080" }` overrides
   `${ACCESS_URL}` per-template so the agent binary download
   resolves over the tailnet (CF Access edge bypass-free).
-- `git_branch` parameter wires `ENVBUILDER_GIT_BRANCH` (default
-  empty = repo HEAD).
+- VM startup_script installs three vendors via apt with **GPG
+  fingerprint pinning** for all three: Tailscale (observed
+  `2596A9...957F5868`), Google Cloud (`35BAA0...DC6315A3`),
+  Docker (`9DC858...0EBFCD88`). Mismatch fails the bootstrap
+  closed (no curl|bash, no `|| true`).
+- VM startup_script then `docker pull`s the prebuilt dev
+  container image from Artifact Registry, `docker run`s it with
+  `--volume /home/<user>:/root` (operator state persistence) and
+  `--network host` (tailnet visibility for the agent).
 - Agent startup_script exports `INSTALL_SKIP_HOMEBREW=1
-  INSTALL_SKIP_ADD_UPDATE=1` so dotfiles install.sh skips brew
-  install / brew-bundle replays and reaches `just deploy`. gcloud
-  arrives via the `google-cloud-cli` devcontainer feature so
-  install.sh's `command -v gcloud` short-circuits naturally.
+  INSTALL_SKIP_ADD_UPDATE=1` (belt-and-suspenders; ADR 0005
+  install.sh OS dispatch already auto-skips Mac-only steps on
+  Linux), then `MISE_OFFLINE=1 mise install` against the workspace
+  mise.toml. The mise data dir is `/opt/mise` (ADR 0006 relocation)
+  so the build-time-baked installs survive the `/root` overlay
+  mask.
 - Workspace VM runs as `exe-workspace@…` (not the default compute
-  SA). Only the workspace tailnet authkey is readable.
+  SA). Holds `roles/secretmanager.secretAccessor` on the workspace
+  tailnet authkey and `roles/artifactregistry.reader` on the
+  dotfiles repo (for docker pull).
 
 ## Out of scope
 

--- a/exe/docs/runbook.md
+++ b/exe/docs/runbook.md
@@ -96,13 +96,29 @@ cdr ssh my-ws.dev
 cdr delete my-ws --yes
 ```
 
-Pre-merge testing of dev container changes (otherwise envbuilder
-clones the repo's default branch):
+Pre-merge testing of dev container changes:
 
-```bash
-cdr create my-ws --template exe-dotfiles-devcontainer \
-  --parameter git_branch=feat/<branch-name> --yes
-```
+1. Push the branch and let `publish-devcontainer.yaml` build a
+   `:<sha>` image into Artifact Registry (or run a local
+   `devcontainer build` and push manually).
+2. Push a throwaway template version pinning that sha:
+
+   ```bash
+   cdr templates push exe-dotfiles-devcontainer \
+     -d exe/coder/templates/dotfiles-devcontainer \
+     --variable image=$(just exe-output -raw artifact_registry_repo)/devcontainer:<sha> \
+     --variable project_id=gen-ai-hironow \
+     --variable workspace_sa_email=$(just exe-output -raw exe_workspace_sa_email) \
+     --variable coder_internal_url=$(just exe-output -raw coder_internal_url) \
+     --yes
+   cdr create my-ws --template exe-dotfiles-devcontainer --yes
+   ```
+
+3. Once verified, push another version with `:main` to revert.
+
+The previous `git_branch` parameter (envbuilder-only) is gone:
+the prebuilt-image template doesn't clone at workspace boot;
+operator branch testing happens via the image tag instead.
 
 ## Tailscale auth-key rotation
 

--- a/exe/docs/runbook.md
+++ b/exe/docs/runbook.md
@@ -175,9 +175,13 @@ arguments.
 ### Setup (once)
 
 ```bash
-# 1. Install the Coder CLI.
+# 1. Install the Coder CLI via Homebrew. Mac is assumed to have
+#    Homebrew preinstalled (per ADR 0005). The upstream
+#    `curl https://coder.com/install.sh | sh` convenience installer
+#    is intentionally NOT recommended here — the same TOFU concerns
+#    that drove ADR 0007 on the control-plane VM apply to operator
+#    machines too.
 brew install coder/coder/coder
-# or: curl -fsSL https://coder.com/install.sh | sh
 
 # 2. Symlink the cdr wrapper into ~/.local/bin.
 just exe-cdr-install

--- a/exe/scripts/README.md
+++ b/exe/scripts/README.md
@@ -1,9 +1,27 @@
 # exe/scripts/
 
-Operational scripts for `exe.hironow.dev` (added in subsequent commits):
+Operational scripts for `exe.hironow.dev`.
 
-- `bootstrap.sh` — first-time provisioning (tofu apply + cloudflared login)
-- `teardown.sh` — destroy GCE workspace, keep Cloudflare/Tailscale state
-- `smoke.sh` — post-deploy connectivity checks (Tailscale up, CF Access OK, SSH reachable)
+## Files
+
+| Path | Purpose |
+|---|---|
+| [`cdr`](./cdr) | Wrapper around the upstream `coder` CLI. Fetches Cloudflare Access service-token credentials from Secret Manager (cached for 5 min), exports `CODER_HEADER_COMMAND`, then exec's `coder` with the original arguments. Symlinked into `~/.local/bin` via `just exe-cdr-install`. |
+| [`cdr-header`](./cdr-header) | Helper invoked by `cdr` via `CODER_HEADER_COMMAND` to emit the `CF-Access-*` headers Coder needs on every API call. |
+| [`bootstrap.sh`](./bootstrap.sh) | First-time provisioning helper (tofu apply + cloudflared tunnel login). Idempotent. |
+| [`teardown.sh`](./teardown.sh) | Destroys the GCE workspace VM and Coder template, retains Cloudflare + Tailscale state for re-bootstrap. Idempotent. |
+| [`smoke.sh`](./smoke.sh) | Post-deploy connectivity checks (Tailscale up, CF Access reachable, SSH reachable, Coder UI 200). Idempotent. |
 
 All scripts must be idempotent (per `scripts-guidelines` in CLAUDE.md).
+
+## Related docs
+
+- [`../docs/runbook.md`](../docs/runbook.md) — day-to-day operator
+  workflow (uses `cdr` for every Coder API call)
+- [`../docs/architecture.md`](../docs/architecture.md) — full
+  exe.hironow.dev architecture
+- [`../coder/templates/dotfiles-devcontainer/README.md`](../coder/templates/dotfiles-devcontainer/README.md)
+  — workspace template; `cdr templates push` is the deployment path
+- [`../../tests/test_cdr_wrapper.py`](../../tests/test_cdr_wrapper.py)
+  — regression tests for `cdr` (secret refresh, cleanup-on-failure,
+  empty-payload guard)

--- a/exe/tailscale/README.md
+++ b/exe/tailscale/README.md
@@ -2,15 +2,34 @@
 
 Tailscale ACL and tag definitions for `exe.hironow.dev`.
 
-Tag model (Pattern A — tagged auth keys):
+## Tag model (Pattern A — tagged auth keys)
 
 | Tag | Holder | Permitted destinations |
 |---|---|---|
-| `tag:owner` | hironow's devices | `*:*` |
-| `tag:agent` | AI agents | `tag:exe-coder:22,80,443` only |
+| `tag:owner` | hironow's personal devices | `*:*` (full tailnet) |
+| `tag:exe-coder` | the Coder control-plane VM | `tag:exe-coder:*` (loopback over tailnet) |
+| `tag:exe-workspace` | Coder workspace VMs | `tag:exe-coder:7080` (agent download + protocol — see [ADR 0004](../../docs/adr/0004-workspace-tailnet-routing.md)) |
+| `tag:agent` | AI agents | `tag:exe-coder:22,80,443,3000-3999` |
 
-Files (added in subsequent commits):
+## Files
 
-- `acl.hujson` — full ACL document
-- `*.authkey` — generated tagged keys, never committed
-  (provisioned via OpenTofu into Secret Manager)
+| Path | Purpose |
+|---|---|
+| [`acl.hujson`](./acl.hujson) | Full ACL document, bound by `tailscale_acl.this` (`prevent_destroy`, `overwrite_existing_content`) |
+
+Auth keys themselves are **never** committed here — they are
+provisioned by OpenTofu into GCP Secret Manager
+(`exe-tailscale-coder-authkey`, `exe-tailscale-workspace-authkey`,
+`exe-tailscale-agent-authkey`) and rotated every 90 days via
+`time_rotating.tailscale_keys` in
+[`../../tofu/exe/tailscale.tf`](../../tofu/exe/tailscale.tf).
+
+## Related docs
+
+- [`../docs/architecture.md`](../docs/architecture.md) — full
+  tailnet topology and trust boundary table
+- [`../../docs/adr/0004-workspace-tailnet-routing.md`](../../docs/adr/0004-workspace-tailnet-routing.md)
+  — why workspace VMs reach the Coder server over the tailnet
+  instead of the public CF Access edge (B-plan)
+- [`../../tofu/exe/tailscale.tf`](../../tofu/exe/tailscale.tf)
+  — actual auth-key + ACL IaC

--- a/tests/README.md
+++ b/tests/README.md
@@ -194,8 +194,26 @@ Tests are designed to run in CI environments:
 
 | File | Description |
 |------|-------------|
-| `.devcontainer/devcontainer.json` | Dev container declaration (image + features) |
-| `scripts/sync_agents.py` | Python script for sync-agents (PEP 723) |
-| `justfile` | Commands being tested |
-| `ROOT_AGENTS.md` | Base agent instruction file |
-| `ROOT_AGENTS_*.md` | Additional agent files (path-converted) |
+| [`../.devcontainer/devcontainer.json`](../.devcontainer/devcontainer.json) | Dev container declaration (image + features) |
+| [`../scripts/sync_agents.py`](../scripts/sync_agents.py) | Python script for sync-agents (PEP 723) |
+| [`../justfile`](../justfile) | Commands being tested |
+| [`../ROOT_AGENTS.md`](../ROOT_AGENTS.md) | Base agent instruction file |
+
+## Related docs
+
+- [`../README.md`](../README.md) — repo overview + architecture
+- [`../docs/adr/0001-devcontainer-debian-features.md`](../docs/adr/0001-devcontainer-debian-features.md)
+  — why debian-12 + curated features for the test container
+- [`../exe/docs/architecture.md`](../exe/docs/architecture.md)
+  — exe.hironow.dev (some tests under `tests/exe/` exercise its
+  IaC heredocs)
+
+> [!NOTE]
+> **Beyond `test_sync_agents.py`**: this directory now hosts many
+> more test files (devcontainer runtime smokes, install.sh OS
+> dispatch, mise pin consistency, /opt/mise relocation,
+> publish-workflow / cdr-wrapper / vm-bootstrap regressions, exe
+> startup-script extraction). The detailed walkthrough above is
+> kept for the original sync-agents flow; refer to each
+> `tests/test_*.py` file's module docstring for that test's
+> contract.

--- a/tofu/README.md
+++ b/tofu/README.md
@@ -13,4 +13,15 @@ isolated stack with its own backend / state file.
 - Remote state in GCS bucket per stack; state encryption enabled.
 - `terraform.tfvars` is gitignored. Real values live in GCP Secret
   Manager and are wired in via `data "google_secret_manager_secret_version"`.
+- `.terraform.lock.hcl` IS tracked (HashiCorp recommends this; per
+  [PR #62](https://github.com/hironow/dotfiles/pull/62)). The
+  runtime cache dir `.terraform/` and state files stay ignored.
 - Run `tofu fmt -recursive` before commit.
+
+## Related docs
+
+- [`exe/README.md`](./exe/README.md) — exe.hironow.dev stack
+  (variables, files, lifecycle, state)
+- [`../exe/docs/architecture.md`](../exe/docs/architecture.md)
+  — full architecture and trust boundary table for the stack
+- [`../docs/adr/`](../docs/adr/) — Architecture Decision Records

--- a/tofu/exe/README.md
+++ b/tofu/exe/README.md
@@ -7,25 +7,33 @@ OpenTofu stack provisioning `exe.hironow.dev`.
 | Variable | Default | Description |
 |---|---|---|
 | `gcp_project_id` | `gen-ai-hironow` | GCP project (single-project, single-stack) |
-| `gcp_region` | `asia-northeast1` | (TBD) |
-| `gcp_zone` | `asia-northeast1-a` | (TBD) |
+| `gcp_region` | `asia-northeast1` | Primary region |
+| `gcp_zone` | `asia-northeast1-a` | Primary zone |
 | `domain` | `exe.hironow.dev` | Cloudflare-managed apex |
 | `tailnet` | (from `tailscale_token` secret) | Tailscale tailnet identifier |
+| `coder_version` | `v2.31.11` | Pinned Coder server release tag (see [ADR 0007](../../docs/adr/0007-coder-server-install-hardening.md)) |
+| `coder_sha256` | `32cf14...8430` | Sha256 of `coder_<ver>_linux_amd64.tar.gz` from the release's `checksums.txt` |
 
-## Files (added in subsequent commits)
+## Files
 
-- `main.tf` — backend, providers, locals
-- `variables.tf` — input variables
-- `coder.tf` — GCE + Coder workspace (gcp-vm-container template)
-- `tailscale.tf` — tagged auth keys, ACL bootstrap
-- `cloudflare.tf` — Tunnel + Access policy + DNS records
-- `outputs.tf` — workspace URL, tailnet IP, tunnel ID
+| Path | Purpose |
+|---|---|
+| [`main.tf`](./main.tf) | Backend (GCS), providers, locals |
+| [`variables.tf`](./variables.tf) | Input variables (incl. Coder pin) |
+| [`outputs.tf`](./outputs.tf) | Workspace SA email, AR repo, control-plane URL |
+| [`coder.tf`](./coder.tf) | Control-plane VM startup_script (Coder server install + cloudflared + tailscaled, with apt-key fingerprint pin per [PR #61](https://github.com/hironow/dotfiles/pull/61)) |
+| [`tailscale.tf`](./tailscale.tf) | Tagged auth keys, ACL bootstrap, 90-day rotation |
+| [`cloudflare.tf`](./cloudflare.tf) | Tunnel + Access policy + DNS records |
+| [`artifact_registry.tf`](./artifact_registry.tf) | Dev container image AR repo (`devcontainer:main` + `devcontainer:<sha>`) |
+| [`iam.tf`](./iam.tf) | Workload Identity Federation (GHA → AR) + workspace SA |
+| [`locals.tf`](./locals.tf) | Hostnames, tag names |
+| [`.terraform.lock.hcl`](./.terraform.lock.hcl) | Provider plugin lockfile (tracked per [PR #62](https://github.com/hironow/dotfiles/pull/62)) |
 
 ## State
 
 Backend: GCS bucket `gs://gen-ai-hironow-tofu-state/exe/`
 (bucket creation is a one-time bootstrap step; see
-`exe/scripts/bootstrap.sh`).
+[`../../exe/scripts/bootstrap.sh`](../../exe/scripts/bootstrap.sh)).
 
 State encryption: native `tofu` state encryption (1.7+) with passphrase
 from `~/.config/tofu/exe.passphrase` (700 mode, gitignored).
@@ -37,3 +45,16 @@ just exe-plan    # tofu plan
 just exe-apply   # tofu apply
 just exe-down    # tofu destroy (keeps state)
 ```
+
+## Related docs
+
+- [`../../exe/docs/architecture.md`](../../exe/docs/architecture.md)
+  — full architecture diagram and trust boundary table
+- [`../../exe/docs/runbook.md`](../../exe/docs/runbook.md) —
+  operator workflow (apply, smoke, key rotation, Coder bump)
+- [`../../docs/adr/`](../../docs/adr/) — architectural decisions
+  (debian-12 dev container, prebuilt image, Actions hardening,
+  tailnet routing, install path, mise pinning, Coder hardening)
+- [`../../tests/exe/test_startup_script.py`](../../tests/exe/test_startup_script.py)
+  — heredoc extraction + bash lint + systemd-analyze for the
+  control-plane startup script

--- a/tools/README.md
+++ b/tools/README.md
@@ -4,7 +4,14 @@
 
 ## ディレクトリ構成
 
-- **[rttm](./rttm)**: RTTM ファイルを ELAN (EAF) 形式に変換したり、可視化したりする Python ツール。
-- **[simple-server](./simple-server)**: Go 言語で書かれた簡易サーバー。
+- **[rttm](./rttm/README.md)**: RTTM ファイルを ELAN (EAF) 形式に変換したり、可視化したりする Python ツール
+- **[simple-server](./simple-server/README.md)**: Go 言語で書かれた簡易サーバー (ローカル HTTPS のテスト用)
+- **[tmux](./tmux/CHEATSHEET.md)**: tmux のキーバインド早見表
 
-各ツールの詳細な使用方法については、それぞれのディレクトリ内の `README.md` (存在する場合) またはソースコードを参照してください。
+各ツールの詳細な使用方法については、それぞれのディレクトリ内の
+`README.md` (存在する場合) またはソースコードを参照してください。
+
+## Related docs
+
+- [`../README.md`](../README.md) — リポジトリ全体のアーキテクチャと
+  doc tree のエントリポイント


### PR DESCRIPTION
## Summary

Documentation refresh reflecting the changes that landed in
PRs #57, #59, #60, #61, #62. No code changes.

## What changed

### \`README.md\`

- New **Architecture overview** section near the top with a
  simple ASCII diagram showing the three environments — Mac
  host, dev container, Coder workspace — converging on the
  shared SoT (\`mise.toml\` + \`devcontainer.json\` + \`install.sh\` +
  \`dump/\`).
- **Relative links to detail docs**:
  \`docs/intent.md\`, \`docs/adr/\`, \`exe/docs/architecture.md\`,
  \`exe/docs/runbook.md\`,
  \`exe/coder/templates/dotfiles-devcontainer/README.md\`,
  \`exe/scripts/README.md\`, \`tools/README.md\`.
- **Dev Container section**: drops the envbuilder language;
  the workspace template uses a prebuilt image per ADR 0002.
- **Installation note**: clarifies that Mac assumes Homebrew is
  preinstalled (per ADR 0005 install.sh OS dispatch decision).

### \`exe/docs/architecture.md\`

- **Component-map ASCII** updated: drops the "envbuilder image"
  workspace VM line and shows the docker-pull / docker-run flow
  on a debian-12 host instead.
- **Coder server section** reflects the tag-pin + sha256 verify
  install path (ADR 0007) instead of the pre-pin curl|sh.
- **Workspace template section** reflects the apt-key
  fingerprint pin trio (Tailscale + Google Cloud + Docker) and
  the \`/opt/mise\` data-dir relocation.

### \`exe/docs/runbook.md\`

- **Pre-merge dev container test path** rewritten to image-tag-
  based testing. The envbuilder \`git_branch\` parameter is
  gone — operator branch testing happens via the image tag.

## Why now

ADR 0005/0006/0007 implementation is fully landed (#60, #61, #62)
and operator-verified. Documentation was lagging the code. This
PR closes that gap before any new work starts.

## Out of scope

- \`docs/handover.md\` (gitignored, refreshed locally only).
- The Coder template README at \`exe/coder/templates/.../README.md\`
  — already current; no changes needed.