### PR TITLE
fix(cdr): polling bug + cdr-exec warm-reuse wrapper (ADR 0008 amend)

### DIFF
--- a/docs/adr/0008-event-driven-workspace-runner.md
+++ b/docs/adr/0008-event-driven-workspace-runner.md
@@ -179,3 +179,61 @@ is killed mid-flight, the `dotfiles-job` template sets:
   wrapper as CI-style jobs; they just call `claude` / `codex`
   inside the workspace instead of `tofu plan`. No code path
   forks for "agent" vs "ci".
+
+## Amendment 2026-05-03 — warm-reuse path (cdr-exec)
+
+The first smoke run of `cdr-job` measured the boot tax for a
+pure-ephemeral run at **~6 minutes** (disk + VM creation 30s +
+debian apt install / docker pull / container init ~5 min). For
+short jobs (a 1-second `tofu plan` style command) that is 99%+
+overhead and unacceptable as a default pattern.
+
+Coder Prebuilds (the official warm pool feature) would address
+this but is **Premium-license-only** as of 2026-05; not adoptable
+on this single-operator stack.
+
+To keep `cdr-job`'s pure-ephemeral semantics intact while still
+offering a low-latency option, this ADR adds a **second wrapper
+`cdr-exec`** that targets an **existing long-lived workspace**
+(`coder start <ws>` if stopped, then `coder ssh <ws> -- <cmd>`).
+Trade-offs are explicit:
+
+| | `cdr-job` | `cdr-exec` |
+|---|---|---|
+| Workspace per call | new each time | one shared, long-lived |
+| Boot tax | ~6 min (cold) | ~10-30s (warm cache) |
+| State isolation | guaranteed | NOT guaranteed (`/tmp`, env, processes persist) |
+| Concurrency | unbounded | 1 per workspace |
+| Teardown | trap `coder delete` | none — workspace stays alive |
+
+Operators choose per call:
+
+- `cdr-job` for one-shot agent tasks, secret-handling commands,
+  or anything where a previous job's leftover state could be a
+  problem.
+- `cdr-exec` for repeated short jobs (`tofu plan`, `just lint`,
+  health checks) where boot tax dominates and isolation is not
+  meaningful.
+
+`cdr-job`'s polling loop also gained a fix in this amendment:
+the agent's `lifecycle_state` transitions to `ready` after a
+successful startup_script exit (the agent process keeps running
+idly), and the prior loop only broke on terminal/error states.
+The fix breaks on `ready` for ephemeral templates so the trap-
+handler delete fires immediately instead of after the wall-clock
+budget expires.
+
+Polling-fix detail: the smoke test on PR #70 hit the 30-minute
+budget despite the actual command finishing in <1s, because the
+loop kept seeing `lifecycle_state=ready` (which the prior case
+treated as "not yet"). The fix treats `ready` after start as
+"job done, tear down" for the ephemeral-job template.
+
+A long-lived runner workspace (`coder create runner --template
+exe-dotfiles-job --parameter job_command='sleep infinity' --yes`)
+plus `cdr-exec runner -- <cmd>` is the operational pattern this
+amendment enables. A dedicated `dotfiles-runner` template was
+considered but rejected for now: the existing `dotfiles-job`
+template, when given `sleep infinity` as the job_command, fills
+the role with no new IaC. We may add a dedicated template later
+if the runner needs different VM sizing or volume layout.

--- a/exe/scripts/README.md
+++ b/exe/scripts/README.md
@@ -8,6 +8,8 @@ Operational scripts for `exe.hironow.dev`.
 |---|---|
 | [`cdr`](./cdr) | Wrapper around the upstream `coder` CLI. Fetches Cloudflare Access service-token credentials from Secret Manager (cached for 5 min), exports `CODER_HEADER_COMMAND`, then exec's `coder` with the original arguments. Symlinked into `~/.local/bin` via `just exe-cdr-install`. |
 | [`cdr-header`](./cdr-header) | Helper invoked by `cdr` via `CODER_HEADER_COMMAND` to emit the `CF-Access-*` headers Coder needs on every API call. |
+| [`cdr-job`](./cdr-job) | Run a single command in a fresh ephemeral Coder workspace per [ADR 0008](../../docs/adr/0008-event-driven-workspace-runner.md). Pure isolation, ~6 min boot tax. Trap-handler `coder delete` on exit. |
+| [`cdr-exec`](./cdr-exec) | Run a command in an EXISTING long-lived workspace (warm reuse, ~10-30s start). State is NOT isolated between calls. See ADR 0008 amendment for the trade-off. |
 | [`bootstrap.sh`](./bootstrap.sh) | First-time provisioning helper (tofu apply + cloudflared tunnel login). Idempotent. |
 | [`teardown.sh`](./teardown.sh) | Destroys the GCE workspace VM and Coder template, retains Cloudflare + Tailscale state for re-bootstrap. Idempotent. |
 | [`smoke.sh`](./smoke.sh) | Post-deploy connectivity checks (Tailscale up, CF Access reachable, SSH reachable, Coder UI 200). Idempotent. |

