### PR TITLE
feat(exe): nightly tofu-plan cron via ephemeral workspace (ADR 0008 step 4)

### DIFF
--- a/.devcontainer/features/dotfiles-tools/install.sh
+++ b/.devcontainer/features/dotfiles-tools/install.sh
@@ -243,6 +243,7 @@ cat > /etc/mise/config.toml <<'EOF'
 [tools]
 just = "1.40.0"
 markdownlint-cli2 = "0.22.1"
+opentofu = "1.11.6"
 prek = "0.3.11"
 uv = "0.11.8"
 vp = "0.1.20"

--- a/exe/docs/architecture.md
+++ b/exe/docs/architecture.md
@@ -215,13 +215,15 @@ Two pieces ship in the VM startup_script:
 | `/etc/default/coder-cron` | Env file with `CODER_CRON_SECRET_NAME` + `CODER_CRON_PROJECT`. Sourced by the helper. |
 | `/usr/local/bin/coder-cron-run` | Helper that fetches the admin token from Secret Manager (`exe-coder-admin-token`) and `exec`s `coder` against `http://127.0.0.1:7080`. Exits 65 with a runbook pointer if the token version is missing. |
 | `coder-cron-heartbeat.service` + `.timer` | Daily `logger` one-shot at 09:17 UTC (`Persistent=true`, `RandomizedDelaySec=300`). Pure smoke validation — does NOT call `coder-cron-run`, so it works before the operator sets up the admin token. |
+| `/usr/local/bin/coder-cron-spawn-job` | VM-side analog of `cdr-job`: generates a unique workspace name (prefix + UTC timestamp), calls `coder-cron-run create` with the dotfiles-job template, polls the agent's `lifecycle_state` until `ready` (= startup_script finished), then deletes the workspace via a trap handler. |
+| `coder-cron-tofu-plan.service` + `.timer` | Step 4 nightly use case (04:23 UTC, `Persistent=true`, `RandomizedDelaySec=600`). `bash -c` wraps the multi-step command so `&&` is shell-interpreted. The job clones dotfiles inside the workspace and runs `exe/scripts/cron-tofu-plan.sh`. |
 
