### PR TITLE
feat(exe): on-VM systemd timer scaffolding (ADR 0008 step 3)

### DIFF
--- a/exe/docs/architecture.md
+++ b/exe/docs/architecture.md
@@ -204,6 +204,25 @@ The first-boot admin password is generated to
 `/var/lib/coder/.admin_password` (mode 0600). Change it via the Coder
 UI immediately after first login.
 
+### On-VM cron (ADR 0008 step 3)
+
+The Coder VM also hosts the systemd-timer half of the event-driven
+runner ([ADR 0008](../../docs/adr/0008-event-driven-workspace-runner.md)).
+Two pieces ship in the VM startup_script:
+
+| File | Purpose |
+|---|---|
+| `/etc/default/coder-cron` | Env file with `CODER_CRON_SECRET_NAME` + `CODER_CRON_PROJECT`. Sourced by the helper. |
+| `/usr/local/bin/coder-cron-run` | Helper that fetches the admin token from Secret Manager (`exe-coder-admin-token`) and `exec`s `coder` against `http://127.0.0.1:7080`. Exits 65 with a runbook pointer if the token version is missing. |
+| `coder-cron-heartbeat.service` + `.timer` | Daily `logger` one-shot at 09:17 UTC (`Persistent=true`, `RandomizedDelaySec=300`). Pure smoke validation — does NOT call `coder-cron-run`, so it works before the operator sets up the admin token. |
+
+Concrete cron use cases (e.g., nightly `tofu plan` to GCS) get added
+as additional `.service` + `.timer` units in step 4. The helper +
+heartbeat scaffolding here is the building block.
+
+Operator one-time setup for the admin token is in
+[runbook.md › Coder admin token for cron](./runbook.md#coder-admin-token-for-cron).
+
 ## Workspace template — `dotfiles-devcontainer`
 
 Source: [`exe/coder/templates/dotfiles-devcontainer/`](../coder/templates/dotfiles-devcontainer/).

--- a/exe/docs/runbook.md
+++ b/exe/docs/runbook.md
@@ -192,6 +192,63 @@ gcloud secrets versions list exe-tailscale-coder-authkey
 gcloud secrets versions destroy <N> --secret=exe-tailscale-coder-authkey
 ```
 
+## Coder admin token for cron
+
+Per [ADR 0008](../../docs/adr/0008-event-driven-workspace-runner.md)
+the Coder VM runs a local systemd timer that calls the Coder API on
+`http://127.0.0.1:7080`. The helper at `/usr/local/bin/coder-cron-run`
+fetches an admin token from Secret Manager (`exe-coder-admin-token`)
+and exports it as `CODER_SESSION_TOKEN` for the duration of one
+`coder` invocation.
+
+Tofu creates the secret *shell* but cannot generate the value: the
+token comes from `coder tokens create`, which requires the Coder
+server to be running. So the operator runs this **once after the
+first apply**:
+
+```bash
+# Login on the Mac if not already (browser flow).
+cdr login https://exe.hironow.dev
+
+# Mint a long-lived token for cron use.
+cdr tokens create --lifetime 720h --name cron > /tmp/coder-cron-token
+# (4320h = 180 days; choose a lifetime that fits your rotation policy.)
+
+# Upload as the first version on the existing Secret Manager secret.
+gcloud secrets versions add exe-coder-admin-token \
+  --project=gen-ai-hironow \
+  --data-file=/tmp/coder-cron-token
+
+# Wipe the local copy.
+shred -u /tmp/coder-cron-token   # or rm -P on mac
+```
+
+Verify on the Coder VM:
+
+```bash
+ssh exe-coder.<tailnet>
+sudo /usr/local/bin/coder-cron-run users list
+```
+
+Expected: a JSON list of users, exit 0. If the helper exits 65 with a
+"failed to fetch" message, the secret has no version yet — re-run the
+`gcloud secrets versions add` step.
+
+The `coder-cron-heartbeat.timer` that ships with this stack does NOT
+use this token — it is a pure `logger` one-shot that proves the timer
+mechanism works without depending on operator-side setup. Inspect it
+on the VM with:
+
+```bash
+journalctl -u coder-cron-heartbeat --since today
+# expected: a single 'tick' line per day shortly after 09:17 UTC
+systemctl list-timers coder-cron-heartbeat.timer
+```
+
+To rotate the token, `coder tokens delete <id>` the old one, mint a
+new one, and `gcloud secrets versions add` again — the helper always
+reads `latest`.
+
 ## Cloudflare tunnel credentials rotation
 
 The tunnel secret is a `random_id`. Rotate via the `just exe-replace`

--- a/tests/exe/test_startup_script.py
+++ b/tests/exe/test_startup_script.py
@@ -67,6 +67,9 @@ HCL_SUBSTITUTIONS: dict[str, str] = {
     r"\$\{google_secret_manager_secret\.exe_coder_authkey\.secret_id\}": (
         "exe-tailscale-coder-authkey"
     ),
+    r"\$\{google_secret_manager_secret\.exe_coder_admin_token\.secret_id\}": (
+        "exe-coder-admin-token"
+    ),
     r"\$\{google_secret_manager_secret\.tunnel_credentials\.secret_id\}": (
         "exe-cloudflared-credentials"
     ),
@@ -685,7 +688,8 @@ def test_systemd_units_validate(
     startup_script: str, docker_image: str, tmp_path: Path
 ) -> None:
     """After running the script, every unit file under
-    /etc/systemd/system/{cloudflared-exe.service,coder.service} must
+    /etc/systemd/system/{cloudflared-exe.service,coder.service,
+    coder-cron-heartbeat.service,coder-cron-heartbeat.timer} must
     pass `systemd-analyze verify`. Catches missing User=, bad
     ExecStart= path, malformed Environment=, etc."""
     harness = tmp_path / "run.sh"
@@ -696,16 +700,23 @@ def test_systemd_units_validate(
         + "\n\n"
         + "echo '--- generated units ---' >&2\n"
         + "for u in /etc/systemd/system/cloudflared-exe.service "
-        + "/etc/systemd/system/coder.service; do\n"
+        + "/etc/systemd/system/coder.service "
+        + "/etc/systemd/system/coder-cron-heartbeat.service "
+        + "/etc/systemd/system/coder-cron-heartbeat.timer; do\n"
         + '  if [[ -f "$u" ]]; then\n'
         + '    echo "=== $u ===" >&2\n'
         + '    cat "$u" >&2\n'
         + '    systemd-analyze verify "$u" 2>&1 || true\n'
         + "  fi\n"
         + "done\n"
-        + "# Hard-fail if either file is missing.\n"
+        + "# Hard-fail if any unit file is missing.\n"
         + "test -f /etc/systemd/system/cloudflared-exe.service\n"
         + "test -f /etc/systemd/system/coder.service\n"
+        + "test -f /etc/systemd/system/coder-cron-heartbeat.service\n"
+        + "test -f /etc/systemd/system/coder-cron-heartbeat.timer\n"
+        + "# coder-cron-run helper + defaults file must also exist.\n"
+        + "test -x /usr/local/bin/coder-cron-run\n"
+        + "test -f /etc/default/coder-cron\n"
     )
 
     r = _run(
@@ -866,4 +877,154 @@ def test_coder_tf_no_unverified_apt_key_curls(startup_script: str) -> None:
         assert not re.search(pattern, startup_script), (
             f"coder.tf startup_script still uses the unverified-curl "
             f"pattern matching {pattern!r}."
+        )
+
+
+# ---------- ADR 0008 step 3: systemd timer scaffolding ------------
+
+
+@pytest.mark.exe
+def test_admin_token_secret_resource_present() -> None:
+    """ADR 0008 step 3 requires a Secret Manager *shell* for the Coder
+    admin token. The value is operator-provided post-apply (chicken-
+    and-egg: the token can't be created until the Coder server is up),
+    so tofu declares only the resource + IAM grant."""
+    coder_tf = (ROOT / "tofu" / "exe" / "coder.tf").read_text()
+    secret = re.search(
+        r'resource\s+"google_secret_manager_secret"\s+"exe_coder_admin_token"\s*\{(.*?)^\}',
+        coder_tf,
+        re.DOTALL | re.MULTILINE,
+    )
+    assert secret is not None, (
+        "tofu/exe/coder.tf must declare\n"
+        '  resource "google_secret_manager_secret" "exe_coder_admin_token"'
+    )
+    assert "coder-admin-token" in secret.group(1), (
+        "secret_id should embed 'coder-admin-token' so it is\n"
+        "recognisable in the GCP console alongside the other exe-* secrets"
+    )
+
+    iam = re.search(
+        r'resource\s+"google_secret_manager_secret_iam_member"\s+'
+        r'"exe_coder_admin_token_reader"\s*\{(.*?)^\}',
+        coder_tf,
+        re.DOTALL | re.MULTILINE,
+    )
+    assert iam is not None, (
+        "missing IAM grant — Coder VM SA cannot read the admin token"
+    )
+    body = iam.group(1)
+    assert "secretmanager.secretAccessor" in body
+    assert "exe_coder.email" in body, (
+        "the reader must be the exe_coder VM SA, not exe_workspace"
+    )
+
+
+@pytest.mark.exe
+def test_admin_token_secret_has_no_version_resource() -> None:
+    """The admin token value is operator-managed post-apply, so tofu
+    MUST NOT declare a google_secret_manager_secret_version for
+    exe_coder_admin_token. If a version resource were added, tofu
+    would either need a placeholder value (defeating the operator-
+    managed model) or fail at plan time on a missing variable."""
+    coder_tf = (ROOT / "tofu" / "exe" / "coder.tf").read_text()
+    assert not re.search(
+        r'resource\s+"google_secret_manager_secret_version"\s+"exe_coder_admin_token"',
+        coder_tf,
+    ), (
+        "exe_coder_admin_token must remain operator-managed (no _version "
+        "resource). Operator runs `coder tokens create | gcloud secrets "
+        "versions add` after first apply."
+    )
+
+
+@pytest.mark.exe
+def test_coder_cron_run_helper_emitted(startup_script: str) -> None:
+    """The startup_script must drop /usr/local/bin/coder-cron-run, the
+    helper any future systemd .service unit calls to talk to the local
+    Coder API. Verify the bash heredoc that materialises it is present
+    and uses CODER_URL=http://127.0.0.1:7080 (loopback only — no CF
+    Access edge round-trip)."""
+    assert "/usr/local/bin/coder-cron-run" in startup_script, (
+        "coder.tf must write coder-cron-run helper to /usr/local/bin/"
+    )
+    assert "<<'HELPER'" in startup_script, (
+        "the helper heredoc must be QUOTED so inner $#, $@, $CODER_CRON_*\n"
+        "are written literally (not expanded by the outer bash)"
+    )
+    assert "http://127.0.0.1:7080" in startup_script, (
+        "coder-cron-run must hit the local Coder server (loopback) rather\n"
+        "than the public CF Access edge — the VM has no service token chain"
+    )
+    # Operator-onboarding pointer: when the helper fails (no token
+    # version yet), the error must point at the runbook so the operator
+    # knows what to do, not just 'gcloud failed'.
+    assert "exe/docs/runbook.md" in startup_script, (
+        "the helper's NOT_FOUND error path must reference the runbook"
+    )
+
+
+@pytest.mark.exe
+def test_coder_cron_defaults_file_emitted(startup_script: str) -> None:
+    """The helper reads CODER_CRON_SECRET_NAME and CODER_CRON_PROJECT
+    from /etc/default/coder-cron (so the helper itself stays
+    operator-readable plain bash). The startup_script must populate
+    that file from the bash variables set at the top of the script."""
+    assert "/etc/default/coder-cron" in startup_script
+    assert "CODER_CRON_SECRET_NAME=" in startup_script
+    assert "CODER_CRON_PROJECT=" in startup_script
+
+
+@pytest.mark.exe
+def test_heartbeat_units_emitted(startup_script: str) -> None:
+    """ADR 0008 step 3 ships a tiny .service + .timer pair that proves
+    the systemd timer mechanism on the VM works without depending on
+    the operator-side admin token setup. The .service is a one-shot
+    `logger` call; the .timer fires daily on a non-:00 minute with
+    Persistent=true so a missed run after VM reboot still fires."""
+    assert "coder-cron-heartbeat.service" in startup_script
+    assert "coder-cron-heartbeat.timer" in startup_script
+    # Off-the-hour minute avoids the cron thundering-herd (everyone
+    # runs at :00). RandomizedDelaySec adds further jitter.
+    assert "OnCalendar=*-*-* 09:17:00 UTC" in startup_script, (
+        "heartbeat timer must use a non-:00 minute with explicit UTC; the\n"
+        "Coder VM's TZ may not be UTC, and an unanchored 09:17 would drift"
+    )
+    assert "Persistent=true" in startup_script, (
+        "Persistent=true is REQUIRED so a missed run after VM reboot\n"
+        "(preempted SPOT instance, planned restart) still fires once on\n"
+        "the next boot — see ADR 0008"
+    )
+    assert "RandomizedDelaySec=" in startup_script, (
+        "RandomizedDelaySec is recommended jitter; remove only with cause"
+    )
+
+
+@pytest.mark.exe
+def test_heartbeat_does_not_call_coder_api(startup_script: str) -> None:
+    """The whole point of the heartbeat is that it runs WITHOUT the
+    admin token — that's the smoke validation. If a future change
+    wires the heartbeat through coder-cron-run, the heartbeat starts
+    failing silently when the operator has not yet uploaded the admin
+    token, which defeats the smoke purpose. Pin the simple form."""
+    # Locate the heartbeat .service heredoc body and inspect ExecStart.
+    m = re.search(
+        r"coder-cron-heartbeat\.service\s*<<UNIT(.*?)^UNIT",
+        startup_script,
+        re.DOTALL | re.MULTILINE,
+    )
+    assert m is not None, "could not locate coder-cron-heartbeat.service heredoc"
+    unit_body = m.group(1)
+    exec_lines = [
+        ln for ln in unit_body.splitlines() if ln.lstrip().startswith("ExecStart=")
+    ]
+    assert exec_lines, "heartbeat .service must have an ExecStart= line"
+    for ln in exec_lines:
+        assert "coder-cron-run" not in ln, (
+            "heartbeat ExecStart must NOT call coder-cron-run; the heartbeat\n"
+            "is the auth-free smoke path. Real cron jobs (step 4) get their\n"
+            "own .service unit that calls coder-cron-run."
+        )
+        assert "/usr/bin/logger" in ln, (
+            "heartbeat ExecStart should use /usr/bin/logger (one-shot, journald-only)"
         )

--- a/tofu/exe/coder.tf
+++ b/tofu/exe/coder.tf
@@ -74,6 +74,36 @@ resource "google_secret_manager_secret_iam_member" "exe_coder_authkey_reader" {
   member    = "serviceAccount:${google_service_account.exe_coder.email}"
 }
 
+# Coder admin token used by the Coder VM's local cron (systemd timer)
+# to call the Coder API on http://127.0.0.1:7080. Tofu creates the
+# Secret Manager *shell* only; the operator populates the value AFTER
+# the first `tofu apply` via:
+#
+#   coder login https://exe.hironow.dev   # via cdr / browser
+#   coder tokens create --lifetime 720h --name cron \
+#     | gcloud secrets versions add exe-coder-admin-token \
+#         --project=gen-ai-hironow --data-file=-
+#
+# Until the operator does this, /usr/local/bin/coder-cron-run exits
+# with a clear error (no version → gcloud returns NOT_FOUND). The
+# coder-cron-heartbeat.timer that ships with this commit deliberately
+# does NOT call coder-cron-run — it only uses /usr/bin/logger so the
+# timer mechanism can be smoke-validated before the operator wires up
+# any real cron job. See ADR 0008 Step 3 + exe/docs/runbook.md.
+resource "google_secret_manager_secret" "exe_coder_admin_token" {
+  secret_id = "${local.prefix}-coder-admin-token"
+  labels    = local.common_labels
+  replication {
+    auto {}
+  }
+}
+
+resource "google_secret_manager_secret_iam_member" "exe_coder_admin_token_reader" {
+  secret_id = google_secret_manager_secret.exe_coder_admin_token.id
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${google_service_account.exe_coder.email}"
+}
+
 # Logs/metrics so a preempted VM still leaves a trail.
 resource "google_project_iam_member" "exe_coder_log_writer" {
   project = var.gcp_project_id
@@ -169,6 +199,7 @@ locals {
     TS_SECRET='${google_secret_manager_secret.exe_coder_authkey.secret_id}'
     CF_SECRET='${google_secret_manager_secret.tunnel_credentials.secret_id}'
     CF_TUNNEL_ID='${cloudflare_zero_trust_tunnel_cloudflared.exe.id}'
+    ADMIN_TOKEN_SECRET='${google_secret_manager_secret.exe_coder_admin_token.secret_id}'
     PROJECT='${var.gcp_project_id}'
     CODER_ACCESS_URL='https://${local.coder_host}'
     CODER_WILDCARD='${local.sandbox_host}'
@@ -423,6 +454,116 @@ locals {
     UNIT
     systemctl daemon-reload
     systemctl enable --now coder.service
+
+    # ---- ADR 0008 step 3: systemd timer scaffolding ------------------
+    # Two pieces ship together but serve different purposes:
+    #
+    #   1. /usr/local/bin/coder-cron-run — helper any future systemd
+    #      .service unit can invoke to call the local Coder API
+    #      (http://127.0.0.1:7080) authenticated with the admin token
+    #      from Secret Manager. Operator must populate the secret
+    #      version after first apply (see runbook). Until then, calling
+    #      the helper exits 65 with a clear pointer to the runbook.
+    #
+    #   2. coder-cron-heartbeat.service + .timer — pure-logger one-liner
+    #      that fires daily and writes to journald. Smoke validation
+    #      that the systemd timer mechanism itself works without
+    #      depending on the operator-side admin token setup. To inspect
+    #      on the VM:    journalctl -u coder-cron-heartbeat --since today
+    #
+    # Real cron jobs (tofu plan, lint, agent task) land in step 4 as
+    # additional .timer + .service units that DO call coder-cron-run.
+
+    # /etc/default/coder-cron — env file consumed by the helper. Keeps
+    # the secret name + project out of the helper's source so the
+    # helper itself is operator-readable plain bash.
+    cat > /etc/default/coder-cron <<DEFAULTS
+    CODER_CRON_SECRET_NAME=$ADMIN_TOKEN_SECRET
+    CODER_CRON_PROJECT=$PROJECT
+    DEFAULTS
+    chmod 0644 /etc/default/coder-cron
+
+    # /usr/local/bin/coder-cron-run — quoted heredoc so the inner
+    # bash variables (\$#, \$@, \$CODER_CRON_*) stay literal.
+    cat > /usr/local/bin/coder-cron-run <<'HELPER'
+    #!/usr/bin/env bash
+    # coder-cron-run — call the local Coder API from this VM with a
+    # short-lived admin token fetched from Secret Manager.
+    #
+    # Usage:
+    #   coder-cron-run <coder-cli-args...>
+    #
+    # Reads CODER_CRON_SECRET_NAME and CODER_CRON_PROJECT from
+    # /etc/default/coder-cron (set by tofu/exe/coder.tf startup_script
+    # at VM bootstrap). The admin token itself is created by the
+    # operator after first apply with `coder tokens create` and
+    # uploaded as a new Secret Manager version. See runbook.
+    set -euo pipefail
+
+    if [ "$#" -lt 1 ]; then
+      echo "usage: coder-cron-run <coder-cli-args...>" >&2
+      exit 64
+    fi
+
+    if [ -r /etc/default/coder-cron ]; then
+      # shellcheck disable=SC1091
+      . /etc/default/coder-cron
+    fi
+    : "$${CODER_CRON_SECRET_NAME:?CODER_CRON_SECRET_NAME is unset; check /etc/default/coder-cron}"
+    : "$${CODER_CRON_PROJECT:?CODER_CRON_PROJECT is unset; check /etc/default/coder-cron}"
+
+    if ! CODER_SESSION_TOKEN="$(gcloud --quiet \
+          --project="$CODER_CRON_PROJECT" \
+          secrets versions access latest \
+          --secret="$CODER_CRON_SECRET_NAME" 2>/dev/null)"; then
+      echo "[coder-cron-run] failed to fetch Coder admin token from Secret Manager." >&2
+      echo "[coder-cron-run] Operator action: see exe/docs/runbook.md" >&2
+      echo "[coder-cron-run] section 'Coder admin token for cron'." >&2
+      exit 65
+    fi
+    export CODER_SESSION_TOKEN
+    export CODER_URL='http://127.0.0.1:7080'
+
+    exec coder "$@"
+    HELPER
+    chmod 0755 /usr/local/bin/coder-cron-run
+
+    # coder-cron-heartbeat.service — one-shot logger; no Coder API
+    # call. Proves the timer fires; journald keeps the trail.
+    cat > /etc/systemd/system/coder-cron-heartbeat.service <<UNIT
+    [Unit]
+    Description=coder-cron heartbeat (ADR 0008 step 3 smoke)
+    After=network-online.target
+
+    [Service]
+    Type=oneshot
+    ExecStart=/usr/bin/logger -t coder-cron-heartbeat -- tick
+    NoNewPrivileges=true
+    ProtectSystem=full
+    ProtectHome=true
+    PrivateTmp=true
+    UNIT
+
+    # coder-cron-heartbeat.timer — daily at 09:17 UTC with up to 5 min
+    # of jitter. The off-the-hour minute (17 not 00) avoids cron
+    # thundering-herd; Persistent=true means a missed run after VM
+    # reboot still fires once on the next boot.
+    cat > /etc/systemd/system/coder-cron-heartbeat.timer <<UNIT
+    [Unit]
+    Description=Run coder-cron-heartbeat daily (ADR 0008 step 3)
+
+    [Timer]
+    OnCalendar=*-*-* 09:17:00 UTC
+    Persistent=true
+    RandomizedDelaySec=300
+    Unit=coder-cron-heartbeat.service
+
+    [Install]
+    WantedBy=timers.target
+    UNIT
+
+    systemctl daemon-reload
+    systemctl enable --now coder-cron-heartbeat.timer
   EOT
 }
 


### PR DESCRIPTION
ADR 0008 step 3 — adds the Coder-VM-side cron half of the
event-driven workspace runner. Triggers stay GHA-free as ADR 0008
specifies; this PR ships the second trigger source (systemd timer
on the control-plane VM) alongside the existing shell trigger
(`cdr-job` / `cdr-exec`) merged in #70 / #71.

## What lands

### IaC (`tofu/exe/coder.tf`)

- `google_secret_manager_secret.exe_coder_admin_token` — empty
  Secret Manager shell. Operator populates the version after first
  apply via `coder tokens create | gcloud secrets versions add`
  (chicken-and-egg: token can't be created until the Coder server
  is running).
- `google_secret_manager_secret_iam_member.exe_coder_admin_token_reader`
  — `roles/secretmanager.secretAccessor` for the `exe_coder` VM SA.

### VM startup_script

- `/etc/default/coder-cron` — env file with `CODER_CRON_SECRET_NAME`
  and `CODER_CRON_PROJECT`. Sourced by the helper.
- `/usr/local/bin/coder-cron-run` — fetches the admin token from
  Secret Manager and `exec`s `coder` against `http://127.0.0.1:7080`
  (loopback only; the VM has no service-token chain to take the CF
  Access edge round-trip). Exits 65 with a runbook pointer if the
  token version is missing.
- `coder-cron-heartbeat.service` + `.timer` — daily 09:17 UTC,
  `Persistent=true`, `RandomizedDelaySec=300`. Pure `logger`
  one-shot. Smoke validation that the systemd timer mechanism
  works **without** depending on operator-side admin token setup.

The heartbeat **deliberately does not** call `coder-cron-run`. Real
cron jobs (the step-4 nightly `tofu plan`) get their own
`.service` + `.timer` units that DO call the helper.

### Tests (`tests/exe/test_startup_script.py`)

Six new regressions, all green locally:

- `test_admin_token_secret_resource_present` — secret + IAM block
  exist, IAM points at the VM SA (not the workspace SA)
- `test_admin_token_secret_has_no_version_resource` — locks the
  operator-managed value contract; tofu must not own the value
- `test_coder_cron_run_helper_emitted` — quoted-heredoc form,
  `127.0.0.1:7080`, runbook pointer in error path
- `test_coder_cron_defaults_file_emitted` — `/etc/default/coder-cron`
  is written and references the bash interpolation vars
- `test_heartbeat_units_emitted` — UTC anchor, off-the-hour minute
  (avoids cron thundering-herd), `Persistent=true`,
  `RandomizedDelaySec=`
- `test_heartbeat_does_not_call_coder_api` — locks the auth-free
  smoke property: heartbeat ExecStart never invokes
  `coder-cron-run`

`test_systemd_units_validate` is also extended to verify the new
unit files via `systemd-analyze verify` (skipped on arm64 Macs by
the pre-existing tarball-arch issue; runs on amd64 CI).

### Docs

- `exe/docs/runbook.md` — new "Coder admin token for cron" section
  with the post-apply operator workflow + heartbeat inspection
  commands. The helper's exit-65 error references this section.
- `exe/docs/architecture.md` — new "On-VM cron (ADR 0008 step 3)"
  subsection mapping the new files to their purposes.

## Operator-side prerequisites

After this PR merges and `just exe-apply` provisions the new
resources, **one** manual step remains for the helper to be useful:

```bash
cdr login https://exe.hironow.dev
cdr tokens create --lifetime 720h --name cron > /tmp/coder-cron-token
gcloud secrets versions add exe-coder-admin-token \
  --project=gen-ai-hironow --data-file=/tmp/coder-cron-token
shred -u /tmp/coder-cron-token
```

The heartbeat works **without this step** so timer mechanics can
be smoke-validated immediately:

```bash
journalctl -u coder-cron-heartbeat --since today
systemctl list-timers coder-cron-heartbeat.timer
```

## What this does NOT include

- No real cron use cases yet (no nightly `tofu plan`, no `just lint`
  cron, no agent task cron). Those are step 4 — separate
  `.service` + `.timer` units calling `coder-cron-run`.
- No Cloud Scheduler trigger. Per ADR 0008 the trigger sources are
  capped at "shell" + "Coder-VM systemd timer".

## Test plan

- [x] `just exe-test` static suite — 28/28 passes (2 pre-existing
      failures on arm64 Mac unrelated to this PR; `tofu plan` and
      arm64 tarball arch)
- [x] `tofu validate` (with `TF_ENCRYPTION='{}'`) — green
- [x] `tofu fmt -check` — clean
- [ ] Operator smoke (post-merge): `just exe-apply`, then
      `journalctl -u coder-cron-heartbeat` after the next 09:17 UTC