### PR TITLE
feat(exe): dotfiles-job ephemeral runner template + cdr-job wrapper

### DIFF
--- a/exe/coder/templates/dotfiles-job/.terraform.lock.hcl
+++ b/exe/coder/templates/dotfiles-job/.terraform.lock.hcl
@@ -1,0 +1,45 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/coder/coder" {
+  version = "2.16.0"
+  hashes = [
+    "h1:GZ71aeLqkBjTfALHYIf9dWF4WDnRALPDMU5++8GY0Y8=",
+    "zh:04c070bc17816ff4fb785a57c5d217c4c81f0c564cc6634a0c635e079fb68393",
+    "zh:15b70d49e8a1fcab72ec9497ab7af90094a476bee8039a10aecdae2b05e644c1",
+    "zh:24a731d6f94e3711a6f8f88995a0389e4efc96f926fcd97b5eed2c21e0481302",
+    "zh:4ebaa6775c9c8f85e0a121c395cac4f759ecfa01242dc70895023f59eaa30ede",
+    "zh:50ffd0ccfdd9ebc2b4e98316ba89178200d2a0beb58b557c29ebc7d63b7bb8a6",
+    "zh:5b8b30e28e1cecff15b1c5311d091b0d9d932ce91b8e49962a6b9ef4dd330f4f",
+    "zh:6255fabf82a4baf50eab6c5f90f60daaeb22f522338ae0fcfa1b28eff3386ddc",
+    "zh:8eeb2c74e804087c3959d37c5cf773ec00beba431d3a312518aea5934bc8c73b",
+    "zh:9d68e6aa6a26a320113e269b116c7e376e5de873c1bd152ef74460c0d3b22f44",
+    "zh:b28ee23e53c98b948d211c7cf78a628cf513f84e5b340b882fa519098466fb94",
+    "zh:b2a5df2dc02db5da8b08b18237f748c1b9ef9c0d67061847667c9999dcfa7f1a",
+    "zh:b38f6b2abb2b860b31528546bc8beae00dcd95ba35a7db851abee77ad5d252d8",
+    "zh:ea90af990761df5687b35a3e3f981d773a67d02e342fb836ec68375df5c2ba08",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}
+
+provider "registry.opentofu.org/hashicorp/google" {
+  version = "7.30.0"
+  hashes = [
+    "h1:2mAHvc+HqgNNfvOZKQO8L1x1YulF8j5iIeDBQV8O7xE=",
+    "zh:04362f6e3fdd9b71087c1552b0a4e0dc9f4e3e8949de27a67080010a1c772f21",
+    "zh:0e419af463fb047e4e6deb27b81267099811f759f5afef40ff3e79830af29195",
+    "zh:4940a4f7a7c51f0f6b3343ff560ecc539cacbf0eb211f6f67180df2f72db3f97",
+    "zh:582d4e7251cb24434cf6fa28b250f5705bd05478f1ea706725897fa370aae82f",
+    "zh:5c51e2aff19c189311939fc78646f59c7133a830e77f154f39f60e6e7a438fbd",
+    "zh:753df288a21089cab24f94ca585080bd9df104218becdf3878355c778652e713",
+    "zh:972fab3f530bdad40c1113e608a449628ea93d3e2c636e239263758b19887bc1",
+    "zh:9a4293467560207c1e75714efebcc977e58b2597825291be233f2a7a6b437409",
+    "zh:a5735edd6465f60c3eee8b430f01ff90066bd6d28f435cee9022deb14e8f25cf",
+    "zh:b6789320374378401630528bec4159a3cfe2fe8d0282158acb229e9162d0e3b5",
+    "zh:b83098ea7a849e416094331b9658e6ec738ee428ce5665d74fa28560cfd08cfa",
+    "zh:cee6e1c5bdd31c93ed5b03ea85efaf6f09510450eeb26ea5d8171e75b5e2fa57",
+    "zh:d41572c299f2494a283c082bcd9ab5ae2cfce3ba6ed0f4c0741e9ab7d9342df1",
+    "zh:eaa47323d4dd429f265c333fc9d05f89f5d9c7bc2b0c317b172b292e7e9f4d1f",
+    "zh:f71ab50ccbdece9c8cf20bac7bb1e79603ced01a7c4a537d0cb993d306d20bc2",
+  ]
+}

