### PR TITLE
fix(exe): wait for Cloud SQL internal IAM role before creating SA user

### DIFF
--- a/tests/exe/test_startup_script.py
+++ b/tests/exe/test_startup_script.py
@@ -1034,6 +1034,34 @@ def test_cloud_sql_resources_present() -> None:
         r'type\s*=\s*"CLOUD_IAM_SERVICE_ACCOUNT"', iam_user_block.group(1)
     ), "coder_iam user MUST have type = CLOUD_IAM_SERVICE_ACCOUNT"
 
+    # Cloud SQL provisions the internal `cloudsqliamserviceaccount`
+    # Postgres role asynchronously after the instance reports READY.
+    # Creating an IAM SA user before that role exists fails with
+    # "role \"cloudsqliamserviceaccount\" does not exist". The
+    # documented workaround is a time_sleep between instance create
+    # and user create.
+    assert 'resource "time_sleep" "cloud_sql_iam_role_settle"' in cloudsql_tf, (
+        'Missing time_sleep "cloud_sql_iam_role_settle" — without it,\n'
+        "the first apply on a brand-new project hits a race condition\n"
+        'where google_sql_user.coder_iam fails with "role\n'
+        '\\"cloudsqliamserviceaccount\\" does not exist".'
+    )
+    sleep_block = re.search(
+        r'resource\s+"time_sleep"\s+"cloud_sql_iam_role_settle"\s*\{(.*?)^\}',
+        cloudsql_tf,
+        re.DOTALL | re.MULTILINE,
+    )
+    assert sleep_block is not None
+    sleep_body = sleep_block.group(1)
+    assert "google_sql_database_instance.coder" in sleep_body, (
+        "time_sleep must depend_on google_sql_database_instance.coder"
+    )
+    # And the IAM user must wait on the sleep.
+    assert "time_sleep.cloud_sql_iam_role_settle" in iam_user_block.group(1), (
+        "google_sql_user.coder_iam MUST depend_on the time_sleep so the\n"
+        "internal role exists by the time the user is created."
+    )
+
     # Pin: there must be NO password resources of any kind. Catches a
     # regression where someone re-introduces a password-based user.
     assert "random_password" not in cloudsql_tf, (

--- a/tofu/exe/cloudsql.tf
+++ b/tofu/exe/cloudsql.tf
@@ -117,6 +117,19 @@ resource "google_sql_database" "coder" {
   instance = google_sql_database_instance.coder.name
 }
 
+# Cloud SQL provisions the internal `cloudsqliamserviceaccount`
+# Postgres role asynchronously after the instance reports READY,
+# while the IAM auth flag is being applied to the running engine.
+# Creating an IAM SA user before that role exists fails with:
+#   "role \"cloudsqliamserviceaccount\" does not exist"
+# A 60s sleep is the documented workaround in the google provider
+# tracker; longer than the typical settle time, short enough that
+# `tofu apply` users do not notice.
+resource "time_sleep" "cloud_sql_iam_role_settle" {
+  depends_on      = [google_sql_database_instance.coder]
+  create_duration = "60s"
+}
+
 # IAM service-account user. Postgres username convention for Cloud
 # SQL IAM SA users is "<sa-email-without-.gserviceaccount.com>" —
 # tofu has the bare account_id + project, we reconstruct that here.
@@ -125,6 +138,10 @@ resource "google_sql_user" "coder_iam" {
   name     = trimsuffix(google_service_account.exe_coder.email, ".gserviceaccount.com")
   instance = google_sql_database_instance.coder.name
   type     = "CLOUD_IAM_SERVICE_ACCOUNT"
+
+  # Wait for the asynchronous internal role creation. See the
+  # time_sleep above for the why.
+  depends_on = [time_sleep.cloud_sql_iam_role_settle]
 }
 
 # ----- IAM on the VM SA -----------------------------------------------


### PR DESCRIPTION
## What

Inserts a 60s `time_sleep` between Cloud SQL instance creation
and IAM SA user creation, fixing a race condition that broke
`just exe-apply` on a fresh project.

## Symptom

```
google_sql_database.coder: Creation complete after 6s
google_sql_user.coder_iam: Creating...

Error 400: failed to create user "exe-coder@gen-ai-hironow.iam":
role "cloudsqliamserviceaccount" does not exist.
```

## Root cause

Cloud SQL provisions the internal Postgres role
`cloudsqliamserviceaccount` asynchronously while the instance
reports READY and `cloudsql.iam_authentication=on` is applied to
the running engine. The role is what backs every IAM SA user.
Tofu sees the instance as ready and immediately calls the user-
create API, but the role that user-creation depends on isn't
visible yet — a documented race condition in the google
provider tracker.

A second `tofu apply` typically succeeds because by then the
role exists. We want the first apply to succeed deterministically.

## Fix

```hcl
resource "time_sleep" "cloud_sql_iam_role_settle" {
  depends_on      = [google_sql_database_instance.coder]
  create_duration = "60s"
}

resource "google_sql_user" "coder_iam" {
  ...
  depends_on = [time_sleep.cloud_sql_iam_role_settle]
}
```

60s is the documented workaround in the upstream tracker —
longer than the typical settle time, short enough to disappear
into the ~5 min Cloud SQL provisioning cost the operator already
pays.

## Tests

`test_cloud_sql_resources_present` extended:
- `time_sleep "cloud_sql_iam_role_settle"` resource exists
- It depends on `google_sql_database_instance.coder`
- `google_sql_user.coder_iam` depends on the sleep

Without all three, a future edit could silently bring the race
back.

## Operator-side

After this merges, re-run:

```bash
git pull
just exe-apply
```

The previously-failed apply left a working Cloud SQL instance +
DB but no IAM user — `tofu apply` is idempotent and resumes from
that state. The new sleep applies before the user-create step.

## Test plan

- [x] `tofu validate` — green
- [x] `tofu fmt -check` — clean
- [x] `test_cloud_sql_resources_present` — green
- [ ] Operator: re-run `just exe-apply` with this branch merged