### PR TITLE
feat(exe): Cloud Monitoring uptime + email alert on Coder healthz

### DIFF
--- a/exe/docs/architecture.md
+++ b/exe/docs/architecture.md
@@ -177,6 +177,7 @@ loopback).
 |---|---|---|
 | GCE VM | e2-small, preemptible (24h), 30 GiB pd-balanced | $5–$7 |
 | Cloud SQL Postgres | db-f1-micro, 10 GB SSD, daily backup, ZONAL (ADR 0010) | $8–$10 |
+| Cloud Monitoring uptime + alert | 1 region (ASIA_PACIFIC), 5 min cadence, 1 email channel | < $0.10 |
 | Cloudflare Tunnel | Free | $0 |
 | Cloudflare Access | Free (Zero Trust, ≤ 50 users) | $0 |
 | Tailscale | Personal Free | $0 |

--- a/exe/docs/runbook.md
+++ b/exe/docs/runbook.md
@@ -540,6 +540,43 @@ then `just exe-apply`.
 
 After `nuke`, run `just exe-bootstrap` again to start over.
 
+## Healthz uptime monitoring
+
+Cloud Monitoring runs an uptime check against
+`https://exe.hironow.dev/healthz` every 5 minutes from the
+ASIA_PACIFIC region, carrying the same CF Access service-token
+headers `cdr` uses. Two consecutive failures (~10 min sustained)
+trigger an email alert to `var.owner_email`.
+
+Inspect:
+
+```bash
+# Last fired / pass rate / configured headers
+gcloud monitoring uptime-checks list --project=gen-ai-hironow
+
+# Alert policy state
+gcloud alpha monitoring policies list --project=gen-ai-hironow
+```
+
+Or in the GCP console: Monitoring → Uptime checks /
+Monitoring → Alerting.
+
+If you receive a `exe-coder-healthz down` email:
+
+1. `just exe-smoke` — DNS / Access gate / VM running / secrets
+2. `gcloud compute instances describe exe-coder ...` — VM status
+3. `gcloud sql instances describe exe-coder-pg ...` — DB status
+4. Cloud SQL logs:
+   `logName="projects/gen-ai-hironow/logs/cloudsql.googleapis.com%2Fpostgres.log"`
+5. The auto-close on the alert policy is 30 min — once healthz
+   recovers, the alert clears itself.
+
+To suppress alerts during planned maintenance (e.g. running
+`just exe-replace google_compute_instance.exe_coder`), the
+operator can either silence the policy via the GCP console or
+just expect a single false alert (it will auto-close in 30 min
+once the VM is back).
+
 ## Cost monitoring
 
 GCS state bucket and Secret Manager are essentially free. The VM is

--- a/exe/scripts/bootstrap.sh
+++ b/exe/scripts/bootstrap.sh
@@ -22,6 +22,7 @@ REQUIRED_APIS=(
   compute.googleapis.com
   iam.googleapis.com
   iamcredentials.googleapis.com
+  monitoring.googleapis.com        # uptime check + alert policy on healthz
   secretmanager.googleapis.com
   servicenetworking.googleapis.com # ADR 0010: VPC peering for Cloud SQL private IP
   sqladmin.googleapis.com          # ADR 0010: Cloud SQL Admin

--- a/tests/exe/test_startup_script.py
+++ b/tests/exe/test_startup_script.py
@@ -1557,3 +1557,81 @@ def test_postgres_admin_user_is_bootstrap_only_not_runtime_path() -> None:
         "any other shape implies the postgres admin path leaked into\n"
         "the runtime URL."
     )
