### PR TITLE
docs(runbook): document AI CLI auth flows and CF Access edge constraint

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,14 +24,14 @@ differs.
            +----------+-----------+------------+-----------+
                                               |
                                               v
-                          +-----------------------------------+
+                          +-------------------------------------+
                           |  Single source of truth (this repo) |
                           |                                     |
                           |  - install.sh        (OS dispatch)  |
                           |  - mise.toml         (tool pins)    |
                           |  - .devcontainer/    (image SoT)    |
                           |  - dump/             (brew/gcloud)  |
-                          +-----------------------------------+
+                          +-------------------------------------+
 ```
 
 ```
@@ -41,7 +41,7 @@ Legend / 凡例:
 - Dev container: .devcontainer/devcontainer.json + features/dotfiles-tools をビルドした image (CI とローカル IDE で同一)
 - Coder workspace: exe.hironow.dev で立ち上がる cloud dev 環境。Artifact Registry 上の prebuilt image を docker pull する
 - install.sh OS dispatch: uname → mac / linux / windows で step_* 関数を切り替える (ADR 0005)
-- mise.toml: just / uv / prek / vp / markdownlint-cli2 を 3 OS 同一バージョンに pin (ADR 0006)
+- mise.toml: just / uv / prek / vp / markdownlint-cli2 / node + 5 AI CLI (codex / gemini / claude / copilot / pi) を 3 OS 同一バージョンに pin (ADR 0006)
 - .devcontainer/: dev container 仕様の SoT (debian-12 + Microsoft-curated features + ローカル feature)
 - Artifact Registry: GitHub Actions が main merge 時に WIF 認証で image push、Coder workspace VM が docker pull
 ```
@@ -150,9 +150,12 @@ features + local `dotfiles-tools` feature). The same file drives CI
 (prebuilt image pulled from Artifact Registry — no envbuilder per
 [ADR 0002](./docs/adr/0002-coder-prebuilt-image.md)), so all three
 environments stay aligned. Open it to get an isolated environment
-with `just`, `mise`, `prek`, `ruff`, `shellcheck`, and
-`markdownlint-cli2` already provisioned — useful as an AI agent
-sandbox for `just fmt|lint|check|test`.
+with `just`, `mise`, `prek`, `ruff`, `shellcheck`,
+`markdownlint-cli2`, Node.js 24, and 5 AI agent CLIs
+(`codex`, `gemini`, `claude`, `copilot`, `pi`) already provisioned
+— useful as an AI agent sandbox for `just fmt|lint|check|test`.
+Auth for the AI CLIs is operator-side and runs once per workspace;
+see [`exe/docs/runbook.md`](./exe/docs/runbook.md#ai-agent-cli-authentication).
 
 - **Claude Code**: run `/devcontainer`
 - **VS Code / Cursor**: install the Dev Containers extension, then `Reopen in Container`

--- a/exe/coder/templates/dotfiles-devcontainer/README.md
+++ b/exe/coder/templates/dotfiles-devcontainer/README.md
@@ -81,11 +81,30 @@ Parameters (interactive on first create unless `--parameter` is passed):
 | `instance_type` | `e2-small` | `e2-micro` is now viable (no envbuilder) |
 | `dotfiles_uri` | `https://github.com/hironow/dotfiles.git` | runs `coder dotfiles` on top of the prebuilt image |
 