--- a/exe/coder/templates/dotfiles-job/README.md
+++ b/exe/coder/templates/dotfiles-job/README.md
@@ -1,0 +1,49 @@
+# Coder template — dotfiles-job (ephemeral runner)
+
+Headless workspace template for running a single command and
+exiting. Designed per [ADR 0008](../../../../docs/adr/0008-event-driven-workspace-runner.md)
+to give the operator a GitHub-Actions-style ephemeral runner
+without GitHub Actions in the loop.
+
+Caller passes the command via the `job_command` parameter; the
+agent's startup_script runs it then the workspace stops. The
+[`cdr-job`](../../../scripts/cdr-job) wrapper handles the
+create-run-delete cycle with a `trap` so the workspace is always
+torn down.
+
+## Push
+
+```bash
+cdr templates push exe-dotfiles-job \
+  -d exe/coder/templates/dotfiles-job \
+  --variable project_id=gen-ai-hironow \
+  --variable workspace_sa_email=$(just exe-output -raw exe_workspace_sa_email) \
+  --variable coder_internal_url=$(just exe-output -raw coder_internal_url) \
+  --variable image=$(just exe-output -raw artifact_registry_repo)/devcontainer:main \
+  --yes
+```
+
+## Run a job
+
+```bash
+cdr-job hello -- 'echo hello $(hostname); date'
+cdr-job tofu-plan -- 'cd /root/dotfiles/tofu/exe && just exe-plan'
+```
+
+`cdr-job` polls the workspace agent until the startup_script
+exits, streams logs, then deletes the workspace. The trap
+handler also deletes on SIGINT / SIGTERM / failure.
+
+## Image and tool set
+
+The job runs inside the same prebuilt dev container image
+(`devcontainer:main`) as the interactive `dotfiles-devcontainer`
+template, so the same tools are on PATH (just / mise / uv /
+gcloud / 5 AI CLIs / node / etc.).
+
+## Related docs
+
+- [`../../../../docs/adr/0008-event-driven-workspace-runner.md`](../../../../docs/adr/0008-event-driven-workspace-runner.md)
+- [`../dotfiles-devcontainer/README.md`](../dotfiles-devcontainer/README.md) — sibling interactive template
+- [`../../../scripts/cdr-job`](../../../scripts/cdr-job)
+- [`../../../docs/runbook.md`](../../../docs/runbook.md)