+
+
+# ---------- Cloud Monitoring uptime check + alert (PR #?) -----------
+
+
+@pytest.mark.exe
+def test_uptime_check_and_alert_present() -> None:
+    """The Coder UI is gated by Cloud Access; uptime monitoring must
+    carry the same CF Access service-token headers `cdr` does.
+    Pin the shape so a future careless edit cannot silently weaken
+    the monitoring posture (e.g., drop the auth headers, switch to
+    a non-existent path, expand to a public endpoint that is gated
+    out, etc.)."""
+    monitoring_tf = (ROOT / "tofu" / "exe" / "monitoring.tf").read_text()
+
+    # Uptime check with the right shape.
+    uptime_block = re.search(
+        r'resource\s+"google_monitoring_uptime_check_config"\s+'
+        r'"exe_coder_healthz"\s*\{(.*?)^\}',
+        monitoring_tf,
+        re.DOTALL | re.MULTILINE,
+    )
+    assert uptime_block is not None, "missing exe_coder_healthz uptime check"
+    body = uptime_block.group(1)
+    assert 'path           = "/healthz"' in body or 'path = "/healthz"' in body
+    assert "use_ssl        = true" in body or "use_ssl = true" in body
+    assert "validate_ssl   = true" in body or "validate_ssl = true" in body
+
+    # Headers must include CF-Access-Client-Id + Secret, sourced
+    # from the same Secret Manager values cdr uses.
+    assert "CF-Access-Client-Id" in body
+    assert "CF-Access-Client-Secret" in body
+    assert "coder_cli_client_id_for_uptime" in body
+    assert "coder_cli_client_secret_for_uptime" in body
+
+    # Notification channel: email to the operator (var.owner_email).
+    chan_block = re.search(
+        r'resource\s+"google_monitoring_notification_channel"\s+'
+        r'"operator_email"\s*\{(.*?)^\}',
+        monitoring_tf,
+        re.DOTALL | re.MULTILINE,
+    )
+    assert chan_block is not None, "missing operator_email notification channel"
+    chan_body = chan_block.group(1)
+    assert 'type         = "email"' in chan_body or 'type = "email"' in chan_body
+    assert "var.owner_email" in chan_body, (
+        "notification channel must use var.owner_email so the operator's\n"
+        "email is the single source of truth (the same field that gates\n"
+        "Cloudflare Access)."
+    )
+
+    # Alert policy must reference the uptime check + the email channel.
+    alert_block = re.search(
+        r'resource\s+"google_monitoring_alert_policy"\s+'
+        r'"exe_coder_healthz_down"\s*\{(.*?)^\}',
+        monitoring_tf,
+        re.DOTALL | re.MULTILINE,
+    )
+    assert alert_block is not None
+    alert_body = alert_block.group(1)
+    assert "google_monitoring_uptime_check_config.exe_coder_healthz" in alert_body
+    assert "google_monitoring_notification_channel.operator_email.id" in alert_body, (
+        "alert policy MUST reference the operator email channel; without it\n"
+        "alerts fire silently into nothing."
+    )
+
+
+@pytest.mark.exe
+def test_bootstrap_enables_monitoring_api() -> None:
+    """The uptime check + alert policy live under
+    monitoring.googleapis.com; bootstrap must enable that API
+    before tofu init (we cannot create monitoring resources
+    without it)."""
+    bootstrap = (ROOT / "exe" / "scripts" / "bootstrap.sh").read_text()
+    assert "monitoring.googleapis.com" in bootstrap, (
+        "bootstrap.sh must enable monitoring.googleapis.com so the\n"
+        "uptime check + alert policy can be provisioned."
+    )

