### PR TITLE
docs: explain why tailscale CLI is intentionally absent from workspace container

### DIFF
--- a/exe/docs/architecture.md
+++ b/exe/docs/architecture.md
@@ -75,6 +75,49 @@ Legend / 凡例:
 | exe-coder → GCP APIs | VM identity | SA `exe-coder@…` (Secret Manager accessor on tailnet/tunnel secrets, compute.instanceAdmin, iam.serviceAccountUser, logging/monitoring) |
 | Workspace → GCP APIs | VM identity | SA `exe-workspace@…` (only the workspace authkey; logging/monitoring) |
 | Public internet → workspace VM | NONE | `deny_all_ingress` firewall + no public ports listening |
+| Workspace **container** → tailnet RPC | NONE (intentional) | `tailscaled` Unix socket is **not** mounted into the container; `tailscale` CLI is **not** installed in the dev container image |
+
+### Why no tailscale CLI inside the workspace container
+
+The workspace VM joins the tailnet at the **host** layer (apt-
+installed `tailscale`, fingerprint-pinned per
+[`PR #61`](https://github.com/hironow/dotfiles/pull/61)). The dev
+container runs with `--network host`, so:
+
+- **Outbound tailnet reach works without a CLI.** Container
+  processes can `curl http://gpu-host.tailnet:8080` directly —
+  the host's resolver handles MagicDNS, and the host's
+  WireGuard tunnel handles the transport.
+- **Inbound exposure works without a CLI.** A web server bound
+  inside the container (e.g. `python -m http.server :8080`) is
+  reachable at `<vm-host>.tailnet:8080` because of host-network
+  sharing. No `tailscale serve` needed for plain tailnet-private
+  access.
+
+The `tailscale` CLI is intentionally NOT installed in the
+container, and the host's `/var/run/tailscale/tailscaled.sock`
+is intentionally NOT mounted. Reason: the socket is a
+control-plane endpoint with **no per-command auth**. Anything
+with socket access can `tailscale serve --funnel` (public
+internet exposure), `tailscale logout` (DoS the VM), or
+`tailscale ssh hironow@<other-node>` (lateral move using the
+VM's `tag:exe-workspace` identity, or worse, `tag:owner` via
+ACL escalation paths). For an environment that runs AI agents
+inside the container, granting that level of authority to any
+in-container process is unacceptable.
+
+If `tailscale serve --funnel` or other CLI-only operations are
+needed, run them from the **VM host shell** instead:
+
+```bash
+gcloud compute ssh coder-<owner>-<workspace>-root \
+  --zone=asia-northeast1-a \
+  --command='sudo tailscale serve --bg http://localhost:8080'
+```
+
+This requires explicit operator action (gcloud auth + sudo) and
+is auditable; an AI agent running inside the container cannot
+reach this path.
 
 ## State and secrets
 

--- a/exe/docs/runbook.md
+++ b/exe/docs/runbook.md
@@ -120,6 +120,39 @@ The previous `git_branch` parameter (envbuilder-only) is gone:
 the prebuilt-image template doesn't clone at workspace boot;
 operator branch testing happens via the image tag instead.
 
+## `tailscale serve` / `tailscale funnel` from a workspace
+
+The workspace dev container intentionally does **not** ship the
+`tailscale` CLI, and the host's `tailscaled` Unix socket is not
+mounted into the container — see the rationale in
+[architecture.md](./architecture.md#why-no-tailscale-cli-inside-the-workspace-container).
+
+If you want to expose a workspace-side dev server over the
+tailnet (or via Tailscale Funnel for a public HTTPS URL), run
+the command from the **VM host shell**, not from inside the
+container:
+
+```bash
+# Tailnet-private exposure
+gcloud compute ssh coder-<owner>-<workspace>-root \
+  --zone=asia-northeast1-a \
+  --command='sudo tailscale serve --bg http://localhost:8080'
+
+# Public Funnel (HTTPS via Tailscale's funnel endpoint)
+gcloud compute ssh coder-<owner>-<workspace>-root \
+  --zone=asia-northeast1-a \
+  --command='sudo tailscale funnel --bg 8080'
+
+# Tear down
+gcloud compute ssh coder-<owner>-<workspace>-root \
+  --zone=asia-northeast1-a \
+  --command='sudo tailscale serve --reset'
+```
+
+This forces explicit, auditable operator action (gcloud auth +
+sudo) and prevents an AI agent inside the container from
+silently exposing a port to the public internet.
+
 ## Tailscale auth-key rotation
 
 The keys rotate automatically every 90 days because of:


### PR DESCRIPTION
## Summary

Records the security decision NOT to install the \`tailscale\`
CLI inside the workspace dev container, and NOT to bind-mount
the host's \`tailscaled\` Unix socket into the container. The
behaviour is already correct on \`main\`; this PR just documents
the rationale so a future contributor doesn't undo the boundary
by "helpfully" adding the mount.

## What changed

### \`exe/docs/architecture.md\`

- New row in the **Boundaries and trust** table:
  \`Workspace container → tailnet RPC | NONE (intentional)\`
- New \`### Why no tailscale CLI inside the workspace container\`
  subsection covering:
  - Why outbound tailnet reach + inbound exposure already work
    via \`--network host\` (no CLI needed for the common cases)
  - Why mounting \`/var/run/tailscale/tailscaled.sock\` into the
    container would be unsafe (the socket is a control-plane
    endpoint with no per-command auth — anything inside the
    container could \`tailscale serve --funnel\`,
    \`tailscale logout\`, or \`tailscale ssh\` other nodes)
  - The escape hatch: run those commands from the VM host shell
    via \`gcloud compute ssh ... --command='sudo tailscale serve
    ...'\`

### \`exe/docs/runbook.md\`

- New \`## tailscale serve / tailscale funnel from a workspace\`
  section pointing operators at the VM-host workflow with
  copy-pasteable \`gcloud compute ssh\` invocations.

## Why now

The post-#61 / #62 / #63 workspace smoke run found
\`which tailscale\` exits non-zero inside the container. That's
the **intended** behaviour, but it was undocumented — the next
operator (or AI agent) might "fix" it by adding the CLI and
socket mount, which would silently weaken the trust boundary.

Captured as a decision in the trust-boundary table + a rationale
block + an operator escape hatch in the runbook.

## Discussion that led here

```
operator: tailscale CLI がないと workspace で起動した web app や
          外部 GPU マシンの LLM を使えないのでは？
assistant: --network host のおかげで CLI なしでも:
          - 外部 tailnet ホストへの curl は通る
          - workspace 起動 web app は host network 経由で reach 可能
          CLI が要るのは tailscale serve / funnel / status / ssh
          の管理コマンド。
operator: なるほど、ならあえて CLI を入れない方がセキュア？
assistant: 入れない方がセキュア。socket mount すると container 内
          のすべてのプロセスが host tailscale daemon の管理権限を
          持つ。AI agent が走る前提では認められない。
operator: そうしよう。
```

## Out of scope

- No code changes. The trust boundary already exists; this PR
  just records *why*.
- The Tailscale 3-key rotation automation question (still open
  per ADR 0004 follow-up) is separate.