+## What's in the workspace image
+
+The prebuilt image bakes the dev container's `dotfiles-tools`
+feature, so a fresh workspace boots with these on PATH:
+
+| Category | Tools |
+|---|---|
+| Core | `just`, `mise`, `uv`, `sheldon`, `gcloud`, `git`, `docker` (cli-only) |
+| Lint / format | `ruff`, `shellcheck`, `markdownlint-cli2`, `prek` |
+| Runtime | `node` 24.15.0, `python` 3 (via mise/devcontainer) |
+| AI agent CLIs | `codex`, `gemini`, `claude`, `copilot`, `pi` (auth on first use — see [runbook](../../../docs/runbook.md#ai-agent-cli-authentication)) |
+
+Versions are pinned in [`mise.toml`](../../../../mise.toml) per
+[ADR 0006](../../../../docs/adr/0006-mise-version-pinning.md).
+
 ## Smoke
 
 ```bash
 cdr workspaces list                # status: starting -> running (~30-60s)
 cdr ssh my-ws.dev -- just --list   # JustSandbox recipes available
+cdr ssh my-ws.dev -- '
+  for cli in codex gemini claude copilot pi; do
+    printf "%s: " "$cli"; "$cli" --version 2>&1 | head -1
+  done'
 ```
 
 ## Related docs

--- a/exe/docs/architecture.md
+++ b/exe/docs/architecture.md
@@ -254,6 +254,12 @@ project's `default` VPC and joins the tailnet as `tag:exe-workspace`.
   mise.toml. The mise data dir is `/opt/mise` (ADR 0006 relocation)
   so the build-time-baked installs survive the `/root` overlay
   mask.
+- The image bakes the dotfiles tool set + 5 AI agent CLIs
+  (`codex`, `gemini`, `claude`, `copilot`, `pi`) + Node.js 24.15.0
+  for the npm-backed shebangs — all under `/opt/mise` so they
+  survive the volume mount. Auth is operator-side and runs once
+  per workspace; see the
+  [runbook](./runbook.md#ai-agent-cli-authentication).
 - Workspace VM runs as `exe-workspace@…` (not the default compute
   SA). Holds `roles/secretmanager.secretAccessor` on the workspace
   tailnet authkey and `roles/artifactregistry.reader` on the

--- a/exe/docs/runbook.md
+++ b/exe/docs/runbook.md
@@ -120,6 +120,77 @@ The previous `git_branch` parameter (envbuilder-only) is gone:
 the prebuilt-image template doesn't clone at workspace boot;
 operator branch testing happens via the image tag instead.
 
+## AI agent CLI authentication
+
+The dev container image (post-PR #65 / #66) ships with five AI
+agent CLIs pre-installed but **with no credentials baked in**.
+Each CLI needs the operator to authenticate once on first use of
+a workspace.
+
+### One-time per workspace
+
+| CLI | Auth command | Account / Provider | Token location |
+|---|---|---|---|
+| `codex` | `codex login` | OpenAI (ChatGPT account) | `~/.codex/` |
+| `gemini` | `gemini auth login` | Google (or `GEMINI_API_KEY` env, or shared `gcloud auth application-default`) | `~/.config/gcloud/` or `~/.gemini/` |
+| `claude` | run `claude`, then `/login` | Anthropic Console | `~/.claude/` |
+| `copilot` | `copilot auth` | GitHub (Copilot subscription required) | `~/.config/github-copilot/` |
+| `pi` | `pi auth` (per LLM provider API key) | OpenAI / Anthropic / etc. — multi-provider | `~/.config/pi/` |
+
+`/root` inside the container is bind-mounted to the host VM's
+`/home/<user>/`, which sits on a `auto_delete = false` boot disk
+— **token files persist across `cdr stop`, `cdr start`, `cdr
+restart`, and the preemptible 24h VM cycle.** Tokens are only
+lost when the workspace is `cdr delete`-d (disk destroyed).
+
+### CF Access edge consideration (browser-OAuth CLIs)
+
+`codex login`, `gemini auth login`, and `copilot auth` open a
+browser-based OAuth flow. The workspace itself is behind
+Cloudflare Access, so the OAuth callback **cannot be served from
+inside the container**. Modern CLIs work around this with the
+**device-code flow**:
+
+```text
+$ codex login
+Visit https://auth.openai.com/device and enter code: ABC-1234
+Waiting for authorization...
+```
+
+Complete the device-code flow in the operator's local browser.
+The CLI polls the provider's OAuth endpoint (outbound from the
+workspace, no inbound port required) and writes the token when
+the operator confirms in their browser.
+
+If a CLI offers no device-code flow, set the corresponding
+`*_API_KEY` env var instead (most CLIs accept that as an
+alternative auth):
+
+```bash
+export OPENAI_API_KEY=sk-...
+export ANTHROPIC_API_KEY=sk-ant-...
+export GEMINI_API_KEY=...
+```
+
+Persist these by adding to `~/.zshrc.local` or use `dotenvx`
+(already on the image) for encrypted-at-rest secrets.
+
+### Smoke after auth
+
+```bash
+cdr ssh my-ws.dev -- '
+  codex --version
+  gemini --version
+  claude --version
+  copilot --version
+  pi --version
+  node --version    # /opt/mise/shims/node, runtime for the 4 npm-backed CLIs
+'
+```
+
+All five binaries are baked into `:main` images post-PR #66 and
+respond to `--version` without auth.
+
 ## `tailscale serve` / `tailscale funnel` from a workspace
 
 The workspace dev container intentionally does **not** ship the


### PR DESCRIPTION
## Summary

Adds a new \`AI agent CLI authentication\` section to
\`exe/docs/runbook.md\` covering the operator-side auth recipe
for the five CLIs that PR #65 + #66 baked into the dev container
image.

## What changed

- **Per-CLI auth command + account provider + token location**
  for codex / gemini / claude / copilot / pi.
- **Token persistence semantics**: tokens survive \`cdr stop\`/
  \`start\`/\`restart\` and the preemptible 24h VM cycle because
  \`/home/<user>\` lives on the \`auto_delete = false\` boot disk.
  Only \`cdr delete\` loses them.
- **CF Access edge constraint**: browser-OAuth CLIs cannot serve
  a callback from inside the container (Cloudflare Access gates
  inbound). Use the **device-code flow** that modern CLIs
  provide, or set \`*_API_KEY\` env vars as an alternative.
- **Post-auth smoke recipe** verifying all five CLIs + node
  respond to \`--version\`.

## Why now

The smoke run on \`my-sixth-ws.dev\` confirmed all five CLIs
work end-to-end after PR #66 landed node. The next operator
who creates a workspace shouldn't have to discover the auth
flow + the CF Access edge nuance on their own.