### PR TITLE
fix(exe): grant CREATE on public schema to Coder IAM SA user (Postgres 15+)

### DIFF
--- a/tests/exe/test_startup_script.py
+++ b/tests/exe/test_startup_script.py
@@ -78,6 +78,10 @@ HCL_SUBSTITUTIONS: dict[str, str] = {
         "gen-ai-hironow:asia-northeast1:exe-coder-pg"
     ),
     r"\$\{local\.cloud_sql_iam_db_user\}": "exe-coder@gen-ai-hironow.iam",
+    r"\$\{local\.cloud_sql_private_ip\}": "10.130.224.3",
+    r"\$\{google_secret_manager_secret\.postgres_admin\.secret_id\}": (
+        "exe-postgres-admin-password"
+    ),
     r"\$\{google_secret_manager_secret\.exe_coder_authkey\.secret_id\}": (
         "exe-tailscale-coder-authkey"
     ),
@@ -587,6 +591,12 @@ case "$*" in
   *secrets*versions*access*--secret=exe-cloudflared-credentials*)
     echo '{"AccountTag":"a","TunnelID":"00000000-0000-0000-0000-000000000000","TunnelName":"exe-tunnel","TunnelSecret":"AAAA"}'
     ;;
+  *secrets*versions*access*--secret=exe-postgres-admin-password*)
+    # ADR 0010 IAM-user-bootstrap path: deterministic fake admin
+    # password (32 char alphanum) so the bootstrap loop can call
+    # psql against a (mocked) Postgres without exiting prematurely.
+    echo "fakepostgresadminpasswordfakepass"
+    ;;
   *)
     echo "gcloud mock: unhandled args: $*" >&2
     exit 0
@@ -602,6 +612,18 @@ cat > /opt/mock/tailscale <<'MOCK'
 exit 0
 MOCK
 chmod +x /opt/mock/tailscale
+
+# ---- mock psql for the IAM user privilege bootstrap step --------
+# The startup_script issues a wait-loop against psql followed by a
+# GRANT batch. Both must "succeed" so the script flows past them
+# without retrying for the full 60s timeout.
+cat > /opt/mock/psql <<'MOCK'
+#!/usr/bin/env bash
+# Capture invocation for visibility, then succeed.
+echo "psql mock $*" >> /var/log/psql-mock.log 2>/dev/null || true
+exit 0
+MOCK
+chmod +x /opt/mock/psql
 
 cat > /opt/mock/systemctl <<'MOCK'
 #!/usr/bin/env bash
@@ -1062,16 +1084,27 @@ def test_cloud_sql_resources_present() -> None:
         "internal role exists by the time the user is created."
     )
 
