### PR TITLE
docs: simplify post-#67 — trim duplication, fix stale facts, consolidate

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,13 +48,13 @@ Legend / 凡例:
 
 詳細は以下を参照:
 
-- [`docs/intent.md`](./docs/intent.md) — リクエスト元の意図
-- [`docs/adr/`](./docs/adr/) — Architecture Decision Records (0001–0007、debian-12 / prebuilt image / Actions 強化 / tailnet routing / install path / mise pin / Coder server hardening)
+- [`docs/adr/`](./docs/adr/) — Architecture Decision Records
 - [`exe/docs/architecture.md`](./exe/docs/architecture.md) — exe.hironow.dev 全体図 (Cloudflare + Tailscale + Coder + GCP)
 - [`exe/docs/runbook.md`](./exe/docs/runbook.md) — 運用手順 (operator workflow)
 - [`exe/coder/templates/dotfiles-devcontainer/README.md`](./exe/coder/templates/dotfiles-devcontainer/README.md) — Coder template の push / create
 - [`exe/scripts/README.md`](./exe/scripts/README.md) — `cdr` wrapper (CF Access service token 経由で `coder` CLI を実行)
 - [`tools/README.md`](./tools/README.md) — RTTM converter / simple server などの補助ツール
+- `docs/intent.md` — リクエスト元の意図 (operator-only, gitignored)
 
 ## Installation
 
@@ -65,7 +65,7 @@ bash -c "$(curl -fsSL https://raw.githubusercontent.com/hironow/dotfiles/main/in
 ```
 
 > [!NOTE]
-> Mac, Linux, Windows([WSL](https://learn.microsoft.com/en-us/windows/wsl/)内Linux)へ対応。Windows native (scoop) は OS dispatch hook のみで実装は TODO。
+> Mac, Linux, Windows([WSL](https://learn.microsoft.com/en-us/windows/wsl/)内Linux)へ対応。Windows native (scoop) は未対応。
 > Mac は Homebrew が前提条件 (操作者が手動で先にインストール)、それ以降は install.sh が自動。
 
 ## usage

--- a/exe/cloudflared/README.md
+++ b/exe/cloudflared/README.md
@@ -1,32 +1,10 @@
 # exe/cloudflared/
 
-Cloudflare Tunnel ingress configuration for `exe.hironow.dev`.
+Cloudflare Tunnel ingress for `exe.hironow.dev`. The tunnel +
+ingress rules are managed in
+[`../../tofu/exe/cloudflare.tf`](../../tofu/exe/cloudflare.tf);
+credentials live in Secret Manager (`exe-cloudflared-credentials`).
 
-The tunnel and its ingress rules are managed entirely by OpenTofu
-(see [`../../tofu/exe/cloudflare.tf`](../../tofu/exe/cloudflare.tf))
-— there are no static config files in this directory. Tunnel
-credentials live in GCP Secret Manager
-(`exe-cloudflared-credentials`); the `cloudflared` daemon on the
-control-plane VM fetches them at startup via `gcloud secrets
-versions access`.
-
-## Ingress rules
-
-Defined in `cloudflare_zero_trust_tunnel_cloudflared_config.exe`:
-
-| Hostname | Origin | Notes |
-|---|---|---|
-| `exe.hironow.dev` | `http://localhost:7080` | Coder UI, gated by Cloudflare Access OIDC; only `var.owner_email` is admitted |
-| catch-all | `http_status:404` | Returns 404 for anything not matched (incl. accidental `*.sandbox.hironow.dev` until P-mode lands) |
-
-Both real routes use `http2_origin = true` and
-`no_tls_verify = true` (loopback origin, TLS terminates at the CF
-edge).
-
-## Related docs
-
-- [`../docs/architecture.md`](../docs/architecture.md) — full edge / tunnel diagram and trust boundary table
-- [`../docs/runbook.md`](../docs/runbook.md) — operator workflow
-  (tunnel credential rotation, debugging tunnel state)
-- [`../../tofu/exe/cloudflare.tf`](../../tofu/exe/cloudflare.tf)
-  — actual IaC
+See [`../docs/architecture.md`](../docs/architecture.md) for the
+full ingress table and trust boundary, and
+[`../docs/runbook.md`](../docs/runbook.md) for tunnel operations.

--- a/exe/coder/templates/dotfiles-devcontainer/README.md
+++ b/exe/coder/templates/dotfiles-devcontainer/README.md
@@ -109,21 +109,7 @@ cdr ssh my-ws.dev -- '
 
 ## Related docs
 