--- a/exe/scripts/cdr-exec
+++ b/exe/scripts/cdr-exec
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# cdr-exec — run a command inside an EXISTING long-lived Coder
+# workspace (D2 warm-reuse pattern, see ADR 0008 amendment).
+#
+# Usage:
+#   cdr-exec <workspace-name> -- <command...>
+#
+# Example:
+#   cdr-exec runner -- 'cd /root/dotfiles/tofu/exe && just exe-plan'
+#
+# What this does:
+#   1. Reuse `cdr` for the CF Access service-token chain.
+#   2. `coder show <ws>` — verify workspace exists.
+#   3. If workspace is stopped, `coder start <ws>` and wait until
+#      the agent reaches `ready` (warm boot — disk + image cache
+#      survives, so this is ~10-30s vs ~6 min for a fresh create).
+#   4. `coder ssh <ws> -- 'sh -c "<command>"'` — exec inside the
+#      existing container. Output streams back; exit code is
+#      forwarded.
+#   5. The workspace is **NOT** stopped or deleted afterwards. The
+#      operator (or template autostop / dormancy) handles that.
+#
+# Trade-off vs `cdr-job` (per ADR 0008 amendment):
+#   - cdr-job: pure ephemeral, fresh VM each time, ~6 min boot tax,
+#     state isolation guaranteed
+#   - cdr-exec: warm reuse, ~10-30s boot tax, state may persist
+#     between invocations (/tmp, env vars, processes)
+#
+# Use cdr-exec when isolation does not matter and latency does
+# (e.g., quick `tofu plan`, repeated `just lint`). Use cdr-job
+# when isolation matters (one-shot agent task, secret-handling
+# command).
+#
+# Required tools: cdr (which requires gcloud + coder).
+
+set -euo pipefail
+
+err() { printf '\033[31m[cdr-exec]\033[0m %s\n' "$*" >&2; exit 1; }
+log() { printf '\033[36m[cdr-exec]\033[0m %s\n' "$*" >&2; }
+
+# Wall-clock budget for warm boot + exec. Override via env.
+CDR_EXEC_TIMEOUT_SEC="${CDR_EXEC_TIMEOUT_SEC:-1800}" # 30 min default
+
+if [[ $# -lt 3 ]] || [[ "$2" != "--" ]]; then
+  err "usage: cdr-exec <workspace-name> -- <command...>"
+fi
+
+WS_NAME="$1"
+shift 2
+EXEC_COMMAND="$*"
+
+if ! [[ "$WS_NAME" =~ ^[a-z0-9-]+$ ]]; then
+  err "workspace-name must match [a-z0-9-]+ (got: $WS_NAME)"
+fi
+
+command -v cdr >/dev/null 2>&1 || \
+  err "cdr not on PATH; run 'just exe-cdr-install' first"
+
+log "checking workspace '$WS_NAME'"
+WS_JSON="$(cdr show "$WS_NAME" --output json 2>/dev/null || true)"
+if [[ -z "$WS_JSON" ]] || [[ "$WS_JSON" == "null" ]]; then
+  err "workspace '$WS_NAME' does not exist; create it first with cdr create"
+fi
+
+WS_STATUS="$(jq -r '.latest_build.status // empty' <<<"$WS_JSON")"
+log "current status: ${WS_STATUS:-unknown}"
+
+case "$WS_STATUS" in
+  running)
+    log "workspace already running; skipping start"
+    ;;
+  stopped|"")
+    log "starting workspace (warm boot — disk + image cache survives)"
+    cdr start "$WS_NAME" --yes
+    ;;
+  starting|stopping|deleting|deleted|canceling|pending)
+    err "workspace is in transient state '$WS_STATUS'; retry once it settles"
+    ;;
+  *)
+    err "unexpected workspace status '$WS_STATUS'"
+    ;;
+esac
+
+# Wait until agent reaches `ready` (cdr start returns once the
+# build completes, but the agent may still be coming up).
+START_TS=$(date +%s)
+log "waiting for agent ready"
+while true; do
+  STATUS_JSON="$(cdr show "$WS_NAME" --output json 2>/dev/null || echo '{}')"
+  AGENT_STATE="$(jq -r '.latest_build.resources[]?.agents[]?.lifecycle_state // empty' <<<"$STATUS_JSON" | head -1)"
+
+  case "$AGENT_STATE" in
+    ready)
+      log "agent ready; exec'ing command"
+      break
+      ;;
+    starting|created|"") ;;
+    start_timeout|start_error|shutdown_timeout|shutdown_error|off)
+      err "agent reached terminal state '$AGENT_STATE' before becoming ready"
+      ;;
+  esac
+
+  NOW=$(date +%s)
+  if (( NOW - START_TS >= CDR_EXEC_TIMEOUT_SEC )); then
+    err "agent did not reach ready within ${CDR_EXEC_TIMEOUT_SEC}s"
+  fi
+
+  sleep 3
+done
+
+log "command: $EXEC_COMMAND"
+exec cdr ssh "$WS_NAME" -- sh -c "$EXEC_COMMAND"