-    # Pin: there must be NO password resources of any kind. Catches a
-    # regression where someone re-introduces a password-based user.
-    assert "random_password" not in cloudsql_tf, (
-        "There must be NO random_password — IAM auth eliminates the password.\n"
-        "Google Cloud strongly recommends auto-iam-authn over password auth\n"
-        "(2026 Cloud SQL connection guidance)."
+    # Pin: there must be NO COMPILER-time password for the Coder
+    # runtime user. The IAM SA user must be auth'd via OAuth tokens.
+    # The only random_password permitted in this file is the
+    # `postgres_admin` BUILT_IN bootstrap-only password (used once
+    # at VM startup to grant CREATE on public to the IAM user; not
+    # used by coder.service at runtime).
+    assert 'random_password" "coder_pg_password"' not in cloudsql_tf, (
+        "There must be NO random_password.coder_pg_password — IAM auth\n"
+        "eliminates the Coder runtime password. Google Cloud strongly\n"
+        "recommends auto-iam-authn over password auth (2026 guidance)."
     )
-    assert "coder_pg_password" not in cloudsql_tf, (
-        "There must be NO Postgres password secret — IAM auth eliminates it."
+    assert 'google_secret_manager_secret" "coder_pg_password"' not in cloudsql_tf, (
+        "There must be NO Postgres password secret for the runtime user."
     )
+
+    # Cross-check: coder.tf must NOT pass any postgres password into
+    # the CODER_PG_CONNECTION_URL — that would defeat the IAM auth
+    # posture. The URL's password slot stays a literal 'placeholder'.
+    # (See test_etc_default_coder_pg_url_is_envfile_not_unit_environment
+    # for the URL-shape pin; here we just guard against the cloudsql.tf
+    # adding a non-bootstrap password resource.)
 
     # VPC peering for private IP.
     assert 'resource "google_compute_global_address" "exe_psa_range"' in cloudsql_tf
@@ -1226,16 +1259,24 @@ def test_etc_default_coder_pg_url_is_envfile_not_unit_environment(
         "leg between the proxy and the managed instance)"
     )
 
-    # No literal 'PG_PASSWORD' anywhere — IAM auth eliminates it.
-    assert "PG_PASSWORD" not in startup_script, (
-        "startup_script must not reference PG_PASSWORD anywhere — IAM\n"
-        "auth eliminates the password fetch + assembly path. Re-introducing\n"
-        "this would mean back-sliding from 2026 best practice."
+    # No literal 'PG_PASSWORD=' (the runtime variable) — IAM auth
+    # eliminates the runtime password fetch. The bootstrap path uses
+    # PG_ADMIN_PASSWORD which is conceptually different and allowed.
+    # Match exactly 'PG_PASSWORD=' so PG_ADMIN_PASSWORD does not
+    # false-positive as a substring.
+    assert "PG_PASSWORD=" not in startup_script, (
+        "startup_script must not declare PG_PASSWORD= — that was the\n"
+        "Coder runtime password fetch path. IAM auth eliminates it.\n"
+        "(The bootstrap path uses PG_ADMIN_PASSWORD; that is allowed.)"
     )
     assert (
         "secrets versions access latest --secret=exe-coder-pg-password"
         not in startup_script
-    ), "startup_script must not fetch a password secret — IAM auth eliminates it."
+    ), (
+        "startup_script must not fetch a Coder runtime password secret —\n"
+        "IAM auth eliminates it. (The bootstrap path fetches a separate\n"
+        "exe-postgres-admin-password secret; that is allowed.)"
+    )
 
 
 @pytest.mark.exe
@@ -1371,14 +1412,24 @@ def test_cloud_sql_security_posture_no_regression() -> None:
         "CLOUD_IAM_SERVICE_ACCOUNT type as ADR 0010 specifies."
     )
 
-    # No other google_sql_user that might be of BUILT_IN type.
-    other_users = re.findall(
-        r'resource\s+"google_sql_user"\s+"([^"]+)"',
-        cloudsql_tf,
+    # Permitted google_sql_user resources:
+    #   - coder_iam (CLOUD_IAM_SERVICE_ACCOUNT) — runtime
+    #   - postgres (BUILT_IN, password) — bootstrap-only, grants the
+    #     IAM user CREATE on public schema once at VM start
+    # Anything beyond these two is a regression (no application
+    # password account, no shared "coder" password user).
+    permitted_users = {"coder_iam", "postgres"}
+    other_users = set(
+        re.findall(
+            r'resource\s+"google_sql_user"\s+"([^"]+)"',
+            cloudsql_tf,
+        )
     )
-    assert other_users == ["coder_iam"], (
-        f"Only the IAM SA user is allowed to be provisioned by tofu.\n"
-        f"Found additional users: {[u for u in other_users if u != 'coder_iam']!r}"
+    extra = other_users - permitted_users
+    assert not extra, (
+        f"Only the IAM SA user (coder_iam) and the bootstrap-only\n"
+        f"postgres superuser are permitted. Found additional users:\n"
+        f"  {sorted(extra)!r}"
     )
 
     # --- Connection URL must NOT carry a real password --------------
@@ -1419,4 +1470,90 @@ def test_cloud_sql_security_posture_no_regression() -> None:
         "startup_script must URL-encode PG_IAM_DB_USER's '@' into '%40'\n"
         "before assembling the postgres:// URL, otherwise libpq mis-parses\n"
         "the URL grammar."
+    )
+
+
+@pytest.mark.exe
+def test_iam_user_privilege_bootstrap_emitted(startup_script: str) -> None:
+    """ADR 0010 incident 2026-05-03: Postgres 15+ locks down the
+    public schema by default — newly-created IAM SA users cannot
+    CREATE TABLE there until cloudsqlsuperuser grants USAGE +
+    CREATE on public. Without the grant, Coder server fails its
+    initial migration and loops forever at "permission denied for
+    schema public".
+
+    The startup_script bootstraps the IAM user's privileges once
+    via the postgres BUILT_IN superuser (random password,
+    bootstrap-only, fetched from Secret Manager). The connection
+    goes via private IP DIRECTLY (not through CSAP) because CSAP's
+    --auto-iam-authn would substitute an OAuth token for the
+    postgres password.
+
+    Pin the shape so a future careless edit cannot silently revert
+    to the broken state.
+    """
+    # The script installs psql if missing.
+    assert "postgresql-client" in startup_script, (
+        "startup_script must install postgresql-client before running\n"
+        "the IAM user privilege bootstrap"
+    )
+
+    # The admin password is fetched from Secret Manager.
+    assert "PG_ADMIN_SECRET=" in startup_script
+    assert "secrets versions access latest --secret=" in startup_script, (
+        "startup_script must fetch the postgres admin password from Secret Manager"
+    )
+
+    # The connection is direct private IP (not CSAP loopback) — the
+    # bootstrap needs to send a real password, which CSAP's
+    # --auto-iam-authn would intercept and replace.
+    assert "PG_PRIVATE_IP=" in startup_script, (
+        "startup_script must declare PG_PRIVATE_IP from the local"
+    )
+    assert "host=$PG_PRIVATE_IP" in startup_script, (
+        "bootstrap psql call must use the Cloud SQL private IP directly,\n"
+        "NOT 127.0.0.1 (CSAP loopback). CSAP's --auto-iam-authn would\n"
+        "swap the postgres password for an OAuth token."
+    )
+    assert "sslmode=require" in startup_script, (
+        "direct private-IP psql connections MUST use sslmode=require so\n"
+        "the password is not sent in plaintext over the VPC peer."
+    )
+
+    # The actual GRANT statements — the whole point of the bootstrap.
+    assert 'GRANT CONNECT ON DATABASE coder TO "$PG_IAM_DB_USER"' in startup_script
+    assert 'GRANT USAGE, CREATE ON SCHEMA public TO "$PG_IAM_DB_USER"' in startup_script
+
+    # PG_ADMIN_PASSWORD must be unset after use so a stray subprocess
+    # cannot inherit it from the environment. (Defense in depth.)
+    assert re.search(r"unset PG_ADMIN_PASSWORD", startup_script), (
+        "PG_ADMIN_PASSWORD must be `unset` after the bootstrap GRANT\n"
+        "so subsequent steps in the startup_script do not inherit it."
+    )
+
+
+@pytest.mark.exe
+def test_postgres_admin_user_is_bootstrap_only_not_runtime_path() -> None:
+    """The postgres BUILT_IN user with random_password is permitted
+    ONLY for the one-time bootstrap GRANT. coder.service must not
+    use it at runtime — that is the whole point of the IAM auth
+    pivot. Pin negatively: the postgres admin secret name must not
+    appear in CODER_PG_CONNECTION_URL or in /etc/default/coder."""
+    coder_tf = (ROOT / "tofu" / "exe" / "coder.tf").read_text()
+
+    # CODER_PG_CONNECTION_URL must reference the IAM SA user via
+    # PG_IAM_DB_USER_ENC, not the postgres admin user. Verify the
+    # admin secret name does not leak into the URL line.
+    pg_url_match = re.search(
+        r"CODER_PG_CONNECTION_URL=postgres://[^\s\n]+",
+        coder_tf,
+    )
+    assert pg_url_match is not None
+    pg_url = pg_url_match.group(0)
+    assert "postgres-admin-password" not in pg_url
+    assert "PG_ADMIN_PASSWORD" not in pg_url
+    assert ":placeholder@" in pg_url, (
+        "the URL password slot must remain the literal 'placeholder';\n"
+        "any other shape implies the postgres admin path leaked into\n"
+        "the runtime URL."
     )

--- a/tofu/exe/cloudsql.tf
+++ b/tofu/exe/cloudsql.tf
@@ -144,6 +144,63 @@ resource "google_sql_user" "coder_iam" {
   depends_on = [time_sleep.cloud_sql_iam_role_settle]
 }
 
+# ----- Postgres admin user (bootstrap-only) ---------------------------
+#
+# Why this exists: Postgres 15+ locks down the public schema by
+# default — newly-created users (including IAM SA users) cannot
+# CREATE TABLE in it. Coder server fails its initial schema
+# migration with "permission denied for schema public" until a
+# privileged role grants USAGE + CREATE on public to the IAM user.
+#
+# Cloud SQL's `postgres` BUILT_IN user holds `cloudsqlsuperuser`
+# and CAN issue those grants. Tofu sets a random password on it,
+# stores the password in Secret Manager, and the VM startup_script
+# uses it ONCE at first boot to bootstrap the IAM user's grants.
+# Coder server then runs entirely under IAM auth at runtime — the
+# postgres password is bootstrap-only.
+#
+# Threat model: the postgres password lives in Secret Manager
+# (mode 0600 on the secret resource, IAM-restricted to the VM
+# SA only). On the VM it is fetched once at startup, used in a
+# subprocess, then unset. Worst case if leaked: ability to
+# re-bootstrap the DB; coder.service runtime path remains pure
+# IAM auth.
+
+resource "random_password" "postgres_admin" {
+  length  = 32
+  special = false
+}
+
+resource "google_sql_user" "postgres" {
+  name     = "postgres"
+  instance = google_sql_database_instance.coder.name
+  password = random_password.postgres_admin.result
+  # Cloud SQL auto-creates the postgres BUILT_IN superuser on
+  # every Postgres instance; tofu's google_sql_user reconciles by
+  # setting our managed password. type defaults to BUILT_IN.
+
+  depends_on = [time_sleep.cloud_sql_iam_role_settle]
+}
+
+resource "google_secret_manager_secret" "postgres_admin" {
+  secret_id = "${local.prefix}-postgres-admin-password"
+  labels    = local.common_labels
+  replication {
+    auto {}
+  }
+}
+
+resource "google_secret_manager_secret_version" "postgres_admin" {
+  secret      = google_secret_manager_secret.postgres_admin.id
+  secret_data = random_password.postgres_admin.result
+}
+
+resource "google_secret_manager_secret_iam_member" "postgres_admin_reader" {
+  secret_id = google_secret_manager_secret.postgres_admin.id
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${google_service_account.exe_coder.email}"
+}
+
 # ----- IAM on the VM SA -----------------------------------------------
 # Two roles are required for IAM database authentication:
 #   roles/cloudsql.client       — TLS cert to dial the instance
@@ -173,6 +230,7 @@ resource "google_project_iam_member" "exe_coder_cloudsql_instance_user" {
 locals {
   cloud_sql_connection_name = google_sql_database_instance.coder.connection_name
   cloud_sql_iam_db_user     = google_sql_user.coder_iam.name
+  cloud_sql_private_ip      = google_sql_database_instance.coder.private_ip_address
   cloud_sql_proxy_url = format(
     "https://storage.googleapis.com/cloud-sql-connectors/cloud-sql-proxy/%s/cloud-sql-proxy.linux.amd64",
     var.cloud_sql_proxy_version,

--- a/tofu/exe/coder.tf
+++ b/tofu/exe/coder.tf
@@ -178,6 +178,8 @@ locals {
     CSAP_URL='${local.cloud_sql_proxy_url}'
     PG_CONNECTION_NAME='${local.cloud_sql_connection_name}'
     PG_IAM_DB_USER='${local.cloud_sql_iam_db_user}'
+    PG_PRIVATE_IP='${local.cloud_sql_private_ip}'
+    PG_ADMIN_SECRET='${google_secret_manager_secret.postgres_admin.secret_id}'
 
     export DEBIAN_FRONTEND=noninteractive
     apt-get update -y
@@ -433,6 +435,56 @@ locals {
       chmod 0600 /var/lib/coder/.admin_password
     fi
 
+    # ---- One-time IAM user privilege bootstrap ------------------------
+    # Postgres 15+ locks down the public schema by default — newly-
+    # created IAM SA users cannot CREATE TABLE there until a
+    # cloudsqlsuperuser-privileged role grants USAGE + CREATE on
+    # public. Coder's first migration fails closed without this,
+    # looping at "permission denied for schema public".
+    #
+    # Cloud SQL's `postgres` BUILT_IN superuser does the grant once.
+    # Connection goes via the Cloud SQL private IP directly (10.x.x.x)
+    # rather than through CSAP, because CSAP runs with
+    # --auto-iam-authn and would substitute an OAuth token for the
+    # postgres password. sslmode=require encrypts the connection
+    # without strict cert verification (sufficient inside the
+    # peered VPC).
+    #
+    # Idempotent: the GRANTs are no-ops on repeat. We always re-run
+    # so a future variable bump that re-applies the grants stays
+    # truthful — there is no marker file to inspect.
+    if ! command -v psql >/dev/null 2>&1; then
+      apt-get install -y --no-install-recommends postgresql-client
+    fi
+
+    PG_ADMIN_PASSWORD="$(gcloud --quiet --project="$PROJECT" \
+      secrets versions access latest --secret="$PG_ADMIN_SECRET")"
+
+    # Wait up to 60s for Cloud SQL to accept connections (in case the
+    # VM came up before the DB engine finished its own bootstrap).
+    for i in $(seq 1 30); do
+      if PGPASSWORD="$PG_ADMIN_PASSWORD" psql \
+            "host=$PG_PRIVATE_IP port=5432 user=postgres dbname=coder sslmode=require connect_timeout=5" \
+            -c '\q' 2>/dev/null; then
+        break
+      fi
+      sleep 2
+    done
+
+    # Run the privilege bootstrap. ON_ERROR_STOP=1 makes psql exit
+    # non-zero if any GRANT fails; we capture the rc but do not
+    # abort the script — coder.service will surface the symptom on
+    # its own next start if the bootstrap was insufficient.
+    PGPASSWORD="$PG_ADMIN_PASSWORD" psql \
+      "host=$PG_PRIVATE_IP port=5432 user=postgres dbname=coder sslmode=require" \
+      --set ON_ERROR_STOP=1 <<SQL
+    GRANT CONNECT ON DATABASE coder TO "$PG_IAM_DB_USER";
+    GRANT USAGE, CREATE ON SCHEMA public TO "$PG_IAM_DB_USER";
+    ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON TABLES TO "$PG_IAM_DB_USER";
+    ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON SEQUENCES TO "$PG_IAM_DB_USER";
+    SQL
+    unset PG_ADMIN_PASSWORD
+
     # /etc/default/coder — holds CODER_PG_CONNECTION_URL. The "password"
     # is a literal placeholder string: with --auto-iam-authn the proxy
     # ignores whatever Coder sends and substitutes a fresh OAuth access
@@ -598,5 +650,12 @@ resource "google_compute_instance" "exe_coder" {
     google_project_iam_member.exe_coder_cloudsql_instance_user,
     google_sql_user.coder_iam,
     google_sql_database.coder,
+    # The privilege-bootstrap path needs the postgres BUILT_IN user
+    # password + Secret Manager grant in place before the VM boots
+    # (script fetches the password from the secret and uses psql to
+    # grant the IAM user CREATE on public schema).
+    google_sql_user.postgres,
+    google_secret_manager_secret_version.postgres_admin,
+    google_secret_manager_secret_iam_member.postgres_admin_reader,
   ]
 }


### PR DESCRIPTION
## Symptom

`https://exe.hironow.dev/` returns HTTP 502. Cloud SQL Postgres
log query (`logName=cloudsql.googleapis.com%2Fpostgres.log`)
shows Coder looping at:

```
ERROR: permission denied for schema public at character 28
STATEMENT: CREATE TABLE IF NOT EXISTS schema_migrations ...
db=coder, user=exe-coder@gen-ai-hironow.iam
```

## Root cause

PostgreSQL 15+ revoked the implicit CREATE on `public` from the
PUBLIC role. Cloud SQL IAM SA users do **not** auto-receive
`cloudsqlsuperuser`. Per Google Cloud docs:

> "When you add an IAM user to a Cloud SQL instance, this user
> does not have any privileges in any Cloud SQL database.
> Privileges are managed using standard PostgreSQL grants. These
> grants must be performed by a user with the appropriate
> privileges, such as one with the cloudsqlsuperuser role."

Coder server connects as the IAM SA user, tries to run its
initial schema migration, hits the lockdown, exits 1, gets
restarted by systemd, repeats every 10s.

## Fix

Add a `postgres` BUILT_IN superuser with `random_password` stored
in Secret Manager. The VM startup_script fetches the password
once at boot, connects to Cloud SQL **via private IP directly**
(NOT through CSAP — see below), and runs the GRANTs.

```hcl
resource "random_password" "postgres_admin" { length = 32 special = false }
resource "google_sql_user" "postgres" {
  name     = "postgres"
  instance = google_sql_database_instance.coder.name
  password = random_password.postgres_admin.result
}
resource "google_secret_manager_secret"         "postgres_admin" { ... }
resource "google_secret_manager_secret_version" "postgres_admin" { ... }
resource "google_secret_manager_secret_iam_member" "postgres_admin_reader" {
  member = "serviceAccount:${google_service_account.exe_coder.email}"
}
```

Bootstrap step in startup_script (idempotent — re-runs are no-ops):

```bash
PG_ADMIN_PASSWORD="$(gcloud secrets versions access latest --secret=$PG_ADMIN_SECRET)"
PGPASSWORD="$PG_ADMIN_PASSWORD" psql \
  "host=$PG_PRIVATE_IP port=5432 user=postgres dbname=coder sslmode=require" \
  --set ON_ERROR_STOP=1 <<SQL
GRANT CONNECT ON DATABASE coder TO "$PG_IAM_DB_USER";
GRANT USAGE, CREATE ON SCHEMA public TO "$PG_IAM_DB_USER";
ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON TABLES TO "$PG_IAM_DB_USER";
ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON SEQUENCES TO "$PG_IAM_DB_USER";
SQL
unset PG_ADMIN_PASSWORD
```

## Why direct private IP, not CSAP

CSAP runs with `--auto-iam-authn` (the 2026 best practice from
ADR 0010). That flag **substitutes whatever password the client
sends with an OAuth access token**. If the bootstrap went through
CSAP, the postgres password would be replaced with an OAuth token
for the `exe-coder@` SA — Postgres would then reject auth because
the `postgres` BUILT_IN user is not IAM-mapped.

The simplest fix is to bypass CSAP for this one call and dial the
Cloud SQL private IP directly. The VM and the DB are in the same
peered VPC; `sslmode=require` encrypts the leg.

The runtime path (`coder.service`) is unchanged — pure IAM auth,
no password.

## Tests (4 new + 2 updated)

| test | what it pins |
|---|---|
| **`test_iam_user_privilege_bootstrap_emitted`** (NEW) | postgres-client install, password fetch via Secret Manager, direct private IP (NOT 127.0.0.1), sslmode=require, the four GRANT/ALTER DEFAULT PRIVILEGES statements, PG_ADMIN_PASSWORD unset after use |
| **`test_postgres_admin_user_is_bootstrap_only_not_runtime_path`** (NEW) | postgres admin secret name does NOT appear in `CODER_PG_CONNECTION_URL`; URL retains `:placeholder@` |
| `test_cloud_sql_security_posture_no_regression` (UPDATED) | random_password ban relaxed for `postgres_admin` (bootstrap-only); permitted users = {coder_iam, postgres}; runtime password resources still pinned negatively |
| `test_etc_default_coder_pg_url_is_envfile_not_unit_environment` (UPDATED) | `PG_PASSWORD=` substring ban (no longer false-positives on `PG_ADMIN_PASSWORD`) |
| `HCL_SUBSTITUTIONS` table | + `cloud_sql_private_ip` + postgres_admin secret_id placeholders |
| `HARNESS_PRELUDE` | + gcloud mock case for postgres-admin secret + psql mock so the bootstrap loop passes |

Full suite: **34/34 static + 2/2 docker** green.

## Operator-side rollout

The Cloud SQL instance is unchanged; the IAM SA user is unchanged
— this PR adds a new BUILT_IN postgres user + Secret Manager +
the VM bootstrap step.

```bash
git pull
just exe-apply        # creates postgres user + secret, replaces VM
                      # → bootstrap GRANTs run, coder.service starts
```

Within ~3 minutes (VM rebuild + bootstrap), expect:

- Cloud SQL Postgres logs stop showing `permission denied`
- `coder.service` runs continuously instead of looping
- `https://exe.hironow.dev/healthz` returns 200

## Test plan

- [x] `tofu validate` — green
- [x] `tofu fmt -check` — clean
- [x] 34 static + 2 docker tests — green
- [ ] Operator: `just exe-apply`, then verify `coder.service`
      stays in "running" state and healthz returns 200