### PR TITLE
fix(exe): bump uptime check selected_regions to 3 (GCP API minimum)

### DIFF
--- a/exe/docs/architecture.md
+++ b/exe/docs/architecture.md
@@ -177,7 +177,7 @@ loopback).
 |---|---|---|
 | GCE VM | e2-small, preemptible (24h), 30 GiB pd-balanced | $5–$7 |
 | Cloud SQL Postgres | db-f1-micro, 10 GB SSD, daily backup, ZONAL (ADR 0010) | $8–$10 |
-| Cloud Monitoring uptime + alert | 1 region (ASIA_PACIFIC), 5 min cadence, 1 email channel | < $0.10 |
+| Cloud Monitoring uptime + alert | 3 regions (ASIA_PACIFIC + USA + EUROPE — GCP API minimum), 5 min cadence, 1 email channel | ~$0.30 |
 | Cloudflare Tunnel | Free | $0 |
 | Cloudflare Access | Free (Zero Trust, ≤ 50 users) | $0 |
 | Tailscale | Personal Free | $0 |

--- a/exe/docs/runbook.md
+++ b/exe/docs/runbook.md
@@ -543,10 +543,11 @@ After `nuke`, run `just exe-bootstrap` again to start over.
 ## Healthz uptime monitoring
 
 Cloud Monitoring runs an uptime check against
-`https://exe.hironow.dev/healthz` every 5 minutes from the
-ASIA_PACIFIC region, carrying the same CF Access service-token
-headers `cdr` uses. Two consecutive failures (~10 min sustained)
-trigger an email alert to `var.owner_email`.
+`https://exe.hironow.dev/healthz` every 5 minutes from three
+regions (ASIA_PACIFIC + USA + EUROPE — GCP API requires the
+minimum three), carrying the same CF Access service-token headers
+`cdr` uses. Two consecutive failures (~10 min sustained) trigger
+an email alert to `var.owner_email`.
 
 Inspect:
 

--- a/tests/exe/test_startup_script.py
+++ b/tests/exe/test_startup_script.py
@@ -1593,6 +1593,17 @@ def test_uptime_check_and_alert_present() -> None:
     assert "coder_cli_client_secret_for_uptime" in body
 
     # Notification channel: email to the operator (var.owner_email).
+    # selected_regions must contain at least three (GCP API floor).
+    # Apply fails with `Error 400: selected_regions must include at
+    # least three locations` if you try one or two regions.
+    sr_match = re.search(r"selected_regions\s*=\s*\[([^\]]*)\]", body, re.DOTALL)
+    assert sr_match is not None, "selected_regions must be declared"
+    region_count = len(re.findall(r'"[A-Z_]+"', sr_match.group(1)))
+    assert region_count >= 3, (
+        f"Cloud Monitoring uptime checks require >= 3 selected_regions; "
+        f"got {region_count}. The API rejects 1 or 2 with HTTP 400."
+    )
+
     chan_block = re.search(
         r'resource\s+"google_monitoring_notification_channel"\s+'
         r'"operator_email"\s*\{(.*?)^\}',

--- a/tofu/exe/monitoring.tf
+++ b/tofu/exe/monitoring.tf
@@ -74,9 +74,18 @@ resource "google_monitoring_uptime_check_config" "exe_coder_healthz" {
     }
   }
 
-  # Single region (ASIA_PACIFIC) keeps cost and probe noise minimal
-  # while still covering the operator's primary access region.
-  selected_regions = ["ASIA_PACIFIC"]
+  # Cloud Monitoring uptime checks require **at least three**
+  # selected_regions (or none = all six). Three is the minimum the
+  # API accepts — picking a single region returns:
+  #   Error 400: selected_regions must include at least three locations
+  # Three regions also matches Cloud Monitoring's default "uptime"
+  # availability semantics (a check is "down" only when all probes
+  # fail, smoothing transient single-region edge issues).
+  selected_regions = [
+    "ASIA_PACIFIC", # primary — operator is in JP
+    "USA",
+    "EUROPE",
+  ]
 }
 
 # ----- alert policy: page on 2 consecutive uptime failures -----------


### PR DESCRIPTION
## Symptom

`just exe-apply` for PR #83 fails:

```
google_monitoring_notification_channel.operator_email: Creation complete after 1s
Error: Error creating UptimeCheckConfig: googleapi: Error 400:
selected_regions must include at least three locations
```

## Root cause

GCP Cloud Monitoring uptime check API enforces a **minimum of
three** `selected_regions` when the field is non-empty. PR #83
shipped with a single region (ASIA_PACIFIC) per operator
preference; that's API-rejected.

## Fix

Bump to the API-compliant minimum:

```hcl
selected_regions = [
  "ASIA_PACIFIC", # primary — operator is in JP
  "USA",
  "EUROPE",
]
```

Cost delta: ~$0.20/month (1 region was ~$0.10, 3 regions ~$0.30).
Three regions also smooths transient single-region edge issues —
the alert fires only when all three probers fail.

## Tests

`test_uptime_check_and_alert_present` extended:
```python
region_count = len(re.findall(r'"[A-Z_]+"', sr_match.group(1)))
assert region_count >= 3
```

So a future "let me drop one region for cost" edit fails the
test instead of failing the apply.

## Docs

- `architecture.md`: cost row updated 1 region/$0.10 → 3 regions/$0.30
- `runbook.md`: "Healthz uptime monitoring" section explains why 3 regions

## Operator-side

After this merges:

```bash
git pull
just exe-apply
```

The previously-failed apply created the `operator_email`
notification channel but bailed before the uptime check / alert
policy. tofu apply is idempotent and resumes from there.

## Test plan

- [x] `tofu validate` — green
- [x] `tofu fmt -check` — clean
- [x] `test_uptime_check_and_alert_present` — green
- [ ] Operator: re-run `just exe-apply` with this branch merged