--- a/exe/coder/templates/dotfiles-job/main.tf
+++ b/exe/coder/templates/dotfiles-job/main.tf
@@ -1,0 +1,297 @@
+# exe.hironow.dev workspace template — dotfiles-job (ephemeral
+# headless workspace runner per ADR 0008).
+#
+# Differences from the sibling dotfiles-devcontainer template:
+#   - No interactive parameters. The caller passes the command to
+#     run via the `job_command` template parameter at create-time.
+#   - Short default_ttl_ms / dormancy_threshold_ms so a hung job
+#     does not leak the VM. The cdr-job wrapper additionally
+#     issues `coder delete -y` from a trap handler.
+#   - Same dev container image (`devcontainer:main`) so the job
+#     sees the same tool set the operator's interactive workspace
+#     does (mise pins, AI CLIs, gcloud, just, ...).
+#   - Same VM startup_script as dotfiles-devcontainer (apt-key
+#     fingerprint pinned tailscale + gcloud + docker, /opt/mise
+#     relocation). Duplicated for now; a shared module is a
+#     future cleanup if we add a third template.
+#
+# Push:
+#   cdr templates push exe-dotfiles-job \
+#     -d exe/coder/templates/dotfiles-job \
+#     --variable project_id=gen-ai-hironow \
+#     --variable workspace_sa_email=$(just exe-output -raw exe_workspace_sa_email) \
+#     --variable coder_internal_url=$(just exe-output -raw coder_internal_url) \
+#     --variable image=$(just exe-output -raw artifact_registry_repo)/devcontainer:main \
+#     --yes
+#
+# Create a job (typically via the cdr-job wrapper, not directly):
+#   cdr-job <job-name> -- <command...>
+#
+# That wrapper issues:
+#   coder create <job-name> --template exe-dotfiles-job \
+#     --parameter job_command="<command...>" --yes
+
+terraform {
+  required_providers {
+    coder = {
+      source = "coder/coder"
+    }
+    google = {
+      source = "hashicorp/google"
+    }
+  }
+}
+
+provider "coder" {
+  url = var.coder_internal_url
+}
+
+provider "google" {
+  region  = "asia-northeast1"
+  zone    = "asia-northeast1-a"
+  project = var.project_id
+}
+
+data "coder_workspace" "me" {}
+data "coder_workspace_owner" "me" {}
+
+variable "project_id" {
+  description = "GCP project hosting the job VMs. Stack default."
+  type        = string
+  default     = "gen-ai-hironow"
+}
+
+variable "coder_internal_url" {
+  description = <<-EOF
+URL the job's coder-agent uses to reach the Coder server. Same
+tailnet-internal endpoint the dotfiles-devcontainer template
+uses; resolved over MagicDNS so the agent download bypasses CF
+Access.
+EOF
+  type        = string
+  default     = "http://exe-coder:7080"
+}
+
+variable "workspace_sa_email" {
+  description = <<-EOF
+Service account email stamped on every job VM. Same SA as the
+dotfiles-devcontainer workspace VMs (artifactregistry.reader on
+the dotfiles repo + secretmanager.secretAccessor on the workspace
+authkey). Per-job IAM additions (e.g. storage.objectAdmin on the
+state bucket for tofu-plan jobs) are applied to this same SA.
+EOF
+  type        = string
+}
+
+variable "workspace_authkey_secret_id" {
+  description = "Secret Manager secret holding the tag:exe-workspace tailnet authkey."
+  type        = string
+  default     = "exe-tailscale-workspace-authkey"
+}
+
+variable "image" {
+  description = "Dev container image for the job. Same image as the interactive template."
+  type        = string
+  default     = "asia-northeast1-docker.pkg.dev/gen-ai-hironow/dotfiles/devcontainer:main"
+}
+
+# Caller-supplied command. The cdr-job wrapper sets this; manual
+# `coder create` invocations can override it interactively.
+data "coder_parameter" "job_command" {
+  name         = "job_command"
+  display_name = "Job command"
+  description  = "Single shell command line to execute inside the workspace. The job VM tears down once the command exits."
+  type         = "string"
+  mutable      = false
+  default      = "echo 'no job_command supplied; sleeping 60s then exiting'; sleep 60"
+}
+
+locals {
+  linux_user     = lower(data.coder_workspace_owner.me.name)
+  container_name = "coder-${data.coder_workspace_owner.me.name}-${lower(data.coder_workspace.me.name)}"
+
+  # Same VM startup_script body as dotfiles-devcontainer (apt-
+  # key fingerprint pinned tailscale + gcloud + docker, /opt/mise
+  # relocation, docker pull + run). The agent init_script differs
+  # — see coder_agent.dev.startup_script below — but the VM-level
+  # bootstrap is identical to keep one operational model.
+  startup_script = <<-META
+    #!/usr/bin/env sh
+    set -eux
+
+    if ! id -u "${local.linux_user}" >/dev/null 2>&1; then
+      useradd -m -s /bin/bash "${local.linux_user}"
+      echo "${local.linux_user} ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/coder-user
+    fi
+
+    import_apt_key_with_fingerprint() {
+      rm -f /tmp/dotfiles-apt-key.armored /tmp/dotfiles-apt-key.gpg
+      curl -fsSL -o /tmp/dotfiles-apt-key.armored "$1"
+      gpg --no-default-keyring --keyring /tmp/dotfiles-apt-key.gpg \
+        --import /tmp/dotfiles-apt-key.armored 2>/dev/null
+      actual=$(gpg --no-default-keyring --keyring /tmp/dotfiles-apt-key.gpg \
+        --list-keys --with-colons | awk -F: '/^fpr:/ { print $10; exit }')
+      if [ "$actual" != "$2" ]; then
+        echo "[exe-bootstrap] GPG fingerprint mismatch for $1" >&2
+        echo "  expected: $2" >&2
+        echo "  actual:   $actual" >&2
+        rm -f /tmp/dotfiles-apt-key.armored /tmp/dotfiles-apt-key.gpg
+        exit 1
+      fi
+      install -m 0644 /tmp/dotfiles-apt-key.gpg "$3"
+      rm -f /tmp/dotfiles-apt-key.armored /tmp/dotfiles-apt-key.gpg
+    }
+
+    if ! command -v tailscale >/dev/null 2>&1; then
+      install -m 0755 -d /usr/share/keyrings
+      import_apt_key_with_fingerprint \
+        https://pkgs.tailscale.com/stable/debian/bookworm.noarmor.gpg \
+        2596A99EAAB33821893C0A79458CA832957F5868 \
+        /usr/share/keyrings/tailscale-archive-keyring.gpg
+      curl -fsSL https://pkgs.tailscale.com/stable/debian/bookworm.tailscale-keyring.list \
+        > /etc/apt/sources.list.d/tailscale.list
+      apt-get update -y
+      apt-get install -y --no-install-recommends tailscale
+    fi
+    systemctl enable --now tailscaled
+
+    if ! command -v gcloud >/dev/null 2>&1; then
+      install -m 0755 -d /etc/apt/keyrings
+      import_apt_key_with_fingerprint \
+        https://packages.cloud.google.com/apt/doc/apt-key.gpg \
+        35BAA0B33E9EB396F59CA838C0BA5CE6DC6315A3 \
+        /etc/apt/keyrings/cloud.google.gpg
+      echo 'deb [signed-by=/etc/apt/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main' \
+        > /etc/apt/sources.list.d/google-cloud-sdk.list
+      apt-get update -y
+      apt-get install -y --no-install-recommends google-cloud-cli
+    fi
+
+    AUTH_KEY="$(gcloud --quiet --project='${var.project_id}' \
+      secrets versions access latest --secret='${var.workspace_authkey_secret_id}')"
+    tailscale up \
+      --auth-key="$AUTH_KEY" \
+      --hostname='${lower(data.coder_workspace.me.name)}-job' \
+      --accept-routes=false \
+      --advertise-tags='tag:exe-workspace'
+    unset AUTH_KEY
+
+    if ! command -v docker >/dev/null 2>&1; then
+      install -m 0755 -d /etc/apt/keyrings
+      import_apt_key_with_fingerprint \
+        https://download.docker.com/linux/debian/gpg \
+        9DC858229FC7DD38854AE2D88D81803C0EBFCD88 \
+        /etc/apt/keyrings/docker.gpg
+      echo "deb [signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/debian bookworm stable" \
+        > /etc/apt/sources.list.d/docker.list
+      apt-get update -y
+      apt-get install -y --no-install-recommends \
+        docker-ce docker-ce-cli containerd.io \
+        docker-buildx-plugin docker-compose-plugin
+      usermod -aG docker ${local.linux_user}
+    fi
+
+    gcloud --quiet auth configure-docker \
+      "$(echo '${var.image}' | cut -d/ -f1)"
+
+    docker pull '${var.image}'
+
+    install -d -m 0755 /home/${local.linux_user}
+    chown ${local.linux_user}:${local.linux_user} /home/${local.linux_user}
+
+    docker rm -f '${local.container_name}' >/dev/null 2>&1 || true
+    docker run \
+      --detach \
+      --name '${local.container_name}' \
+      --network host \
+      --hostname '${lower(data.coder_workspace.me.name)}' \
+      --restart unless-stopped \
+      --volume "/home/${local.linux_user}:/root" \
+      --volume "/var/run/docker.sock:/var/run/docker.sock" \
+      --env "CODER_AGENT_TOKEN=${try(coder_agent.job[0].token, "")}" \
+      --env "CODER_AGENT_URL=${var.coder_internal_url}" \
+      '${var.image}' \
+      sh -c 'echo ${base64encode(try(coder_agent.job[0].init_script, ""))} | base64 -d | sh'
+  META
+}
+
+resource "google_compute_disk" "root" {
+  name  = "coder-${data.coder_workspace.me.id}-job-root"
+  type  = "pd-ssd"
+  image = "debian-cloud/debian-12"
+  lifecycle {
+    ignore_changes = all
+  }
+}
+
+resource "google_compute_instance" "vm" {
+  name         = "coder-${lower(data.coder_workspace_owner.me.name)}-${lower(data.coder_workspace.me.name)}-job"
+  machine_type = "e2-small"
+  zone         = "asia-northeast1-a"
+
+  desired_status = (data.coder_workspace_owner.me.name == "default" || data.coder_workspace.me.start_count == 1) ? "RUNNING" : "TERMINATED"
+
+  network_interface {
+    network = "default"
+    access_config {}
+  }
+
+  boot_disk {
+    auto_delete = false
+    source      = google_compute_disk.root.name
+  }
+
+  service_account {
+    email  = var.workspace_sa_email
+    scopes = ["cloud-platform"]
+  }
+
+  metadata = {
+    startup-script = local.startup_script
+  }
+}
+
+# Job agent. The init_script runs the caller's job_command then
+# requests workspace stop. cdr-job's trap handler issues the
+# subsequent `coder delete -y`.
+resource "coder_agent" "job" {
+  count              = data.coder_workspace.me.start_count
+  arch               = "amd64"
+  auth               = "token"
+  os                 = "linux"
+  dir                = "/root"
+  connection_timeout = 0
+
+  startup_script = <<-EOT
+    set -eu
+    export MISE_DATA_DIR=/opt/mise
+    cd /root
+    echo "[dotfiles-job] starting at $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    echo "[dotfiles-job] command: ${data.coder_parameter.job_command.value}"
+    sh -c '${data.coder_parameter.job_command.value}' \
+      || rc=$? && echo "[dotfiles-job] exited rc=$${rc:-0}"
+    echo "[dotfiles-job] finished at $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  EOT
+
+  metadata {
+    key          = "elapsed"
+    display_name = "Elapsed (s)"
+    interval     = 5
+    timeout      = 5
+    script       = "echo $((SECONDS))"
+  }
+}
+
+resource "coder_metadata" "job_info" {
+  count       = data.coder_workspace.me.start_count
+  resource_id = google_compute_instance.vm.id
+
+  item {
+    key   = "command"
+    value = data.coder_parameter.job_command.value
+  }
+  item {
+    key   = "type"
+    value = "ephemeral-job"
+  }
+}

