### PR TITLE
fix(exe): unbork Coder tarball extract on Ubuntu 24.04 (GNU tar member-match)

### DIFF
--- a/tests/exe/test_startup_script.py
+++ b/tests/exe/test_startup_script.py
@@ -777,14 +777,23 @@ def test_coder_install_uses_pinned_tag_and_sha256(startup_script: str) -> None:
 
 @pytest.mark.exe
 def test_coder_variables_have_validation() -> None:
-    """The tofu variables that drive the Coder install MUST have
+    r"""The tofu variables that drive the Coder install MUST have
     validation blocks so a mis-typed version or non-hex sha256 is
-    caught at `tofu plan` time, not at VM bootstrap time."""
+    caught at `tofu plan` time, not at VM bootstrap time.
+
+    Note on the dot-escape level: HCL string `"\\."` is two literal
+    backslashes plus a dot in the source file (the regex receives
+    `\.`). Python's read_text() returns those two backslashes
+    verbatim, so the assertion regex must match `\\` (two backslashes)
+    + `.` — written as `\\\\\.` in a Python raw-string regex
+    (`\\\\` matches two literal backslashes, `\.` matches the dot).
+    The earlier `\\\.` form was off-by-one and false-negatived this
+    check on every run."""
     variables_tf = (ROOT / "tofu" / "exe" / "variables.tf").read_text()
     # coder_version: SemVer with leading 'v'
     assert re.search(
         r'variable\s+"coder_version"\s*\{[^}]*?validation\s*\{[^}]*?'
-        r"regex\([^)]*?v\[0-9\]\+\\\.\[0-9\]\+\\\.\[0-9\]\+",
+        r"regex\([^)]*?v\[0-9\]\+\\\\\.\[0-9\]\+\\\\\.\[0-9\]\+",
         variables_tf,
         re.DOTALL,
     ), "var.coder_version must validate against a SemVer-with-v regex."
@@ -811,6 +820,66 @@ def test_coder_install_attestation_verify_is_best_effort(startup_script: str) ->
     assert has_conditional_attestation is not None, (
         "Bootstrap should attempt gh attestation verify only when gh "
         "is installed and authenticated."
+    )
+
+
+@pytest.mark.exe
+def test_coder_tarball_extract_does_not_use_bare_member_name(
+    startup_script: str,
+) -> None:
+    """Production bug 2026-05-03: the Coder release tarball stores all
+    members with a leading "./" prefix (./coder, ./LICENSE, ...). GNU
+    tar (Ubuntu 24.04 host) treats `tar -x ... coder` as an exact
+    member-name match and fails with "tar: coder: Not found in
+    archive". BSD tar (macOS dev) normalizes the leading `./` so the
+    bug only surfaces on the live VM, not on dev macs.
+
+    The result was a fatal startup_script abort on every fresh boot:
+    coder.service was never written, the Coder server never started,
+    and `https://exe.hironow.dev/` returned CF tunnel errors.
+
+    Fix: extract everything to a temp dir + `install` the binary into
+    /usr/local/bin. Robust against future tarball layout changes
+    (sub-directory, prefix tweaks) without tracking the specific
+    member name. This test pins that fix.
+    """
+    # Locate the Coder install block (between "# ---- Coder OSS server"
+    # and the systemctl that enables coder.service).
+    install_block_match = re.search(
+        r"# ---- Coder OSS server.*?systemctl enable --now coder\.service",
+        startup_script,
+        re.DOTALL,
+    )
+    assert install_block_match is not None, (
+        "could not locate the Coder OSS server install block"
+    )
+    install_block = install_block_match.group(0)
+
+    # Pin the fix: tar must NOT pass a bare 'coder' as a member-name
+    # argument anywhere within the install block.
+    bad_pattern = re.search(
+        r"tar\s+-xz?[a-z]*\s+[^\n]*?\s+coder(?:\s|$)",
+        install_block,
+    )
+    assert bad_pattern is None, (
+        "Coder install block uses `tar ... coder` — GNU tar treats this\n"
+        "as an exact member-name match and fails on the upstream tarball\n"
+        "(member is `./coder`, not `coder`). Use the temp-dir + `install`\n"
+        "pattern instead. See the 2026-05-03 production incident."
+    )
+
+    # Pin the recovery shape (positive): extract to a temp dir, then
+    # install into /usr/local/bin/coder.
+    assert "install -m 0755" in install_block, (
+        "install block should use `install -m 0755 .../coder /usr/local/bin/coder`\n"
+        "to copy the extracted binary atomically with mode."
+    )
+    assert re.search(
+        r"tar\s+-xz?[a-z]*\s+-C\s+[^\n]+\s+-f\s+[^\n]+(?<!\scoder)$",
+        install_block,
+        re.MULTILINE,
+    ), (
+        "install block should extract the whole tarball to a temp dir, not target a single member."
     )
 
 

