### PR TITLE
fix(exe): pin Cloud SQL edition = ENTERPRISE for db-f1-micro support

### DIFF
--- a/tests/exe/test_startup_script.py
+++ b/tests/exe/test_startup_script.py
@@ -1007,6 +1007,18 @@ def test_cloud_sql_resources_present() -> None:
         "(2026 best practice — CSAP --auto-iam-authn requires this flag)."
     )
 
+    # ENTERPRISE edition pin. New Cloud SQL instances default to
+    # ENTERPRISE_PLUS, which only accepts the more expensive
+    # db-perf-optimized-N-* tiers and REJECTS db-f1-micro at
+    # create time with "Invalid Tier ... for (ENTERPRISE_PLUS)
+    # Edition." Pinning ENTERPRISE keeps the small/cheap tiers
+    # available; single-operator stack does not need EP features.
+    assert re.search(r'edition\s*=\s*"ENTERPRISE"', body), (
+        'Cloud SQL instance MUST set edition = "ENTERPRISE" — without\n'
+        "this, new instances default to ENTERPRISE_PLUS which rejects\n"
+        "db-f1-micro at apply time."
+    )
+
     # DB + IAM SA user.
     assert 'resource "google_sql_database" "coder"' in cloudsql_tf
     iam_user_block = re.search(

--- a/tofu/exe/cloudsql.tf
+++ b/tofu/exe/cloudsql.tf
@@ -60,6 +60,14 @@ resource "google_sql_database_instance" "coder" {
   deletion_protection = true
 
   settings {
+    # ENTERPRISE edition supports the legacy shared-core tiers
+    # (db-f1-micro, db-g1-small, db-custom-N-RAMMB). New instances
+    # default to ENTERPRISE_PLUS, which only accepts the more
+    # expensive db-perf-optimized-N-* tiers and rejects db-f1-micro
+    # at create time. Single-operator stack does not need EP
+    # features (Read Pools, sub-second failover, etc.); pin to
+    # ENTERPRISE so cloud_sql_tier remains a small/cheap value.
+    edition           = "ENTERPRISE"
     tier              = var.cloud_sql_tier
     availability_type = "ZONAL" # personal stack; no HA
     disk_type         = "PD_SSD"


### PR DESCRIPTION
## What

Pins `settings.edition = "ENTERPRISE"` on the Cloud SQL instance
created by ADR 0010 (#78). Without this, `just exe-apply` fails
at instance-create time:

```
Error 400: Invalid request: Invalid Tier (db-f1-micro) for
(ENTERPRISE_PLUS) Edition. Use a predefined Tier like
db-perf-optimized-N-* instead.
```

## Root cause

Cloud SQL has two editions:
- **ENTERPRISE** — supports the legacy shared-core tiers
  (`db-f1-micro`, `db-g1-small`, `db-custom-*`)
- **ENTERPRISE_PLUS** — requires the more expensive
  `db-perf-optimized-N-*` tiers

New Cloud SQL Postgres instances created via the API now default
to `ENTERPRISE_PLUS` when `settings.edition` is unspecified.
ADR 0010's IaC didn't pin the edition, so the apply hit the
default-flip in real time.

Single-operator personal stack doesn't need EP features (Read
Pools, sub-second failover, etc.). Pinning ENTERPRISE keeps
`db-f1-micro` (~$8/mo) accessible.

## Tests

`test_cloud_sql_resources_present` extended with:

```python
assert re.search(r'edition\s*=\s*"ENTERPRISE"', body)
```

Fails the build with a clear explanation if anyone removes the
explicit pin in the future.

## Operator-side

After this merges, re-run:

```bash
export CLOUDFLARE_API_TOKEN="$(gcloud --quiet --project=gen-ai-hironow \
  secrets versions access latest --secret=exe-operator-cloudflare-token)"
export TAILSCALE_API_KEY="$(gcloud --quiet --project=gen-ai-hironow \
  secrets versions access latest --secret=exe-operator-tailscale-key)"

git pull
just exe-apply
```

The previous failed apply did not leave any half-created Cloud
SQL instance behind (verified via `gcloud sql instances list` —
empty). The next apply starts from a clean state.

## Test plan

- [x] `tofu validate` — green
- [x] `tofu fmt -check` — clean
- [x] `test_cloud_sql_resources_present` — green
- [ ] Operator: re-run `just exe-apply` with this branch merged