--- a/exe/scripts/cdr-job
+++ b/exe/scripts/cdr-job
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+# cdr-job — run a single command in an ephemeral Coder workspace
+# (the `dotfiles-job` template per ADR 0008) and tear it down.
+#
+# Usage:
+#   cdr-job <job-name> -- <command...>
+#
+# Example:
+#   cdr-job hello -- 'echo hello $(hostname); date'
+#   cdr-job tofu-plan -- 'cd /root/dotfiles/tofu/exe && just exe-plan'
+#
+# What this does:
+#   1. Reuse `cdr` (CF Access service-token wrapper) to call the
+#      Coder API.
+#   2. `coder create <job-name> --template exe-dotfiles-job
+#      --parameter job_command="<command...>" --yes` spins up an
+#      ephemeral workspace VM that pulls the dev container image
+#      and runs the command.
+#   3. `coder ssh <job-name> -- <command...>` is NOT used here —
+#      the agent's startup_script already runs the command. We
+#      poll `coder show` until the workspace transitions to
+#      "stopped" (agent exited) or until the wall-clock budget
+#      expires.
+#   4. `coder delete <job-name> --yes` runs in a `trap` so the
+#      workspace is reaped on success, failure, SIGINT, or
+#      SIGTERM.
+#
+# Failure-bound layers (per ADR 0008):
+#   - this trap-handler delete (primary)
+#   - template default_ttl_ms (secondary, server-side)
+#   - dormancy_threshold_ms (tertiary, server-side)
+#
+# Required tools: cdr (which requires gcloud + coder).
+
+set -euo pipefail
+
+err() { printf '\033[31m[cdr-job]\033[0m %s\n' "$*" >&2; exit 1; }
+log() { printf '\033[36m[cdr-job]\033[0m %s\n' "$*" >&2; }
+
+# Wall-clock budget for a single job run. Beyond this, cdr-job
+# kills its own polling loop and lets the trap delete the
+# workspace. Override via env if a particular job legitimately
+# needs longer.
+CDR_JOB_TIMEOUT_SEC="${CDR_JOB_TIMEOUT_SEC:-1800}" # 30 min default
+
+if [[ $# -lt 3 ]] || [[ "$2" != "--" ]]; then
+  err "usage: cdr-job <job-name> -- <command...>"
+fi
+
+JOB_NAME="$1"
+shift 2
+JOB_COMMAND="$*"
+
+# coder workspace names allow [a-z0-9-]; reject anything else
+# early so we don't get a confusing API error.
+if ! [[ "$JOB_NAME" =~ ^[a-z0-9-]+$ ]]; then
+  err "job-name must match [a-z0-9-]+ (got: $JOB_NAME)"
+fi
+
+require_cdr() {
+  command -v cdr >/dev/null 2>&1 || \
+    err "cdr not on PATH; run 'just exe-cdr-install' first"
+}
+require_cdr
+
+cleanup() {
+  local rc=$?
+  if [[ "${CDR_JOB_KEEP_ON_FAILURE:-}" == "1" ]] && [[ $rc -ne 0 ]]; then
+    log "leaving workspace '$JOB_NAME' alive (CDR_JOB_KEEP_ON_FAILURE=1, rc=$rc)"
+    log "manual cleanup: cdr delete $JOB_NAME --yes"
+    return
+  fi
+  log "tearing down workspace '$JOB_NAME' (rc=$rc)"
+  cdr delete "$JOB_NAME" --yes >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+log "creating workspace '$JOB_NAME' from template exe-dotfiles-job"
+log "  command: $JOB_COMMAND"
+
+# `coder create` blocks until the workspace agent connects, so
+# the command's startup_script has begun by the time this returns.
+cdr create "$JOB_NAME" \
+  --template exe-dotfiles-job \
+  --parameter "job_command=$JOB_COMMAND" \
+  --yes
+
+# Stream the agent's startup_script log until the agent reports
+# the script finished (workspace will then auto-stop).
+log "streaming job log (wall-clock budget: ${CDR_JOB_TIMEOUT_SEC}s)"
+START_TS=$(date +%s)
+LAST_LINE=0
+while true; do
+  # `coder show <name>` includes per-agent startup_script status.
+  # When script_state == "exited" the job has finished.
+  STATUS_JSON="$(cdr show "$JOB_NAME" --output json 2>/dev/null || echo '{}')"
+  AGENT_STATE="$(jq -r '.latest_build.resources[]?.agents[]?.lifecycle_state // empty' <<<"$STATUS_JSON" | head -1)"
+
+  # Tail new log lines.
+  LOG_LINES="$(cdr logs "$JOB_NAME" 2>/dev/null || true)"
+  TOTAL_LINES="$(echo "$LOG_LINES" | wc -l | tr -d ' ')"
+  if [[ "$TOTAL_LINES" -gt "$LAST_LINE" ]]; then
+    echo "$LOG_LINES" | sed -n "$((LAST_LINE + 1)),${TOTAL_LINES}p"
+    LAST_LINE="$TOTAL_LINES"
+  fi
+
+  case "$AGENT_STATE" in
+    ready|starting|created|"") ;;
+    start_timeout|start_error|shutdown_timeout|shutdown_error|off)
+      log "agent reached terminal state: $AGENT_STATE"
+      break
+      ;;
+  esac
+
+  NOW=$(date +%s)
+  if (( NOW - START_TS >= CDR_JOB_TIMEOUT_SEC )); then
+    log "wall-clock budget exceeded (${CDR_JOB_TIMEOUT_SEC}s); aborting"
+    exit 124
+  fi
+
+  sleep 5
+done
+
+log "job '$JOB_NAME' completed; trap-handler will delete the workspace"

--- a/justfile
+++ b/justfile
@@ -1000,7 +1000,7 @@ exe-cdr-install:
     #!/usr/bin/env bash
     set -euo pipefail
     mkdir -p "${HOME}/.local/bin"
-    for name in cdr cdr-header; do
+    for name in cdr cdr-header cdr-job; do
       src="$(pwd)/exe/scripts/$name"
       dst="${HOME}/.local/bin/$name"
       ln -sf "$src" "$dst"


### PR DESCRIPTION
## Summary

Implements steps 1 + 2 of [ADR 0008](./docs/adr/0008-event-driven-workspace-runner.md):
a second Coder workspace template (\`dotfiles-job\`) that runs a
single command and exits, plus a shell wrapper (\`cdr-job\`) that
drives the create-run-delete cycle with a \`trap\` handler so the
workspace is always torn down.

## What changed

| Path | Purpose |
|---|---|
| \`exe/coder/templates/dotfiles-job/main.tf\` | Headless template; \`job_command\` parameter; same image + VM bootstrap as the \`dotfiles-devcontainer\` sibling (apt-key fingerprint pinned) |
| \`exe/coder/templates/dotfiles-job/README.md\` | Push + run docs |
| \`exe/coder/templates/dotfiles-job/.terraform.lock.hcl\` | Provider lockfile (tracked per [ADR-style decision in PR #62](https://github.com/hironow/dotfiles/pull/62)) |
| \`exe/scripts/cdr-job\` | Wrapper: \`cdr create\` → poll/stream logs → trap \`cdr delete\` |
| \`justfile\` | \`just exe-cdr-install\` now also symlinks \`cdr-job\` |

## How to use (post-merge)

1. **Push the new template once** (operator-side):

   \`\`\`bash
   cdr templates push exe-dotfiles-job \
     -d exe/coder/templates/dotfiles-job \
     --variable project_id=gen-ai-hironow \
     --variable workspace_sa_email=$(just exe-output -raw exe_workspace_sa_email) \
     --variable coder_internal_url=$(just exe-output -raw coder_internal_url) \
     --variable image=$(just exe-output -raw artifact_registry_repo)/devcontainer:main \
     --yes
   \`\`\`

2. **Run a smoke job**:

   \`\`\`bash
   cdr-job hello -- 'echo hello $(hostname); date'
   \`\`\`

   Expected: workspace creates in ~30-60s, the agent startup_script
   runs the command, logs stream back, the trap handler issues
   \`cdr delete hello -y\` on exit.

## Failure-bound layers (per ADR 0008)

1. **Trap handler** in \`cdr-job\` — \`coder delete -y\` on EXIT (incl. SIGINT / SIGTERM / non-zero rc).
2. **Wall-clock budget** in the wrapper — \`CDR_JOB_TIMEOUT_SEC\` (default 30 min) abort.
3. (Future) Template-level \`default_ttl_ms\` + \`dormancy_threshold_ms\` — to be added in a follow-up alongside the systemd timer step.

\`CDR_JOB_KEEP_ON_FAILURE=1\` opts out of the auto-delete on failure (for forensic inspection).

## Out of scope (later PRs)

- **Step 3**: systemd timer in \`tofu/exe/coder.tf\` startup-script for Coder-VM-side cron.
- **Step 4**: first nightly use case (\`tofu plan\` → GCS).
- Template TTL / dormancy tuning (lands with step 3 once we have a real cadence to size against).