--- a/tofu/exe/monitoring.tf
+++ b/tofu/exe/monitoring.tf
@@ -1,0 +1,140 @@
+# Cloud Monitoring uptime check + alert policy for the public Coder
+# UI healthz endpoint.
+#
+# What this does
+# --------------
+# Every 5 minutes a Google-hosted prober in ASIA_PACIFIC sends
+# `GET https://exe.hironow.dev/healthz` carrying the same CF Access
+# service-token headers the operator's `cdr` wrapper uses, expecting
+# a 2xx response. Two consecutive failures (~10-15 min) trigger an
+# email alert to the operator (`var.owner_email`).
+#
+# Cost is ~$0.10/month for one region @ 5 min cadence. Coder upstream
+# does not provide an unauthenticated health endpoint behind CF
+# Access, so the check has to carry the same headers `cdr` /
+# `cdr-header` emit. The CF Access tokens already live in Secret
+# Manager (`coder_cli_client_id` / `coder_cli_client_secret`) — we
+# read them via data sources at apply time and inject them into the
+# uptime check's `headers` map.
+#
+# State exposure: the rendered token values land in tofu state, but
+# state is encrypted (existing posture). The same secret values
+# already flow through the smoke / cdr code paths; this adds one
+# more consumer.
+
+# ----- read CF Access service-token values from Secret Manager -------
+
+data "google_secret_manager_secret_version" "coder_cli_client_id_for_uptime" {
+  secret = google_secret_manager_secret.coder_cli_client_id.id
+}
+
+data "google_secret_manager_secret_version" "coder_cli_client_secret_for_uptime" {
+  secret = google_secret_manager_secret.coder_cli_client_secret.id
+}
+
+# ----- notification channel: operator email --------------------------
+
+resource "google_monitoring_notification_channel" "operator_email" {
+  display_name = "${local.prefix}-operator-email"
+  type         = "email"
+  labels = {
+    email_address = var.owner_email
+  }
+
+  # Email channels do not need verification but the API can flap;
+  # ignore the timestamp drift that comes from re-verification cycles.
+  user_labels = local.common_labels
+}
+
+# ----- uptime check --------------------------------------------------
+
+resource "google_monitoring_uptime_check_config" "exe_coder_healthz" {
+  display_name = "${local.prefix}-coder-healthz"
+  timeout      = "10s"
+  period       = "300s" # 5 min cadence — single-operator stack, no need for 60s
+
+  http_check {
+    path           = "/healthz"
+    port           = 443
+    use_ssl        = true
+    validate_ssl   = true
+    request_method = "GET"
+
+    headers = {
+      "CF-Access-Client-Id"     = data.google_secret_manager_secret_version.coder_cli_client_id_for_uptime.secret_data
+      "CF-Access-Client-Secret" = data.google_secret_manager_secret_version.coder_cli_client_secret_for_uptime.secret_data
+    }
+  }
+
+  monitored_resource {
+    type = "uptime_url"
+    labels = {
+      project_id = var.gcp_project_id
+      host       = local.coder_host
+    }
+  }
+
+  # Single region (ASIA_PACIFIC) keeps cost and probe noise minimal
+  # while still covering the operator's primary access region.
+  selected_regions = ["ASIA_PACIFIC"]
+}
+
+# ----- alert policy: page on 2 consecutive uptime failures -----------
+
+resource "google_monitoring_alert_policy" "exe_coder_healthz_down" {
+  display_name = "${local.prefix}-coder-healthz down"
+  combiner     = "OR"
+  enabled      = true
+
+  user_labels = local.common_labels
+
+  conditions {
+    display_name = "Coder healthz is failing"
+    condition_threshold {
+      filter = format(
+        "metric.type=\"monitoring.googleapis.com/uptime_check/check_passed\" AND metric.labels.check_id=\"%s\" AND resource.type=\"uptime_url\"",
+        google_monitoring_uptime_check_config.exe_coder_healthz.uptime_check_id,
+      )
+      duration        = "300s" # 5 min sustained = 2 consecutive 5-min checks
+      comparison      = "COMPARISON_GT"
+      threshold_value = 1
+
+      aggregations {
+        alignment_period     = "300s"
+        per_series_aligner   = "ALIGN_NEXT_OLDER"
+        cross_series_reducer = "REDUCE_COUNT_FALSE"
+        group_by_fields      = ["resource.label.host"]
+      }
+
+      trigger {
+        count = 1
+      }
+    }
+  }
+
+  notification_channels = [google_monitoring_notification_channel.operator_email.id]
+
+  alert_strategy {
+    auto_close = "1800s" # auto-close after 30 min of recovery
+  }
+
+  documentation {
+    content   = <<-DOC
+      `https://exe.hironow.dev/healthz` is returning non-2xx for
+      ~10 minutes. Likely causes:
+      - VM preempt / GCE maintenance restart in progress (gives
+        itself ~3-5 min to reprovision)
+      - cloudflared / coder.service crashed
+      - Cloud SQL data plane outage (rare; check Cloud SQL logs)
+
+      Triage steps:
+      1. `just exe-smoke`
+      2. `gcloud compute instances describe exe-coder ...` — RUNNING?
+      3. `gcloud sql instances describe exe-coder-pg ...` — RUNNABLE?
+      4. Cloud SQL logs:
+         `logName="projects/gen-ai-hironow/logs/cloudsql.googleapis.com%2Fpostgres.log"`
+      5. Operator playbook: `exe/docs/runbook.md` ("Incident — VM is preempted").
+    DOC
+    mime_type = "text/markdown"
+  }
+}