--- a/exe/scripts/cdr-job
+++ b/exe/scripts/cdr-job
@@ -105,7 +105,16 @@ while true; do
   fi
 
   case "$AGENT_STATE" in
-    ready|starting|created|"") ;;
+    ready)
+      # `ready` for an ephemeral-job template means the agent's
+      # startup_script (which IS the job) has exited successfully
+      # — the agent process keeps running idly, but the job
+      # itself is done. Break out so the trap-handler can delete
+      # the workspace.
+      log "agent state=ready (startup_script finished); tearing down"
+      break
+      ;;
+    starting|created|"") ;;
     start_timeout|start_error|shutdown_timeout|shutdown_error|off)
       log "agent reached terminal state: $AGENT_STATE"
       break

--- a/justfile
+++ b/justfile
@@ -1000,7 +1000,7 @@ exe-cdr-install:
     #!/usr/bin/env bash
     set -euo pipefail
     mkdir -p "${HOME}/.local/bin"
-    for name in cdr cdr-header cdr-job; do
+    for name in cdr cdr-header cdr-job cdr-exec; do
       src="$(pwd)/exe/scripts/$name"
       dst="${HOME}/.local/bin/$name"
       ln -sf "$src" "$dst"


### PR DESCRIPTION
## Summary

Two related changes that emerged from PR #70's first smoke run:

1. **\`cdr-job\` polling bug** — the smoke run hit its 30-min budget despite the actual command finishing in <1s. Root cause: agent \`lifecycle_state\` transitions to \`ready\` after a successful \`startup_script\` exit (the agent itself keeps running idly), and the loop only broke on terminal/error states. Fix: treat \`ready\` as \"startup_script done — tear down\" for the ephemeral-job template.

2. **New \`cdr-exec\` wrapper** for the **warm-reuse** pattern against an existing long-lived workspace. \`cdr show\` → \`cdr start\` (if stopped) → \`cdr ssh exec\`. Boot tax drops from **~6 min (cold create)** to **~10-30s (warm cache survives stop)**.

Coder Prebuilds (the official warm-pool feature) would solve this directly but is **Premium-license-only** as of 2026-05; \`cdr-exec\` + a long-lived runner gets ~90% of the value at zero license cost.

## Trade-off (documented in ADR 0008 amend)

| | \`cdr-job\` | \`cdr-exec\` |
|---|---|---|
| Workspace per call | new each time | one shared, long-lived |
| Boot tax | ~6 min (cold) | ~10-30s (warm cache) |
| State isolation | guaranteed | NOT guaranteed (\`/tmp\`, env, processes persist) |
| Concurrency | unbounded | 1 per workspace |
| Teardown | trap \`coder delete\` | none — workspace stays alive |

## Operator pattern (post-merge)

\`\`\`bash
# 1. one-time: create the long-lived runner workspace
cdr create runner --template exe-dotfiles-job \
  --parameter job_command='sleep infinity' --yes

# 2. ongoing: low-latency exec
cdr-exec runner -- 'cd /root/dotfiles/tofu/exe && just exe-plan'

# 3. when isolation is needed, fall back to ephemeral
cdr-job audit -- 'codex review-pr 42'
\`\`\`

## Files

| Path | Change |
|---|---|
| \`exe/scripts/cdr-job\` | break polling on \`ready\` (the bug fix) |
| \`exe/scripts/cdr-exec\` | NEW — warm-reuse wrapper |
| \`exe/scripts/README.md\` | both wrappers in the file table |
| \`docs/adr/0008-event-driven-workspace-runner.md\` | "Amendment 2026-05-03 — warm-reuse path (cdr-exec)" section |
| \`justfile\` | \`exe-cdr-install\` symlinks \`cdr-exec\` too |

## Why one PR (not two)

The polling fix alone is small and correct, but it does not solve the latency problem the smoke surfaced. Operator wanted the warm-reuse follow-up bundled so the post-merge story is "now you have both patterns and can choose per call." The change set is still ~180 lines, all tightly related to the cdr-job/cdr-exec runner contract.