-- [`../../README.md`](../../README.md) — `exe/coder/` overview
-- [`../../../README.md`](../../../README.md) — `exe/` overview
-- [`../../../docs/architecture.md`](../../../docs/architecture.md)
-  — full exe.hironow.dev architecture and trust boundary table
-- [`../../../docs/runbook.md`](../../../docs/runbook.md)
-  — `cdr templates push` / pre-merge image-tag testing
-- [`../../../../README.md`](../../../../README.md) — top-level
-  repo README (architecture overview + doc tree)
-- [`../../../../docs/adr/0002-coder-prebuilt-image.md`](../../../../docs/adr/0002-coder-prebuilt-image.md)
-  — why prebuilt image instead of envbuilder
-- [`../../../../docs/adr/0004-workspace-tailnet-routing.md`](../../../../docs/adr/0004-workspace-tailnet-routing.md)
-  — why workspace VMs reach Coder over the tailnet (B-plan)
-- [`../../../../docs/adr/0005-install-path-rationalization.md`](../../../../docs/adr/0005-install-path-rationalization.md)
-  — install.sh OS dispatch + step\_\* helpers
-- [`../../../../docs/adr/0006-mise-version-pinning.md`](../../../../docs/adr/0006-mise-version-pinning.md)
-  — mise.toml pins + `MISE_DATA_DIR=/opt/mise` relocation
-- [`../../../../docs/adr/0007-coder-server-install-hardening.md`](../../../../docs/adr/0007-coder-server-install-hardening.md)
-  — Coder server install pinning
+- [`../../../docs/architecture.md`](../../../docs/architecture.md) — full exe.hironow.dev architecture
+- [`../../../docs/runbook.md`](../../../docs/runbook.md) — operator workflow
+- [`../../../../docs/adr/0002-coder-prebuilt-image.md`](../../../../docs/adr/0002-coder-prebuilt-image.md) — why prebuilt image
+- [`../../../../docs/adr/`](../../../../docs/adr/) — full ADR list

--- a/exe/docs/README.md
+++ b/exe/docs/README.md
@@ -9,9 +9,7 @@ Documentation for `exe.hironow.dev`.
 
 Architectural decisions go in [`../../docs/adr/`](../../docs/adr/)
 at the repository root — current state lives here, the "why" of
-each decision lives there. See
-[`docs-guidelines`](../../README.md) and
-[`adr-guidelines`](../../docs/adr/) in the project conventions.
+each decision lives there.
 
 ## Related docs
 

--- a/exe/docs/architecture.md
+++ b/exe/docs/architecture.md
@@ -79,45 +79,20 @@ Legend / 凡例:
 
 ### Why no tailscale CLI inside the workspace container
 