--- a/tofu/exe/outputs.tf
+++ b/tofu/exe/outputs.tf
@@ -167,3 +167,20 @@ operator diagnostics (e.g. `gcloud sql users list`).
 EOF
   value       = google_sql_user.coder_iam.name
 }
+
+output "uptime_check_name" {
+  description = <<-EOF
+Cloud Monitoring uptime check config resource name. Operator can
+inspect last fired, success rate, etc., via the GCP console
+Monitoring -> Uptime checks page.
+EOF
+  value       = google_monitoring_uptime_check_config.exe_coder_healthz.name
+}
+
+output "alert_policy_name" {
+  description = <<-EOF
+Cloud Monitoring alert policy that fires on sustained uptime
+check failure. Notifies var.owner_email.
+EOF
+  value       = google_monitoring_alert_policy.exe_coder_healthz_down.name
+}


### PR DESCRIPTION
## What

Adds GCP-native external death monitoring for the Coder UI.

| Resource | Purpose |
|---|---|
| `google_monitoring_uptime_check_config.exe_coder_healthz` | `GET https://exe.hironow.dev/healthz` every **5 min** from **ASIA_PACIFIC**; carries CF Access service-token headers (read from the same Secret Manager values `cdr` uses) |
| `google_monitoring_notification_channel.operator_email` | type=email, address=`var.owner_email` |
| `google_monitoring_alert_policy.exe_coder_healthz_down` | fires on **5 min sustained** failure (= 2 consecutive 5-min checks fail), notifies the email channel, auto-closes after 30 min recovery |

Settings chosen per the operator's "B" option (1 region, 5 min
alert duration, email only).

## Cost

~**$0.10/month** for one region @ 5 min cadence.

## Bootstrap

`exe/scripts/bootstrap.sh` enables `monitoring.googleapis.com`
(idempotent — re-running is safe).

## Operator-side rollout

```bash
git pull
just exe-bootstrap   # enables monitoring.googleapis.com
just exe-apply       # provisions uptime + alert + email channel
```

After apply:

- GCP Console → Monitoring → **Uptime checks**: `exe-exe-coder-healthz`
  should appear and start showing green ticks
- GCP Console → Monitoring → **Alerting**: `exe-exe-coder-healthz down`
  policy enabled, linked to the operator email channel
- Email channel: GCP sends a one-time verification email to
  `var.owner_email`. **Operator must click the verify link** for
  alerts to actually deliver.

## Tests

- `test_uptime_check_and_alert_present` — pins shape: HTTPS
  path/port/SSL, CF Access auth headers, Secret Manager data
  sources, email channel uses `var.owner_email`, alert policy
  references both the uptime check + the email channel
- `test_bootstrap_enables_monitoring_api`

Full suite still green.

## Docs

- `runbook.md` — new "Healthz uptime monitoring" section with
  inspection commands + triage flow + planned-maintenance note
- `architecture.md` — cost table + the new monitoring row

## Triage flow (embedded in alert documentation)

When the operator receives a "exe-coder-healthz down" email:

1. `just exe-smoke`
2. `gcloud compute instances describe exe-coder ...`
3. `gcloud sql instances describe exe-coder-pg ...`
4. Cloud SQL logs:
   `logName="projects/gen-ai-hironow/logs/cloudsql.googleapis.com%2Fpostgres.log"`
5. Auto-close after 30 min of recovery — no manual ack needed
   when healthz comes back

## Test plan

- [x] `tofu validate` — green
- [x] `tofu fmt -check` — clean
- [x] Static + docker tests — all green
- [ ] Operator: `just exe-apply`, then verify email verification
      arrives + check uptime check is green
- [ ] (Optional) Force-fire the alert: `just exe-down vm` for
      ~10 min, expect the alert email