-Concrete cron use cases (e.g., nightly `tofu plan` to GCS) get added
-as additional `.service` + `.timer` units in step 4. The helper +
-heartbeat scaffolding here is the building block.
-
-Operator one-time setup for the admin token is in
-[runbook.md › Coder admin token for cron](./runbook.md#coder-admin-token-for-cron).
+Operator one-time setup is in
+[runbook.md › Coder admin token for cron](./runbook.md#coder-admin-token-for-cron)
+(token) and
+[runbook.md › TF_ENCRYPTION passphrase for cron](./runbook.md#tf_encryption-passphrase-for-cron)
+(passphrase). The nightly `tofu plan` job inspection commands live in
+[runbook.md › Nightly tofu plan cron](./runbook.md#nightly-tofu-plan-cron).
 
 ## Workspace template — `dotfiles-devcontainer`
 

--- a/exe/docs/runbook.md
+++ b/exe/docs/runbook.md
@@ -249,6 +249,73 @@ To rotate the token, `coder tokens delete <id>` the old one, mint a
 new one, and `gcloud secrets versions add` again — the helper always
 reads `latest`.
 
+## TF_ENCRYPTION passphrase for cron
+
+ADR 0008 step 4 introduces a nightly `tofu plan` job that reads the
+exe stack's encrypted state from a Coder workspace VM. The
+workspace cannot reach the operator's local
+`~/.config/tofu/exe.passphrase`, so the passphrase has to live in
+Secret Manager (`exe-tofu-encryption-passphrase`). Tofu provisions
+the secret shell + IAM grant; the operator uploads the value once:
+
+```bash
+gcloud secrets versions add exe-tofu-encryption-passphrase \
+  --project=gen-ai-hironow \
+  --data-file=$HOME/.config/tofu/exe.passphrase
+```
+
+To rotate, generate a new passphrase, re-encrypt local state with
+both passphrases (transient migration), upload the new one, then
+remove the old version. Until rotation tooling lands, the
+recommended path is "don't rotate unless you have to".
+
+The workspace SA (`exe-workspace`) holds
+`roles/secretmanager.secretAccessor` on this secret and
+`roles/storage.objectAdmin` on the state bucket — both granted by
+tofu (`tofu/exe/coder.tf`).
+
+## Nightly `tofu plan` cron
+
+`coder-cron-tofu-plan.timer` on the Coder VM fires daily at 04:23
+UTC (with up to 10 min of jitter). Each fire spawns an ephemeral
+`exe-dotfiles-job` workspace whose job_command:
+
+1. Clones the dotfiles repo to `/root/cron-tofu-plan`
+2. Fetches the TF_ENCRYPTION passphrase from Secret Manager
+3. Runs `tofu init && tofu plan -refresh=false -out=plan.bin`
+4. Ships `plan.bin` (binary), `plan.txt` (human-readable), and
+   `run.log` (full stdout) to
+   `gs://gen-ai-hironow-tofu-state/jobs/<YYYY-MM-DD>/tofu-plan-<HHMMSSZ>.{bin,txt,log}`
+
+`-refresh=false` is used because the workspace SA does not yet hold
+Cloudflare or Tailscale API tokens; refresh would fail there. Once
+those grants land, drop `-refresh=false` for a true plan.
+
+Inspection:
+
+```bash
+# What plans have been generated this week?
+gcloud storage ls gs://gen-ai-hironow-tofu-state/jobs/
+
+# Read the most recent run log + plan text.
+gcloud storage cat \
+  $(gcloud storage ls gs://gen-ai-hironow-tofu-state/jobs/$(date -u +%Y-%m-%d)/ \
+    | grep '\.log$' | tail -1)
+
+# On the Coder VM itself: spawn-job logs (one line per cron run).
+ssh exe-coder.<tailnet>
+journalctl -u coder-cron-tofu-plan --since today
+systemctl list-timers coder-cron-tofu-plan.timer
+```
+
+To force-fire outside the timer cadence (for smoke testing):
+
+```bash
+ssh exe-coder.<tailnet>
+sudo systemctl start coder-cron-tofu-plan.service
+journalctl -u coder-cron-tofu-plan -f
+```
+
 ## Cloudflare tunnel credentials rotation
 
 The tunnel secret is a `random_id`. Rotate via the `just exe-replace`

--- a/exe/scripts/README.md
+++ b/exe/scripts/README.md
@@ -10,6 +10,7 @@ Operational scripts for `exe.hironow.dev`.
 | [`cdr-header`](./cdr-header) | Helper invoked by `cdr` via `CODER_HEADER_COMMAND` to emit the `CF-Access-*` headers Coder needs on every API call. |
 | [`cdr-job`](./cdr-job) | Run a single command in a fresh ephemeral Coder workspace per [ADR 0008](../../docs/adr/0008-event-driven-workspace-runner.md). Pure isolation, ~6 min boot tax. Trap-handler `coder delete` on exit. |
 | [`cdr-exec`](./cdr-exec) | Run a command in an EXISTING long-lived workspace (warm reuse, ~10-30s start). State is NOT isolated between calls. See ADR 0008 amendment for the trade-off. |
+| [`cron-tofu-plan.sh`](./cron-tofu-plan.sh) | Workspace-side script invoked by `coder-cron-tofu-plan.timer` (ADR 0008 step 4). Clones dotfiles, fetches `TF_ENCRYPTION` from Secret Manager, runs `tofu init && tofu plan -refresh=false`, ships artifacts to `gs://<project>-tofu-state/jobs/<date>/`. Always exits 0 so diagnostics ship even when tofu fails. |
 | [`bootstrap.sh`](./bootstrap.sh) | First-time provisioning helper (tofu apply + cloudflared tunnel login). Idempotent. |
 | [`teardown.sh`](./teardown.sh) | Destroys the GCE workspace VM and Coder template, retains Cloudflare + Tailscale state for re-bootstrap. Idempotent. |
 | [`smoke.sh`](./smoke.sh) | Post-deploy connectivity checks (Tailscale up, CF Access reachable, SSH reachable, Coder UI 200). Idempotent. |

--- a/exe/scripts/cron-tofu-plan.sh
+++ b/exe/scripts/cron-tofu-plan.sh
@@ -1,0 +1,153 @@
+#!/usr/bin/env bash
+# cron-tofu-plan.sh — runs INSIDE an ephemeral Coder workspace
+# spawned by the Coder VM's nightly systemd timer (ADR 0008 step 4).
+#
+# Responsibility chain:
+#   1. coder-cron-tofu-plan.timer fires on the Coder VM
+#   2. coder-cron-tofu-plan.service ExecStart calls
+#      coder-cron-spawn-job, which:
+#       - generates a unique workspace name
+#       - calls coder-cron-run create <name> --template
+#         exe-dotfiles-job --parameter "job_command=<this script>"
+#       - polls until the agent's startup_script (which IS this
+#         script) finishes, then deletes the workspace
+#   3. The workspace's agent runs THIS script. The script:
+#       - clones the dotfiles repo (workspace VMs do not bake it)
+#       - fetches the TF_ENCRYPTION passphrase from Secret Manager
+#       - runs `tofu init && tofu plan -refresh=false -out=plan.bin`
+#       - ships plan.bin (binary) + plan.txt (human-readable) to
+#         gs://<project>-tofu-state/jobs/<date>/
+#       - prints a final summary to stdout (captured into journald
+#         on the Coder VM via cdr logs)
+#
+# Failure mode: each step is best-effort wrapped — diagnostic output
+# is shipped to GCS even when tofu plan fails (which is informative
+# for the operator on first runs while CF/TS API token grants are
+# still pending). The script ALWAYS exits 0 unless prerequisites are
+# missing; per-step failures are captured in the artifact.
+
+set -uo pipefail
+
+PROJECT="${EXE_PROJECT_ID:-gen-ai-hironow}"
+PASSPHRASE_SECRET="${EXE_TOFU_PASSPHRASE_SECRET:-exe-tofu-encryption-passphrase}"
+STATE_BUCKET="${EXE_STATE_BUCKET:-${PROJECT}-tofu-state}"
+DOTFILES_REPO="${EXE_DOTFILES_REPO:-https://github.com/hironow/dotfiles.git}"
+DOTFILES_REF="${EXE_DOTFILES_REF:-main}"
+WORKDIR="${EXE_WORKDIR:-/root/cron-tofu-plan}"
+
+# UTC date stamps for artifact naming.
+DATE_STAMP="$(date -u +%Y-%m-%d)"
+TIME_STAMP="$(date -u +%H%M%SZ)"
+ARTIFACT_PREFIX="gs://${STATE_BUCKET}/jobs/${DATE_STAMP}/tofu-plan-${TIME_STAMP}"
+
+log() { printf '[cron-tofu-plan] %s\n' "$*"; }
+err() { printf '[cron-tofu-plan] ERROR: %s\n' "$*" >&2; }
+
+log "starting; artifact prefix=${ARTIFACT_PREFIX}"
+
+require() {
+  command -v "$1" >/dev/null 2>&1 || {
+    err "missing required tool: $1"
+    exit 70
+  }
+}
+require git
+require gcloud
+require tofu
+
+# 1. Clone or refresh the dotfiles repo.
+mkdir -p "$(dirname "$WORKDIR")"
+if [ -d "${WORKDIR}/.git" ]; then
+  log "refreshing existing clone at ${WORKDIR}"
+  git -C "$WORKDIR" fetch --depth 1 origin "$DOTFILES_REF" || \
+    err "git fetch failed; continuing with existing checkout"
+  git -C "$WORKDIR" checkout -q "origin/${DOTFILES_REF}" || true
+else
+  log "cloning ${DOTFILES_REPO}@${DOTFILES_REF} to ${WORKDIR}"
+  if ! git clone --depth 1 --branch "$DOTFILES_REF" "$DOTFILES_REPO" "$WORKDIR"; then
+    err "git clone failed"
+    exit 71
+  fi
+fi
+
+# 2. Fetch TF_ENCRYPTION passphrase from Secret Manager.
+log "fetching TF_ENCRYPTION passphrase from secret '${PASSPHRASE_SECRET}'"
+if ! PASSPHRASE="$(gcloud --quiet --project="$PROJECT" \
+      secrets versions access latest \
+      --secret="$PASSPHRASE_SECRET" 2>/dev/null)"; then
+  err "failed to fetch passphrase from Secret Manager."
+  err "Operator action: see exe/docs/runbook.md section 'TF_ENCRYPTION passphrase for cron'."
+  exit 72
+fi
+
+# Build the HCL TF_ENCRYPTION payload (mirrors justfile:_exe-encryption).
+TF_ENCRYPTION="$(cat <<HCL
+key_provider "pbkdf2" "default" {
+  passphrase = "${PASSPHRASE}"
+}
+method "aes_gcm" "default" {
+  keys = key_provider.pbkdf2.default
+}
+state {
+  method   = method.aes_gcm.default
+  enforced = true
+}
+plan {
+  method   = method.aes_gcm.default
+  enforced = true
+}
+HCL
+)"
+export TF_ENCRYPTION
+unset PASSPHRASE
+
+# 3. tofu init + plan. The whole block is captured to a log file
+#    that ships to GCS regardless of exit code.
+RUN_DIR="$(mktemp -d)"
+PLAN_BIN="${RUN_DIR}/plan.bin"
+PLAN_TXT="${RUN_DIR}/plan.txt"
+RUN_LOG="${RUN_DIR}/run.log"
+
+cd "${WORKDIR}/tofu/exe" || { err "cd ${WORKDIR}/tofu/exe failed"; exit 73; }
+
+log "running tofu init"
+{
+  echo "=== tofu init ==="
+  tofu init -input=false -upgrade=false 2>&1
+  init_rc=$?
+  echo "tofu init rc=${init_rc}"
+
+  echo "=== tofu plan -refresh=false ==="
+  # -refresh=false avoids reaching the CF / Tailscale APIs (whose
+  # tokens are not yet provisioned to this workspace SA). Once
+  # those grants land, drop -refresh=false for a true plan.
+  tofu plan -input=false -refresh=false -out="${PLAN_BIN}" 2>&1
+  plan_rc=$?
+  echo "tofu plan rc=${plan_rc}"
+
+  if [ "${plan_rc}" -eq 0 ] && [ -f "${PLAN_BIN}" ]; then
+    echo "=== tofu show ==="
+    tofu show "${PLAN_BIN}" > "${PLAN_TXT}" 2>&1
+    echo "(human-readable plan written to ${PLAN_TXT})"
+  fi
+} > "${RUN_LOG}" 2>&1
+final_rc=$?
+
+log "tofu run finished (final rc=${final_rc}); shipping artifacts"
+
+# 4. Ship artifacts to GCS. Each upload is independent so a partial
+#    set still surfaces useful debugging.
+gcloud --quiet storage cp "${RUN_LOG}" "${ARTIFACT_PREFIX}.log" || \
+  err "failed to upload run.log"
+if [ -f "${PLAN_BIN}" ]; then
+  gcloud --quiet storage cp "${PLAN_BIN}" "${ARTIFACT_PREFIX}.bin" || \
+    err "failed to upload plan.bin"
+fi
+if [ -f "${PLAN_TXT}" ]; then
+  gcloud --quiet storage cp "${PLAN_TXT}" "${ARTIFACT_PREFIX}.txt" || \
+    err "failed to upload plan.txt"
+fi
+
+log "done; artifacts at ${ARTIFACT_PREFIX}.{log,bin,txt}"
+log "inspect: gcloud storage ls ${ARTIFACT_PREFIX}.*"
+exit 0

--- a/mise.toml
+++ b/mise.toml
@@ -7,6 +7,7 @@
 # constants in .devcontainer/features/dotfiles-tools/install.sh.
 just = "1.40.0"
 markdownlint-cli2 = "0.22.1"
+opentofu = "1.11.6"
 prek = "0.3.11"
 uv = "0.11.8"
 # `vp` is the mise registry alias for npm:vite-plus (NOT the

--- a/tests/exe/test_startup_script.py
+++ b/tests/exe/test_startup_script.py
@@ -702,7 +702,9 @@ def test_systemd_units_validate(
         + "for u in /etc/systemd/system/cloudflared-exe.service "
         + "/etc/systemd/system/coder.service "
         + "/etc/systemd/system/coder-cron-heartbeat.service "
-        + "/etc/systemd/system/coder-cron-heartbeat.timer; do\n"
+        + "/etc/systemd/system/coder-cron-heartbeat.timer "
+        + "/etc/systemd/system/coder-cron-tofu-plan.service "
+        + "/etc/systemd/system/coder-cron-tofu-plan.timer; do\n"
         + '  if [[ -f "$u" ]]; then\n'
         + '    echo "=== $u ===" >&2\n'
         + '    cat "$u" >&2\n'
@@ -714,8 +716,11 @@ def test_systemd_units_validate(
         + "test -f /etc/systemd/system/coder.service\n"
         + "test -f /etc/systemd/system/coder-cron-heartbeat.service\n"
         + "test -f /etc/systemd/system/coder-cron-heartbeat.timer\n"
-        + "# coder-cron-run helper + defaults file must also exist.\n"
+        + "test -f /etc/systemd/system/coder-cron-tofu-plan.service\n"
+        + "test -f /etc/systemd/system/coder-cron-tofu-plan.timer\n"
+        + "# Helpers + defaults file must also exist.\n"
         + "test -x /usr/local/bin/coder-cron-run\n"
+        + "test -x /usr/local/bin/coder-cron-spawn-job\n"
         + "test -f /etc/default/coder-cron\n"
     )
 
@@ -747,20 +752,43 @@ def test_coder_install_does_not_pipe_remote_script(startup_script: str) -> None:
     """ADR 0007: the bootstrap MUST NOT install Coder via
     `curl https://coder.com/install.sh | sh` or any other remote-
     script-piped-into-shell pattern. Replacement is a tag-pinned
-    tarball with sha256 verify."""
-    forbidden = [
+    tarball with sha256 verify.
+
+    The `|| true` ban is scoped to the Coder install block only — it
+    was flagged by codex as a way to mask the integrity check's exit
+    code there. `|| true` is a legitimate idiom in trap-cleanup
+    handlers (e.g. coder-cron-spawn-job's teardown) and elsewhere, so
+    we must not blanket-ban it across the whole script."""
+    # Globally forbidden patterns (apply to the entire script).
+    global_forbidden = [
         r"coder\.com/install\.sh",
         r"curl[^\n]*\|\s*sh\b",
         r"curl[^\n]*\|\s*bash\b",
-        r"\|\| true",  # the masking exit-code pattern flagged by codex
         r"releases/latest",  # the latest-resolution fallback
     ]
-    for pattern in forbidden:
+    for pattern in global_forbidden:
         assert not re.search(pattern, startup_script), (
             f"Coder install path still contains forbidden pattern "
             f"{pattern!r}; ADR 0007 prohibits it. Use the pinned-tag "
             f"+ sha256-verified path instead."
         )
+
+    # Scoped: extract the Coder install block (between '# ---- Coder
+    # OSS server' and the systemctl that enables coder.service) and
+    # ban `|| true` there only.
+    install_block = re.search(
+        r"# ---- Coder OSS server.*?systemctl enable --now coder\.service",
+        startup_script,
+        re.DOTALL,
+    )
+    assert install_block is not None, (
+        "could not locate the Coder OSS server install block"
+    )
+    assert "|| true" not in install_block.group(0), (
+        "Coder install block contains '|| true' — that pattern was used\n"
+        "to mask the sha256/attestation check exit code. ADR 0007 forbids\n"
+        "it within the install path; let the script fail closed instead."
+    )
 
 
 @pytest.mark.exe
@@ -1028,3 +1056,171 @@ def test_heartbeat_does_not_call_coder_api(startup_script: str) -> None:
         assert "/usr/bin/logger" in ln, (
             "heartbeat ExecStart should use /usr/bin/logger (one-shot, journald-only)"
         )
+
+
+# ---------- ADR 0008 step 4: nightly tofu-plan cron ----------------
+
+
+@pytest.mark.exe
+def test_tofu_encryption_passphrase_secret_resource_present() -> None:
+    """ADR 0008 step 4: cron jobs that read the encrypted exe state
+    need the TF_ENCRYPTION passphrase. Tofu owns the secret SHELL +
+    IAM grant only — the value (the operator's local passphrase from
+    ~/.config/tofu/exe.passphrase) is uploaded once after first
+    apply, mirroring the admin-token pattern from step 3."""
+    coder_tf = (ROOT / "tofu" / "exe" / "coder.tf").read_text()
+    secret = re.search(
+        r'resource\s+"google_secret_manager_secret"\s+"exe_tofu_encryption_passphrase"\s*\{(.*?)^\}',
+        coder_tf,
+        re.DOTALL | re.MULTILINE,
+    )
+    assert secret is not None, (
+        "tofu/exe/coder.tf must declare\n"
+        '  resource "google_secret_manager_secret" "exe_tofu_encryption_passphrase"'
+    )
+    assert "tofu-encryption-passphrase" in secret.group(1)
+
+    iam = re.search(
+        r'resource\s+"google_secret_manager_secret_iam_member"\s+'
+        r'"exe_tofu_encryption_passphrase_reader"\s*\{(.*?)^\}',
+        coder_tf,
+        re.DOTALL | re.MULTILINE,
+    )
+    assert iam is not None, "missing IAM grant for the encryption passphrase"
+    body = iam.group(1)
+    assert "secretmanager.secretAccessor" in body
+    # The READER must be the WORKSPACE SA (cron jobs run inside
+    # workspace VMs), NOT the Coder VM SA.
+    assert "exe_workspace.email" in body, (
+        "the encryption passphrase reader must be exe_workspace, not exe_coder\n"
+        "— cron jobs that need the passphrase run INSIDE workspace VMs"
+    )
+
+    # No _version resource: value is operator-managed.
+    assert not re.search(
+        r'resource\s+"google_secret_manager_secret_version"\s+"exe_tofu_encryption_passphrase"',
+        coder_tf,
+    ), "encryption passphrase value must remain operator-managed (no _version)"
+
+
+@pytest.mark.exe
+def test_workspace_state_bucket_iam_present() -> None:
+    """ADR 0008 step 4: the cron-tofu-plan job ships its plan
+    artifact to gs://<project>-tofu-state/jobs/<date>/. The workspace
+    SA must therefore have storage.objectAdmin on the state bucket.
+    The bucket is provisioned outside tofu (by exe/scripts/bootstrap.sh),
+    so the IAM resource references local.state_bucket by name."""
+    coder_tf = (ROOT / "tofu" / "exe" / "coder.tf").read_text()
+    iam = re.search(
+        r'resource\s+"google_storage_bucket_iam_member"\s+'
+        r'"exe_workspace_state_bucket_admin"\s*\{(.*?)^\}',
+        coder_tf,
+        re.DOTALL | re.MULTILINE,
+    )
+    assert iam is not None, (
+        "tofu/exe/coder.tf must declare a google_storage_bucket_iam_member\n"
+        "granting roles/storage.objectAdmin on the state bucket to the\n"
+        "workspace SA"
+    )
+    body = iam.group(1)
+    assert "storage.objectAdmin" in body
+    assert "exe_workspace.email" in body
+    assert "local.state_bucket" in body, (
+        "use local.state_bucket so the bucket name stays consistent with\n"
+        "the bootstrap script and outputs.tf"
+    )
+
+
+@pytest.mark.exe
+def test_coder_cron_spawn_job_helper_emitted(startup_script: str) -> None:
+    """The startup_script must drop /usr/local/bin/coder-cron-spawn-job,
+    the VM-side analog of cdr-job. It generates a unique workspace
+    name (prefix + UTC timestamp), polls the agent's lifecycle_state,
+    and traps `coder-cron-run delete` on exit."""
+    assert "/usr/local/bin/coder-cron-spawn-job" in startup_script
+    # Must use coder-cron-run (the local-API helper), not cdr (which
+    # would try the CF Access edge from the VM and have no creds).
+    assert "coder-cron-run create" in startup_script
+    assert "coder-cron-run delete" in startup_script
+    # Trap-handler teardown is the primary safety net per ADR 0008.
+    assert "trap cleanup EXIT" in startup_script, (
+        "spawn-job must register a trap handler so SIGTERM / failure\n"
+        "still reaps the workspace"
+    )
+    # The polling loop must break on `ready` (the lifecycle_state for
+    # an ephemeral-job template after startup_script exits) — same
+    # fix that landed in cdr-job in PR #71.
+    assert "agent state=ready" in startup_script
+
+
+@pytest.mark.exe
+def test_coder_cron_tofu_plan_units_emitted(startup_script: str) -> None:
+    """The nightly tofu-plan .timer + .service units must be present."""
+    assert "coder-cron-tofu-plan.service" in startup_script
+    assert "coder-cron-tofu-plan.timer" in startup_script
+    # 04:23 UTC is off-the-hour and during operator's typical sleep
+    # window. Anchored to UTC because the VM's TZ is not guaranteed.
+    assert "OnCalendar=*-*-* 04:23:00 UTC" in startup_script
+    assert "Persistent=true" in startup_script
+    # The .service must use bash -c so the && is interpreted as a
+    # shell operator (systemd ExecStart treats && as a literal arg).
+    assert "/bin/bash -c" in startup_script, (
+        "coder-cron-tofu-plan.service must wrap the multi-step command\n"
+        "in /bin/bash -c — systemd ExecStart does not interpret && / |"
+    )
+    # The job invokes the workspace-side cron-tofu-plan.sh from the
+    # cloned dotfiles repo.
+    assert "exe/scripts/cron-tofu-plan.sh" in startup_script
+
+
+@pytest.mark.exe
+def test_cron_tofu_plan_script_present_and_executable() -> None:
+    """The workspace-side cron-tofu-plan.sh script must exist as an
+    executable file with a bash shebang. It runs INSIDE the
+    ephemeral workspace spawned by the systemd timer; the script
+    fetches the TF_ENCRYPTION passphrase from Secret Manager, runs
+    `tofu init && tofu plan`, and ships the artifacts to GCS."""
+    script = ROOT / "exe" / "scripts" / "cron-tofu-plan.sh"
+    assert script.is_file(), f"missing workspace-side script: {script}"
+    import os
+
+    assert os.access(script, os.X_OK), f"script not executable: {script}"
+    text = script.read_text()
+    assert text.startswith("#!/usr/bin/env bash"), (
+        "cron-tofu-plan.sh must use bash shebang"
+    )
+    # The script MUST use the Secret Manager secret name we provisioned
+    # in tofu (exe-tofu-encryption-passphrase), not a hard-coded
+    # passphrase or the on-disk file path.
+    assert "exe-tofu-encryption-passphrase" in text, (
+        "cron-tofu-plan.sh must fetch the passphrase from the Secret\n"
+        "Manager secret named exe-tofu-encryption-passphrase"
+    )
+    # Artifact destination must be the state bucket under jobs/<date>/.
+    assert "gs://" in text and "/jobs/" in text, (
+        "cron-tofu-plan.sh must ship artifacts to gs://<bucket>/jobs/<date>/"
+    )
+    # The script MUST exit 0 even on tofu plan failure so the
+    # diagnostic artifact still ships to GCS (operator visibility).
+    assert "exit 0" in text
+
+
+@pytest.mark.exe
+def test_cron_tofu_plan_script_passes_shellcheck() -> None:
+    """Lint cron-tofu-plan.sh with shellcheck (warning level)."""
+    if shutil.which("shellcheck") is None:
+        pytest.skip("shellcheck not available locally")
+    script = ROOT / "exe" / "scripts" / "cron-tofu-plan.sh"
+    r = _run(["shellcheck", "--severity=warning", str(script)])
+    assert r.returncode == 0, f"shellcheck warnings:\n{r.stdout}\n{r.stderr}"
+
+
+@pytest.mark.exe
+def test_mise_toml_pins_opentofu() -> None:
+    """ADR 0008 step 4 needs `tofu` baked into the workspace dev
+    container image. mise.toml is the SoT for image-time tool
+    versions; opentofu must be pinned there."""
+    mise_toml = (ROOT / "mise.toml").read_text()
+    assert re.search(r'^opentofu\s*=\s*"\d+\.\d+\.\d+"', mise_toml, re.MULTILINE), (
+        'mise.toml must pin opentofu = "<semver>"'
+    )

--- a/tofu/exe/coder.tf
+++ b/tofu/exe/coder.tf
@@ -74,6 +74,44 @@ resource "google_secret_manager_secret_iam_member" "exe_coder_authkey_reader" {
   member    = "serviceAccount:${google_service_account.exe_coder.email}"
 }
 
+# TF_ENCRYPTION passphrase used by cron jobs that read the exe stack's
+# tofu state (e.g. nightly `tofu plan` per ADR 0008 step 4). The
+# passphrase value is operator-generated at bootstrap (lives at
+# ~/.config/tofu/exe.passphrase on the operator's Mac) and uploaded
+# here once after `just exe-apply`:
+#
+#   gcloud secrets versions add exe-tofu-encryption-passphrase \
+#     --project=gen-ai-hironow \
+#     --data-file=$HOME/.config/tofu/exe.passphrase
+#
+# Tofu owns only the secret shell + IAM grant; the value stays
+# operator-managed (re-uploading is the rotation path). Without a
+# version, the cron job fails closed with a runbook pointer.
+resource "google_secret_manager_secret" "exe_tofu_encryption_passphrase" {
+  secret_id = "${local.prefix}-tofu-encryption-passphrase"
+  labels    = local.common_labels
+  replication {
+    auto {}
+  }
+}
+
+resource "google_secret_manager_secret_iam_member" "exe_tofu_encryption_passphrase_reader" {
+  secret_id = google_secret_manager_secret.exe_tofu_encryption_passphrase.id
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${google_service_account.exe_workspace.email}"
+}
+
+# Workspace SA → state bucket. Required so cron jobs that spawn
+# ephemeral workspaces can read the encrypted state and ship plan
+# artifacts to gs://<project>-tofu-state/jobs/<date>/. The bucket
+# itself lives outside tofu (created by exe/scripts/bootstrap.sh),
+# so the IAM grant is on the bucket name (resolved from local).
+resource "google_storage_bucket_iam_member" "exe_workspace_state_bucket_admin" {
+  bucket = local.state_bucket
+  role   = "roles/storage.objectAdmin"
+  member = "serviceAccount:${google_service_account.exe_workspace.email}"
+}
+
 # Coder admin token used by the Coder VM's local cron (systemd timer)
 # to call the Coder API on http://127.0.0.1:7080. Tofu creates the
 # Secret Manager *shell* only; the operator populates the value AFTER
@@ -564,6 +602,142 @@ locals {
 
     systemctl daemon-reload
     systemctl enable --now coder-cron-heartbeat.timer
+
+    # ---- ADR 0008 step 4: nightly tofu-plan cron --------------------
+    # First real cron use case (after the heartbeat smoke). Spawns an
+    # ephemeral dotfiles-job workspace whose job_command runs
+    # exe/scripts/cron-tofu-plan.sh from the cloned dotfiles repo.
+    # Plan artifacts ship to gs://<project>-tofu-state/jobs/<date>/.
+    #
+    # Three new pieces:
+    #   1. /usr/local/bin/coder-cron-spawn-job — VM-side analog of
+    #      cdr-job: generates a unique workspace name, calls
+    #      coder-cron-run create, polls until the agent reports
+    #      ready, then deletes. Trap-handler delete on failure.
+    #   2. coder-cron-tofu-plan.service — calls the spawn-job
+    #      wrapper with a one-liner that clones dotfiles + execs
+    #      the cron-tofu-plan.sh script.
+    #   3. coder-cron-tofu-plan.timer — fires daily at 04:23 UTC
+    #      (off-the-hour minute, Persistent=true,
+    #      RandomizedDelaySec=600) so it runs while the operator is
+    #      typically asleep and out of contention with morning use.
+
+    cat > /usr/local/bin/coder-cron-spawn-job <<'SPAWN'
+    #!/usr/bin/env bash
+    # coder-cron-spawn-job — spawn an ephemeral exe-dotfiles-job
+    # workspace from the Coder VM, wait for the agent's startup_script
+    # (which IS the job) to finish, then delete the workspace.
+    #
+    # Usage:
+    #   coder-cron-spawn-job <name-prefix> <single-shell-command-string>
+    #
+    # The command MUST be a single argument (use bash -c '...' or
+    # explicit quoting to construct it from systemd ExecStart). The
+    # prefix is suffixed with -YYYYMMDD-HHMMSS to keep workspace names
+    # unique across runs. Workspace teardown happens in a trap handler
+    # so SIGTERM / failure still reaps the VM. Template-level
+    # default_ttl_ms + dormancy_threshold_ms remain the secondary +
+    # tertiary safety nets per ADR 0008.
+    set -euo pipefail
+
+    err() { printf '[coder-cron-spawn-job] ERROR: %s\n' "$*" >&2; exit 1; }
+    log() { printf '[coder-cron-spawn-job] %s\n' "$*" >&2; }
+
+    if [ "$#" -ne 2 ]; then
+      err "usage: coder-cron-spawn-job <name-prefix> <single-command-string>"
+    fi
+
+    SPAWN_TIMEOUT_SEC="$${CODER_CRON_SPAWN_TIMEOUT_SEC:-3600}" # 60 min
+
+    PREFIX="$1"
+    JOB_COMMAND="$2"
+    if ! [[ "$PREFIX" =~ ^[a-z0-9-]+$ ]]; then
+      err "name-prefix must match [a-z0-9-]+ (got: $PREFIX)"
+    fi
+    NAME="$${PREFIX}-$(date -u +%Y%m%d-%H%M%S)"
+
+    cleanup() {
+      local rc=$?
+      log "tearing down workspace '$NAME' (rc=$rc)"
+      coder-cron-run delete "$NAME" --yes >/dev/null 2>&1 || true
+    }
+    trap cleanup EXIT
+
+    log "creating workspace '$NAME' from template exe-dotfiles-job"
+    coder-cron-run create "$NAME" \
+      --template exe-dotfiles-job \
+      --parameter "job_command=$${JOB_COMMAND}" \
+      --yes
+
+    log "polling agent state (timeout $${SPAWN_TIMEOUT_SEC}s)"
+    START_TS=$(date +%s)
+    while true; do
+      STATUS_JSON="$(coder-cron-run show "$NAME" --output json 2>/dev/null || echo '{}')"
+      AGENT_STATE="$(jq -r '.latest_build.resources[]?.agents[]?.lifecycle_state // empty' \
+        <<<"$STATUS_JSON" | head -1)"
+
+      case "$AGENT_STATE" in
+        ready)
+          log "agent state=ready (startup_script finished); tearing down"
+          break
+          ;;
+        starting|created|"") ;;
+        start_timeout|start_error|shutdown_timeout|shutdown_error|off)
+          log "agent reached terminal state: $AGENT_STATE"
+          break
+          ;;
+      esac
+
+      NOW=$(date +%s)
+      if (( NOW - START_TS >= SPAWN_TIMEOUT_SEC )); then
+        log "wall-clock budget exceeded ($${SPAWN_TIMEOUT_SEC}s); aborting"
+        exit 124
+      fi
+      sleep 10
+    done
+
+    log "job '$NAME' completed; trap will delete the workspace"
+    SPAWN
+    chmod 0755 /usr/local/bin/coder-cron-spawn-job
+
+    cat > /etc/systemd/system/coder-cron-tofu-plan.service <<'UNIT'
+    [Unit]
+    Description=Nightly tofu plan via ephemeral Coder workspace (ADR 0008 step 4)
+    After=network-online.target coder.service
+    Wants=network-online.target
+
+    [Service]
+    Type=oneshot
+    EnvironmentFile=/etc/default/coder-cron
+    # systemd ExecStart does NOT interpret shell metacharacters, so
+    # the multi-step job goes through /bin/bash -c. Inside, the
+    # second arg to coder-cron-spawn-job is the single shell-string
+    # the workspace agent will exec via sh -c '...' once cloned.
+    ExecStart=/bin/bash -c '/usr/local/bin/coder-cron-spawn-job tofu-plan "git clone --depth 1 https://github.com/hironow/dotfiles.git /root/dotfiles && bash /root/dotfiles/exe/scripts/cron-tofu-plan.sh"'
+    NoNewPrivileges=true
+    ProtectSystem=full
+    ProtectHome=true
+    PrivateTmp=true
+    UNIT
+
+    cat > /etc/systemd/system/coder-cron-tofu-plan.timer <<UNIT
+    [Unit]
+    Description=Run nightly tofu plan (ADR 0008 step 4)
+
+    [Timer]
+    OnCalendar=*-*-* 04:23:00 UTC
+    Persistent=true
+    RandomizedDelaySec=600
+    Unit=coder-cron-tofu-plan.service
+
+    [Install]
+    WantedBy=timers.target
+    UNIT
+
+    systemctl daemon-reload
+    # Enabled on every boot; safe because each fire spawns a fresh
+    # workspace and the spawn-job wrapper traps teardown.
+    systemctl enable --now coder-cron-tofu-plan.timer
   EOT
 }
 


### PR DESCRIPTION
ADR 0008 step 4 — first real cron use case stacked on top of #72's
timer scaffolding (now merged at 8c4e8e5). Re-opened from #73 after
its base branch was deleted on #72 squash-merge.

The Coder VM nightly fires a fresh ephemeral workspace that plans
the exe stack and ships the artifact to GCS.

## What lands

### IaC (`tofu/exe/coder.tf`)

- `google_secret_manager_secret.exe_tofu_encryption_passphrase` —
  shell only; operator uploads the value once after first apply.
- `secretmanager.secretAccessor` IAM grant: workspace SA → that
  secret.
- `google_storage_bucket_iam_member`: workspace SA →
  `roles/storage.objectAdmin` on `local.state_bucket`.

### VM startup_script

- `/usr/local/bin/coder-cron-spawn-job` — VM-side analog of
  `cdr-job`: generates a unique workspace name, calls
  `coder-cron-run create` with the `exe-dotfiles-job` template,
  polls `lifecycle_state` until `ready`, deletes via trap.
- `coder-cron-tofu-plan.service` — `bash -c` wraps the multi-step
  command (systemd ExecStart treats `&&` as a literal arg).
- `coder-cron-tofu-plan.timer` — daily 04:23 UTC, `Persistent=true`,
  `RandomizedDelaySec=600`, enabled at boot.

### Workspace-side script (`exe/scripts/cron-tofu-plan.sh`)

1. Clone dotfiles to `/root/cron-tofu-plan`
2. Fetch `TF_ENCRYPTION` passphrase from Secret Manager
3. `tofu init && tofu plan -refresh=false -out=plan.bin`
   (`-refresh=false` because workspace SA lacks CF/TS API tokens)
4. Ship `plan.bin` + `plan.txt` + `run.log` to
   `gs://gen-ai-hironow-tofu-state/jobs/<YYYY-MM-DD>/tofu-plan-<HHMMSSZ>.{bin,txt,log}`
5. **Always exits 0** so diagnostics ship even on tofu failure

### Tooling pin (`mise.toml`)

- `opentofu = "1.11.6"` so `tofu` is baked into the dev container
  image.

### Tests (8 new)

- `test_tofu_encryption_passphrase_secret_resource_present` (reader
  = workspace SA, not Coder VM SA; no `_version` resource)
- `test_workspace_state_bucket_iam_present`
- `test_coder_cron_spawn_job_helper_emitted`
- `test_coder_cron_tofu_plan_units_emitted`
- `test_cron_tofu_plan_script_present_and_executable`
- `test_cron_tofu_plan_script_passes_shellcheck`
- `test_mise_toml_pins_opentofu`

Plus a passing test fix: scoped the global ADR 0007 `|| true` ban
to the Coder install block only — `|| true` is a legitimate idiom
in trap cleanup handlers.

### Docs

- `runbook.md` — "TF_ENCRYPTION passphrase for cron" + "Nightly
  tofu plan cron" sections.
- `architecture.md` — two new rows in the on-VM cron table.
- `scripts/README.md` — new entry for `cron-tofu-plan.sh`.

## Operator-side prerequisites (one-time, post-apply)

1. Bake the dev container image (`mise.toml` was bumped) + push
   the `exe-dotfiles-job` template.
2. Upload TF_ENCRYPTION passphrase to Secret Manager:

   ```bash
   gcloud secrets versions add exe-tofu-encryption-passphrase \
     --project=gen-ai-hironow \
     --data-file=\$HOME/.config/tofu/exe.passphrase
   ```

3. Upload Coder admin token (from #72).

## Known follow-ups

- CF / Tailscale API tokens for the workspace SA so
  `-refresh=false` can be dropped
- Concurrency lock on the spawn-job wrapper
- GCS lifecycle rule on plan artifacts (currently retained
  indefinitely)

## Test plan

- [x] `just exe-test` static suite — 35/35 + 12/12 green
- [x] `tofu validate` (with `TF_ENCRYPTION='{}'`) — green
- [x] `tofu fmt -check` — clean
- [x] `shellcheck --severity=warning` on `cron-tofu-plan.sh` — clean
- [ ] Operator smoke: post-apply, force-fire via
      `sudo systemctl start coder-cron-tofu-plan.service`,
      verify GCS artifact

Supersedes #73 (closed by base-branch deletion on #72 merge).