-The workspace VM joins the tailnet at the **host** layer (apt-
-installed `tailscale`, fingerprint-pinned per
-[`PR #61`](https://github.com/hironow/dotfiles/pull/61)). The dev
-container runs with `--network host`, so:
+The VM joins the tailnet at the host layer (apt-installed
+`tailscale`, fingerprint-pinned); `--network host` shares it
+with the container, so outbound (`curl http://gpu.tailnet:8080`)
+and tailnet-private inbound (`python -m http.server :8080` →
+`<vm>.tailnet:8080`) work without a CLI in the container.
 
-- **Outbound tailnet reach works without a CLI.** Container
-  processes can `curl http://gpu-host.tailnet:8080` directly —
-  the host's resolver handles MagicDNS, and the host's
-  WireGuard tunnel handles the transport.
-- **Inbound exposure works without a CLI.** A web server bound
-  inside the container (e.g. `python -m http.server :8080`) is
-  reachable at `<vm-host>.tailnet:8080` because of host-network
-  sharing. No `tailscale serve` needed for plain tailnet-private
-  access.
+The `tailscaled` Unix socket is a control-plane endpoint with
+**no per-command auth**. Mounting it would let any in-container
+process call `tailscale serve --funnel` (public exposure),
+`tailscale logout` (DoS), or `tailscale ssh` other nodes —
+unacceptable for an environment that runs AI agents.
 
-The `tailscale` CLI is intentionally NOT installed in the
-container, and the host's `/var/run/tailscale/tailscaled.sock`
-is intentionally NOT mounted. Reason: the socket is a
-control-plane endpoint with **no per-command auth**. Anything
-with socket access can `tailscale serve --funnel` (public
-internet exposure), `tailscale logout` (DoS the VM), or
-`tailscale ssh hironow@<other-node>` (lateral move using the
-VM's `tag:exe-workspace` identity, or worse, `tag:owner` via
-ACL escalation paths). For an environment that runs AI agents
-inside the container, granting that level of authority to any
-in-container process is unacceptable.
-
-If `tailscale serve --funnel` or other CLI-only operations are
-needed, run them from the **VM host shell** instead:
-
-```bash
-gcloud compute ssh coder-<owner>-<workspace>-root \
-  --zone=asia-northeast1-a \
-  --command='sudo tailscale serve --bg http://localhost:8080'
-```
-
-This requires explicit operator action (gcloud auth + sudo) and
-is auditable; an AI agent running inside the container cannot
-reach this path.
+CLI-only ops (`serve`, `funnel`) are run from the VM host shell;
+see [runbook.md](./runbook.md#tailscale-serve--tailscale-funnel-from-a-workspace).
 
 ## State and secrets
 
@@ -264,8 +239,3 @@ project's `default` VPC and joins the tailnet as `tag:exe-workspace`.
   SA). Holds `roles/secretmanager.secretAccessor` on the workspace
   tailnet authkey and `roles/artifactregistry.reader` on the
   dotfiles repo (for docker pull).
-
-## Out of scope
-
-- (P)ublic publish path (`*.sandbox.hironow.dev` reverse proxy).
-- ADRs for Pattern A, OpenTofu choice, tailnet routing.

--- a/exe/docs/runbook.md
+++ b/exe/docs/runbook.md
@@ -122,74 +122,25 @@ operator branch testing happens via the image tag instead.
 
 ## AI agent CLI authentication
 
-The dev container image (post-PR #65 / #66) ships with five AI
-agent CLIs pre-installed but **with no credentials baked in**.
-Each CLI needs the operator to authenticate once on first use of
-a workspace.
+Five AI CLIs ship in the image with **no credentials baked in**.
+Operator authenticates once per workspace; tokens persist across
+`cdr stop` / `start` / `restart` and the preemptible 24h cycle
+(only `cdr delete` loses them — the boot disk has
+`auto_delete = false`).
 
-### One-time per workspace
-
-| CLI | Auth command | Account / Provider | Token location |
+| CLI | Auth command | Provider | Token location |
 |---|---|---|---|
-| `codex` | `codex login` | OpenAI (ChatGPT account) | `~/.codex/` |
-| `gemini` | `gemini auth login` | Google (or `GEMINI_API_KEY` env, or shared `gcloud auth application-default`) | `~/.config/gcloud/` or `~/.gemini/` |
-| `claude` | run `claude`, then `/login` | Anthropic Console | `~/.claude/` |
-| `copilot` | `copilot auth` | GitHub (Copilot subscription required) | `~/.config/github-copilot/` |
-| `pi` | `pi auth` (per LLM provider API key) | OpenAI / Anthropic / etc. — multi-provider | `~/.config/pi/` |
+| `codex` | `codex login` | OpenAI (ChatGPT) | `~/.codex/` |
+| `gemini` | `gemini auth login` | Google | `~/.config/gcloud/` or `~/.gemini/` |
+| `claude` | run `claude`, then `/login` | Anthropic | `~/.claude/` |
+| `copilot` | `copilot auth` | GitHub (Copilot subscription) | `~/.config/github-copilot/` |
+| `pi` | `pi auth` | multi-provider API keys | `~/.config/pi/` |
 
-`/root` inside the container is bind-mounted to the host VM's
-`/home/<user>/`, which sits on a `auto_delete = false` boot disk
-— **token files persist across `cdr stop`, `cdr start`, `cdr
-restart`, and the preemptible 24h VM cycle.** Tokens are only
-lost when the workspace is `cdr delete`-d (disk destroyed).
-
-### CF Access edge consideration (browser-OAuth CLIs)
-
-`codex login`, `gemini auth login`, and `copilot auth` open a
-browser-based OAuth flow. The workspace itself is behind
-Cloudflare Access, so the OAuth callback **cannot be served from
-inside the container**. Modern CLIs work around this with the
-**device-code flow**:
-
-```text
-$ codex login
-Visit https://auth.openai.com/device and enter code: ABC-1234
-Waiting for authorization...
-```
-
-Complete the device-code flow in the operator's local browser.
-The CLI polls the provider's OAuth endpoint (outbound from the
-workspace, no inbound port required) and writes the token when
-the operator confirms in their browser.
-
-If a CLI offers no device-code flow, set the corresponding
-`*_API_KEY` env var instead (most CLIs accept that as an
-alternative auth):
-
-```bash
-export OPENAI_API_KEY=sk-...
-export ANTHROPIC_API_KEY=sk-ant-...
-export GEMINI_API_KEY=...
-```
-
-Persist these by adding to `~/.zshrc.local` or use `dotenvx`
-(already on the image) for encrypted-at-rest secrets.
-
-### Smoke after auth
-
-```bash
-cdr ssh my-ws.dev -- '
-  codex --version
-  gemini --version
-  claude --version
-  copilot --version
-  pi --version
-  node --version    # /opt/mise/shims/node, runtime for the 4 npm-backed CLIs
-'
-```
-
-All five binaries are baked into `:main` images post-PR #66 and
-respond to `--version` without auth.
+The workspace is behind Cloudflare Access, so OAuth callbacks
+cannot be served from inside the container. Use the **device-
+code flow** the CLIs offer, or set `*_API_KEY` env vars
+(`OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `GEMINI_API_KEY` —
+persisted in `~/.zshrc.local` or via `dotenvx`).
 
 ## `tailscale serve` / `tailscale funnel` from a workspace
 
@@ -198,31 +149,20 @@ The workspace dev container intentionally does **not** ship the
 mounted into the container — see the rationale in
 [architecture.md](./architecture.md#why-no-tailscale-cli-inside-the-workspace-container).
 
-If you want to expose a workspace-side dev server over the
-tailnet (or via Tailscale Funnel for a public HTTPS URL), run
-the command from the **VM host shell**, not from inside the
-container:
+Expose a workspace-side dev server only from the VM host shell
+(not from inside the container) so action is explicit and
+auditable:
 
 ```bash
-# Tailnet-private exposure
 gcloud compute ssh coder-<owner>-<workspace>-root \
-  --zone=asia-northeast1-a \
-  --command='sudo tailscale serve --bg http://localhost:8080'
-
-# Public Funnel (HTTPS via Tailscale's funnel endpoint)
-gcloud compute ssh coder-<owner>-<workspace>-root \
-  --zone=asia-northeast1-a \
-  --command='sudo tailscale funnel --bg 8080'
-
-# Tear down
-gcloud compute ssh coder-<owner>-<workspace>-root \
-  --zone=asia-northeast1-a \
-  --command='sudo tailscale serve --reset'
+  --zone=asia-northeast1-a --command='sudo tailscale <action>'
 ```
 
-This forces explicit, auditable operator action (gcloud auth +
-sudo) and prevents an AI agent inside the container from
-silently exposing a port to the public internet.
+| Action | `<action>` |
+|---|---|
+| Tailnet-private serve | `serve --bg http://localhost:8080` |
+| Public Funnel (HTTPS) | `funnel --bg 8080` |
+| Tear down | `serve --reset` |
 
 ## Tailscale auth-key rotation
 

--- a/exe/tailscale/README.md
+++ b/exe/tailscale/README.md
@@ -1,35 +1,14 @@
 # exe/tailscale/
 
-Tailscale ACL and tag definitions for `exe.hironow.dev`.
-
-## Tag model (Pattern A — tagged auth keys)
-
-| Tag | Holder | Permitted destinations |
-|---|---|---|
-| `tag:owner` | hironow's personal devices | `*:*` (full tailnet) |
-| `tag:exe-coder` | the Coder control-plane VM | `tag:exe-coder:*` (loopback over tailnet) |
-| `tag:exe-workspace` | Coder workspace VMs | `tag:exe-coder:7080` (agent download + protocol — see [ADR 0004](../../docs/adr/0004-workspace-tailnet-routing.md)) |
-| `tag:agent` | AI agents | `tag:exe-coder:22,80,443,3000-3999` |
-
-## Files
+Tailscale ACL for `exe.hironow.dev` (Pattern A — tagged auth keys).
 
 | Path | Purpose |
 |---|---|
-| [`acl.hujson`](./acl.hujson) | Full ACL document, bound by `tailscale_acl.this` (`prevent_destroy`, `overwrite_existing_content`) |
+| [`acl.hujson`](./acl.hujson) | Live ACL (`tailscale_acl.this`, `prevent_destroy`) |
 
-Auth keys themselves are **never** committed here — they are
-provisioned by OpenTofu into GCP Secret Manager
-(`exe-tailscale-coder-authkey`, `exe-tailscale-workspace-authkey`,
-`exe-tailscale-agent-authkey`) and rotated every 90 days via
-`time_rotating.tailscale_keys` in
-[`../../tofu/exe/tailscale.tf`](../../tofu/exe/tailscale.tf).
+Auth keys are issued by tofu and stored in Secret Manager
+(`exe-tailscale-{coder,workspace,agent}-authkey`); see
+[`../../tofu/exe/tailscale.tf`](../../tofu/exe/tailscale.tf) for
+issuance + 90-day rotation.
 
-## Related docs
-
-- [`../docs/architecture.md`](../docs/architecture.md) — full
-  tailnet topology and trust boundary table
-- [`../../docs/adr/0004-workspace-tailnet-routing.md`](../../docs/adr/0004-workspace-tailnet-routing.md)
-  — why workspace VMs reach the Coder server over the tailnet
-  instead of the public CF Access edge (B-plan)
-- [`../../tofu/exe/tailscale.tf`](../../tofu/exe/tailscale.tf)
-  — actual auth-key + ACL IaC
+Tag model and trust boundaries: [`../docs/architecture.md`](../docs/architecture.md#permission-model--pattern-a).

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,219 +1,44 @@
-# E2E Tests
+# tests/
 
-End-to-end tests for dotfiles justfile commands.
+Pytest suites that run against the dev container image and the
+exe.hironow.dev IaC. Tests use real Docker / file system / git;
+no mocks of project code.
 
-## Overview
+## Layout
 
-E2E tests run in isolated Docker containers to avoid polluting the host environment. All dependencies (files, directories, commands) are real - no mocks are used.
+| Path | Purpose |
+|---|---|
+| [`test_devcontainer.py`](./test_devcontainer.py) | Dev container image runtime smoke (`mise current`, `MISE_DATA_DIR`, AI CLI `--version`) |
+| [`test_install_os_dispatch.py`](./test_install_os_dispatch.py) | `install.sh` OS dispatch contract (uname → DOTFILES_OS, `step_*` helpers) |
+| [`test_mise_pin_consistency.py`](./test_mise_pin_consistency.py) | `mise.toml` ↔ `feature install.sh` ↔ `/etc/mise/config.toml` drift guard |
+| [`test_mise_data_dir_relocation.py`](./test_mise_data_dir_relocation.py) | `MISE_DATA_DIR=/opt/mise` invariant across 4 files |
+| [`test_vm_bootstrap.py`](./test_vm_bootstrap.py) | Workspace VM startup_script supply-chain regressions (no curl\|bash, fingerprint pins) |
+| [`test_publish_workflow.py`](./test_publish_workflow.py) | `publish-devcontainer.yaml` GHA WIF auth + tag invariants |
+| [`test_cdr_wrapper.py`](./test_cdr_wrapper.py) | `exe/scripts/cdr` Secret Manager fetch + cleanup-on-failure |
+| [`test_just_sandbox.py`](./test_just_sandbox.py) | `just <recipe>` end-to-end inside the dev container |
+| [`test_sync_agents.py`](./test_sync_agents.py) | `just sync-agents` (Claude / Gemini / Codex agent file mirroring) |
+| [`exe/test_startup_script.py`](./exe/test_startup_script.py) | Control-plane VM startup_script (heredoc extraction + bash lint + systemd-analyze) |
+| [`exe/test_template.py`](./exe/test_template.py) | `exe/coder/templates/...` HCL static checks |
+| [`unit/`](./unit/) | Pure-Python helpers (no Docker, no fixtures) |
+| [`docker/`](./docker/) | Dockerfiles supporting the heavier exe smoke tests |
 
-## Requirements
-
-- Docker daemon running
-- `pytest` (installed via `uvx`)
-- `uv` (for running Python scripts)
-- `just` (latest version with `[group()]` syntax support)
-
-## Running Tests
+## Running
 
 ```bash
-# Run all e2e tests
-uvx pytest tests/e2e/ -v
-
-# Run specific test file
-uvx pytest tests/e2e/test_sync_agents.py -v
-
-# Run specific test
-uvx pytest tests/e2e/test_sync_agents.py::test_sync_agents_is_idempotent -v
-
-# Run tests by keyword
-uvx pytest tests/e2e/ -v -k "directory"
+just test                        # full suite (builds dev container image first)
+uvx pytest tests/test_<name>.py  # single file
+uvx pytest -m exe                # only `@pytest.mark.exe` (heavy IaC tests)
 ```
 
-## Test Structure
+## Authoring conventions
 
-### Test Environment
-
-- **Docker Image**: `dotfiles-just-sandbox:latest` (built from `.devcontainer/devcontainer.json` via the `devcontainer` CLI)
-- **Base Image**: `mcr.microsoft.com/devcontainers/base:bookworm` (debian-12, glibc-native)
-- **Tools provisioned by features**: just, mise, uv, gh, gcloud, docker-cli, python, node, zsh
-- **Working Directory**: `/root/dotfiles` (bind-mounted from host repo)
-- **Container Lifecycle**: Each test runs in a fresh container (`--rm` flag)
-
-### Test Isolation
-
-- Each test uses a fresh Docker container
-- No state persists between tests
-- Commands and verification run in the same container instance (single bash script)
-- Host environment is never modified
-
-## Available Tests
-
-### `test_sync_agents.py`
-
-Tests for the `just sync-agents` commands that sync ROOT_AGENTS files to agent instruction directories.
-
-#### File Naming Convention
-
-```
-dotfiles/ (flat)                     -> ~/.claude/ (structured)
----------------------------------------------------------
-ROOT_AGENTS.md                       -> CLAUDE.md
-ROOT_AGENTS_commands_strict.md       -> commands/strict.md
-ROOT_AGENTS_skills_my-skill/         -> skills/my-skill/
-ROOT_AGENTS_hooks_formatter.py       -> hooks/formatter.py
-ROOT_AGENTS_agents_subagent/         -> agents/subagent/
-```
-
-The `_` in filenames (after `ROOT_AGENTS_`) are converted to `/` for target path.
-
-#### Just Commands
-
-| Command | Description |
-|---------|-------------|
-| `just sync-agents` | Interactive sync (prompts on changes) |
-| `just sync-agents-preview` | Dry-run mode (show plan without changes) |
-| `just sync-agents-auto` | Auto-sync all without prompts |
-
-#### Test Cases (12 tests)
-
-**Basic Functionality**
-
-1. `test_sync_agents_creates_files_on_first_run` - Verifies files are created on first run
-2. `test_sync_agents_is_idempotent` - Second run reports "SYNCED" status
-3. `test_sync_agents_creates_missing_directories` - Creates agent directories if missing
-
-**Path Conversion**
-
-4. `test_sync_agents_converts_underscore_to_path` - `ROOT_AGENTS_commands_strict.md` -> `commands/strict.md`
-5. `test_sync_agents_handles_directory_sources` - Syncs directories with nested contents
-6. `test_sync_agents_handles_python_file_extension` - `ROOT_AGENTS_hooks_formatter.py` -> `hooks/formatter.py`
-
-**Preview Mode**
-
-7. `test_sync_agents_preview_shows_plan` - Shows plan without making changes
-8. `test_sync_agents_preview_shows_new_files` - Shows `[NEW]` status for missing files
-9. `test_sync_agents_preview_shows_synced_files` - Shows `[SYNCED]` status for up-to-date files
-
-**Change Detection**
-
-10. `test_sync_agents_detects_changed_files` - Shows `[CHANGED]` status for modified files
-
-**Error Handling**
-
-11. `test_sync_agents_fails_without_base_file` - Fails gracefully when `ROOT_AGENTS.md` is missing
-
-**Multi-Agent**
-
-12. `test_sync_agents_syncs_to_all_agents` - Syncs to all configured agents (Claude, Gemini, Codex)
-
-## Writing New E2E Tests
-
-### Principles
-
-1. **No Mocks**: Use real files, commands, and file systems
-2. **Isolation**: Run in Docker to avoid host pollution
-3. **Single Container Instance**: Run commands and verification in the same container
-4. **Clear Scenarios**: Use Given-When-Then structure
-
-### Example Pattern
-
-```python
-def test_my_just_command(docker_image):
-    """Test description with clear scenario.
-
-    Scenario:
-    - given: Initial state
-    - when: Action performed
-    - then: Expected outcome
-    """
-    cmd = """
-    set -euo pipefail
-
-    # Setup if needed
-    mkdir -p /some/dir
-    echo "content" > /some/file
-
-    # Execute command
-    cd /root/dotfiles && just my-command
-
-    # Verify results in same container
-    [ -f /expected/file ] && echo "file exists"
-    grep -q "expected content" /expected/file && echo "content correct"
-    """
-    result = _run_in_container(docker_image, cmd)
-
-    # Assertions
-    assert "file exists" in result.stdout
-    assert "content correct" in result.stdout
-```
-
-### Helper Functions
-
-- `_run_in_container(docker_image, cmd, check=True)`: Run bash command in container
-- `_run(cmd, cwd=None, env=None)`: Run command on host (for docker commands)
-- `_docker_available()`: Check if Docker is available
-
-## Debugging Failed Tests
-
-1. **Check Docker**: Ensure Docker daemon is running
-
-   ```bash
-   docker info
-   ```
-
-2. **Rebuild Image**: Force rebuild if devcontainer.json changed
-
-   ```bash
-   devcontainer build --workspace-folder . --image-name dotfiles-just-sandbox:latest
-   ```
-
-   Requires `npm i -g @devcontainers/cli` on the host.
-
-3. **Manual Container Run**: Test commands manually
-
-   ```bash
-   docker run --rm -it -w /root/dotfiles dotfiles-just-sandbox:latest bash
-   ```
-
-4. **View Test Output**: Use `-v -s` flags for verbose output
-
-   ```bash
-   uvx pytest tests/e2e/test_sync_agents.py -v -s
-   ```
-
-## CI Integration
-
-Tests are designed to run in CI environments:
-
-- Skip if Docker is unavailable (`pytest.skip`)
-- Build image once per test session (module-scoped fixture)
-- Clean up containers automatically (`--rm` flag)
-- Fast execution (~25s for all 12 tests)
-
-## Related Files
-
-| File | Description |
-|------|-------------|
-| [`../.devcontainer/devcontainer.json`](../.devcontainer/devcontainer.json) | Dev container declaration (image + features) |
-| [`../scripts/sync_agents.py`](../scripts/sync_agents.py) | Python script for sync-agents (PEP 723) |
-| [`../justfile`](../justfile) | Commands being tested |
-| [`../ROOT_AGENTS.md`](../ROOT_AGENTS.md) | Base agent instruction file |
+- **No mocks of project code.** External services (gcloud, coder, npm) get real stubs on PATH; project modules run as-is.
+- **One container per test.** Use the existing fixtures (`docker_image`, `saved_image`); each test gets a fresh `--rm` container.
+- **Given / When / Then** in the test body when setup is non-trivial.
+- **Docker required.** Tests that need it call `pytest.skip` when Docker is unreachable so local runs without Docker still pass the rest.
 
 ## Related docs
 
-- [`../README.md`](../README.md) — repo overview + architecture
-- [`../docs/adr/0001-devcontainer-debian-features.md`](../docs/adr/0001-devcontainer-debian-features.md)
-  — why debian-12 + curated features for the test container
-- [`../exe/docs/architecture.md`](../exe/docs/architecture.md)
-  — exe.hironow.dev (some tests under `tests/exe/` exercise its
-  IaC heredocs)
-
-> [!NOTE]
-> **Beyond `test_sync_agents.py`**: this directory now hosts many
-> more test files (devcontainer runtime smokes, install.sh OS
-> dispatch, mise pin consistency, /opt/mise relocation,
-> publish-workflow / cdr-wrapper / vm-bootstrap regressions, exe
-> startup-script extraction). The detailed walkthrough above is
-> kept for the original sync-agents flow; refer to each
-> `tests/test_*.py` file's module docstring for that test's
-> contract.
+- [`../README.md`](../README.md) — repo overview
+- [`../docs/adr/`](../docs/adr/) — decisions the tests guard
+- [`../exe/docs/architecture.md`](../exe/docs/architecture.md) — what `tests/exe/` exercises

--- a/tofu/exe/README.md
+++ b/tofu/exe/README.md
@@ -10,9 +10,9 @@ OpenTofu stack provisioning `exe.hironow.dev`.
 | `gcp_region` | `asia-northeast1` | Primary region |
 | `gcp_zone` | `asia-northeast1-a` | Primary zone |
 | `domain` | `exe.hironow.dev` | Cloudflare-managed apex |
-| `tailnet` | (from `tailscale_token` secret) | Tailscale tailnet identifier |
+| `tailnet` | (from `terraform.tfvars`, e.g. `hironow.github`) | Tailscale tailnet identifier |
 | `coder_version` | `v2.31.11` | Pinned Coder server release tag (see [ADR 0007](../../docs/adr/0007-coder-server-install-hardening.md)) |
-| `coder_sha256` | `32cf14...8430` | Sha256 of `coder_<ver>_linux_amd64.tar.gz` from the release's `checksums.txt` |
+| `coder_sha256` | (see `variables.tf`) | Sha256 of `coder_<ver>_linux_amd64.tar.gz` from the release's `checksums.txt` |
 
 ## Files
 
@@ -21,13 +21,13 @@ OpenTofu stack provisioning `exe.hironow.dev`.
 | [`main.tf`](./main.tf) | Backend (GCS), providers, locals |
 | [`variables.tf`](./variables.tf) | Input variables (incl. Coder pin) |
 | [`outputs.tf`](./outputs.tf) | Workspace SA email, AR repo, control-plane URL |
-| [`coder.tf`](./coder.tf) | Control-plane VM startup_script (Coder server install + cloudflared + tailscaled, with apt-key fingerprint pin per [PR #61](https://github.com/hironow/dotfiles/pull/61)) |
+| [`coder.tf`](./coder.tf) | Control-plane VM startup_script (Coder server install + cloudflared + tailscaled, with apt-key fingerprint pin) |
 | [`tailscale.tf`](./tailscale.tf) | Tagged auth keys, ACL bootstrap, 90-day rotation |
 | [`cloudflare.tf`](./cloudflare.tf) | Tunnel + Access policy + DNS records |
 | [`artifact_registry.tf`](./artifact_registry.tf) | Dev container image AR repo (`devcontainer:main` + `devcontainer:<sha>`) |
 | [`iam.tf`](./iam.tf) | Workload Identity Federation (GHA → AR) + workspace SA |
 | [`locals.tf`](./locals.tf) | Hostnames, tag names |
-| [`.terraform.lock.hcl`](./.terraform.lock.hcl) | Provider plugin lockfile (tracked per [PR #62](https://github.com/hironow/dotfiles/pull/62)) |
+| [`.terraform.lock.hcl`](./.terraform.lock.hcl) | Provider plugin lockfile (tracked) |
 
 ## State
 
@@ -36,7 +36,7 @@ Backend: GCS bucket `gs://gen-ai-hironow-tofu-state/exe/`
 [`../../exe/scripts/bootstrap.sh`](../../exe/scripts/bootstrap.sh)).
 
 State encryption: native `tofu` state encryption (1.7+) with passphrase
-from `~/.config/tofu/exe.passphrase` (700 mode, gitignored).
+from `~/.config/tofu/exe.passphrase` (0600 mode, gitignored).
 
 ## Lifecycle
 


### PR DESCRIPTION
## Summary

Three parallel review agents (duplication / staleness / structure)
surfaced ~50 findings across the in-scope user-facing markdowns
(submodules + ADRs + autoblogs + plugins excluded). This PR
applies the high-priority subset.

**Net: −420 / +96 lines across 9 tracked files.**

(Gitignored \`docs/setup.md\` got an additional ~110 lines of
closed-migration narrative removed; that change is local-only.)

## Quality / staleness fixes

| File | Issue | Fix |
|---|---|---|
| \`README.md\` | broken link to gitignored \`docs/intent.md\` | annotate "(operator-only, gitignored)" |
| \`README.md\` | "Windows native ... 実装は TODO" embedded TODO | drop, say "未対応" |
| \`tofu/exe/README.md\` | passphrase mode shown as 700 (it's 0600) | fix |
| \`tofu/exe/README.md\` | \`tailnet\` input "(from tailscale_token secret)" — that secret doesn't exist | "(from terraform.tfvars)" |
| \`tofu/exe/README.md\` | \`coder_sha256\` truncated as \`...8430\` (real ends \`...4979\`) | replace with "(see variables.tf)" |
| \`tofu/exe/README.md\` | inline PR #61 / PR #62 commit-trivia links | dropped |
| \`exe/docs/README.md\` | broken docs-guidelines / adr-guidelines links | removed |
| \`exe/docs/architecture.md\` | PR #61 inline link | dropped |
| \`exe/docs/architecture.md\` | "Out of scope" empty section | deleted |
| \`exe/docs/runbook.md\` | "post-PR #65 / #66" bookkeeping notes | dropped |
| \`tests/README.md\` | doc described \`tests/e2e/\` (which doesn't exist) and 12-test enumeration of legacy sync-agents flow only | full rewrite to reflect actual layout (\`tests/\` flat + \`tests/exe/\` + \`tests/unit/\` + \`tests/docker/\`) |

## Duplication consolidation

| Finding | Action |
|---|---|
| Pattern A tag table appeared in 3 files | kept canonical in \`exe/docs/architecture.md\`; \`exe/tailscale/README.md\` reduced to 14 lines + link |
| Tunnel ingress rules duplicated | \`exe/cloudflared/README.md\` reduced to 10 lines + link to architecture |
| AI CLI list duplicated 4× | template README links to runbook; runbook keeps canonical table |
| ADR list enumerated in 4 places | template README's "Related docs" trimmed; ADR enumeration only in \`docs/adr/\` index |
| \`gcloud compute ssh ... 'sudo tailscale ...'\` block 3× | one block + action table in runbook |
| "Why no tailscale CLI" rationale 2× | architecture keeps the rationale; runbook links to it |

## What this PR deliberately does NOT do

- ROOT_AGENTS.md (1117 lines) — out of scope, agent instructions deserve a separate review.
- Cosmetic finds (ASCII fence language hints, inflated narrative tone) — low-value; deferred.
- USAGE.md restructure — separate PR.
- ROOT_AGENTS.md / autoblogs / plugins / ADRs — out of scope per user request.

## Verification

- \`just fmt\` + \`just lint\` (pre-commit hooks): pass
- All relative links validated with \`os.path.exists\`: 0 broken
- Removed sections cross-checked: every concept removed from a non-canonical doc still has a canonical home that's now linked.