### PR TITLE
fix(exe): add --private-ip to Cloud SQL Auth Proxy ExecStart

### DIFF
--- a/tests/exe/test_startup_script.py
+++ b/tests/exe/test_startup_script.py
@@ -1152,6 +1152,13 @@ def test_cloud_sql_proxy_systemd_unit_emitted(startup_script: str) -> None:
         "CSAP MUST run with --auto-iam-authn so Postgres login uses an\n"
         "OAuth access token instead of a static password."
     )
+    # Cloud SQL instance has ipv4_enabled=false (private IP only).
+    # Without --private-ip CSAP defaults to the public-IP path and
+    # fails with `instance does not have IP of type "PUBLIC"`.
+    assert "--private-ip" in body, (
+        "CSAP MUST run with --private-ip — the instance has no public\n"
+        "IP and CSAP defaults to PUBLIC otherwise (fails closed)."
+    )
 
     # And coder.service must declare Requires + After cloud-sql-proxy.
     coder_unit = re.search(

--- a/tofu/exe/coder.tf
+++ b/tofu/exe/coder.tf
@@ -403,9 +403,14 @@ locals {
     # Postgres password at every connection. The "password" Coder
     # sends in its connection URL is ignored (and is set to a
     # placeholder; see /etc/default/coder).
+    # --private-ip: the Cloud SQL instance has ipv4_enabled=false
+    # (private IP only). Without this flag CSAP tries the public
+    # IP path first and fails with `instance does not have IP of
+    # type "PUBLIC"`.
     ExecStart=/usr/local/bin/cloud-sql-proxy \
       --address 127.0.0.1 --port 5432 \
       --auto-iam-authn \
+      --private-ip \
       $PG_CONNECTION_NAME
     Restart=on-failure
     RestartSec=5


### PR DESCRIPTION
## What

Adds `--private-ip` to the `cloud-sql-proxy.service` ExecStart
so CSAP uses the Cloud SQL instance's private IP path. Without
this flag, on an instance with `ipv4_enabled=false`, CSAP loops:

```
cloud-sql-proxy[2904]: failed to connect to instance: config
error: instance does not have IP of type "PUBLIC"
(connection name = "gen-ai-hironow:asia-northeast1:exe-coder-pg")
```

## Root cause

CSAP v2 defaults to the **public** IP path when `--private-ip`
is not specified. The Cloud SQL instance from ADR 0010 is
`ipv4_enabled=false` (private IP only — pinned by the security
regression test), so the proxy never finds a public address to
dial and Coder server crashes when it can't establish a DB
connection.

## Fix

```hcl
ExecStart=/usr/local/bin/cloud-sql-proxy \
  --address 127.0.0.1 --port 5432 \
  --auto-iam-authn \
  --private-ip \             # NEW
  $PG_CONNECTION_NAME
```

## Tests

`test_cloud_sql_proxy_systemd_unit_emitted` extended:

```python
assert "--private-ip" in body, (
    "CSAP MUST run with --private-ip — the instance has no public\n"
    "IP and CSAP defaults to PUBLIC otherwise (fails closed)."
)
```

So this fix cannot silently disappear in a future edit while the
instance remains private-only.

## Operator-side

After this merges, re-run:

```bash
git pull
just exe-apply
```

`tofu apply` detects the startup_script changed → recreates the
VM with the fixed CSAP unit. Cloud SQL instance + IAM SA user +
data plane all stay (deletion_protection plus they're independent
resources).

## Test plan

- [x] `tofu validate` — green
- [x] `tofu fmt -check` — clean
- [x] `test_cloud_sql_proxy_systemd_unit_emitted` — green
- [ ] Operator: re-run `just exe-apply`, verify `coder.service`
      goes from "Started → exited 1" to "Started, running"