--- a/tofu/exe/coder.tf
+++ b/tofu/exe/coder.tf
@@ -351,9 +351,21 @@ locals {
           echo "[coder-bootstrap] gh attestation verify failed (sha256 still in force)" >&2
       fi
 
-      tar -xz -C /usr/local/bin -f /tmp/$${coder_tarball} coder
-      chmod 0755 /usr/local/bin/coder
-      rm -f /tmp/$${coder_tarball}
+      # Extract via temp dir + install. The Coder release tarball stores
+      # all members with a leading "./" prefix (./coder, ./LICENSE, ...).
+      # GNU tar (Ubuntu 24.04 host) treats `tar -x ... coder` as an exact
+      # member-name match and fails with "Not found in archive" because
+      # the actual member is `./coder`. BSD tar normalizes the leading
+      # `./` so this only surfaces on the live VM, not on dev macs.
+      # Extracting to a temp dir + `install` is robust against future
+      # tarball layout changes (sub-directory, prefix tweaks) without
+      # tracking the specific member name.
+      coder_extract_dir="/tmp/coder-extract"
+      rm -rf "$${coder_extract_dir}"
+      mkdir -p "$${coder_extract_dir}"
+      tar -xz -C "$${coder_extract_dir}" -f /tmp/$${coder_tarball}
+      install -m 0755 "$${coder_extract_dir}/coder" /usr/local/bin/coder
+      rm -rf "$${coder_extract_dir}" /tmp/$${coder_tarball}
     fi
 
     # Initial admin password — generated on first boot, persisted on the


### PR DESCRIPTION
## What

Production incident 2026-05-03: a fresh Coder VM came up with no
`coder.service` running, so `https://exe.hironow.dev/` was
unreachable. Root cause was the bootstrap aborting fatally on:

```
2026-05-03T07:57:49Z startup-script: tar: coder: Not found in archive
2026-05-03T07:57:49Z startup-script: tar: Exiting with failure status
2026-05-03T07:57:49Z Script "startup-script" failed with error: exit status 2
```

The Coder release tarball at `v2.31.11` stores **all members with
a leading `./` prefix** (`./coder`, `./LICENSE`, ...). GNU tar
(Ubuntu 24.04 host) treats the member-name argument in
`tar -x ... coder` as an **exact match** and refuses to find the
`./coder` member. BSD tar (macOS dev environment) silently
normalizes the leading `./`, so this only surfaced on the live VM
— not in `tar -tzf` listings on dev macs.

The arm64 docker startup-script test
(`test_systemd_units_validate`) was hitting the SAME bug. It was
mistakenly diagnosed as an arch-only issue and dismissed; in
fact it was reproducing the production failure faithfully and we
should have read it as the canary it was.

## Fix

Extract the whole tarball into a temp dir, then `install -m 0755
.../coder /usr/local/bin/coder`:

```bash
coder_extract_dir="/tmp/coder-extract"
rm -rf "${coder_extract_dir}"
mkdir -p "${coder_extract_dir}"
tar -xz -C "${coder_extract_dir}" -f /tmp/${coder_tarball}
install -m 0755 "${coder_extract_dir}/coder" /usr/local/bin/coder
rm -rf "${coder_extract_dir}" /tmp/${coder_tarball}
```

This is robust against future tarball layout changes
(sub-directory, prefix tweaks) without tracking the specific
member name. The sha256 + (best-effort) SLSA attestation steps
before the extract still serve as the primary integrity guards
(unchanged).

## Tests

Two test changes (`test:` commit, structural):

1. **NEW** `test_coder_tarball_extract_does_not_use_bare_member_name`
   pins the recovery shape — fails if a future edit regresses to
   `tar -x ... coder` (member-name arg).
2. **REPAIRED** `test_coder_variables_have_validation`. The
   dot-escape level was off by one (Python raw-string regex
   needed `\\\\\.` to match `\\.` in the source file, not `\\\.`
   which matched only one backslash + dot). Added a docstring
   paragraph documenting the three-tier escape (HCL → file →
   Python regex) so future test authors do not miscount.

After this PR, the full exe suite is **38 passed / 1 skipped**
(skip is the deliberate dash-portability one). Both pre-existing
red tests are now green:

- `test_systemd_units_validate` — was failing with the SAME `tar`
  error; now it actually runs the full startup_script in Ubuntu
  24.04 and validates every generated systemd unit, including
  `coder.service`. This is the gate that should have caught the
  production bug before it landed.
- `test_coder_variables_have_validation` — was a quiet
  false-negative; now it actually inspects the validation regex.

## Operator-side recovery

After this merges, the production VM needs to be replaced so the
fixed startup_script runs:

```bash
export CLOUDFLARE_API_TOKEN="$(gcloud --quiet --project=gen-ai-hironow \
  secrets versions access latest --secret=exe-operator-cloudflare-token)"
export TAILSCALE_API_KEY="$(gcloud --quiet --project=gen-ai-hironow \
  secrets versions access latest --secret=exe-operator-tailscale-key)"
just exe-replace google_compute_instance.exe_coder
```

Or simpler (replaces the VM by changing the startup_script):

```bash
just exe-apply
```

(tofu detects the startup_script changed and recreates the VM
with the fix.)

After the new VM is up:

```bash
just exe-smoke           # DNS / Access gate / VM state / secrets
curl -sS https://exe.hironow.dev/ | head -5
```

## Test plan

- [x] `tofu validate` (with `TF_ENCRYPTION='{}'`) — green
- [x] `tofu fmt -check` — clean
- [x] Static + docker-based exe tests — 38/38 (was 36/38 with two
      pre-existing reds)
- [x] `bash -n` + `shellcheck` of the modified extract block — clean
- [ ] Operator: `just exe-apply` (or `just exe-replace`), then
      `just exe-smoke` + browser-test `https://exe.hironow.dev/`