### PR TITLE
docs(exe): align all docs with current implementation (post Cloud SQL + monitoring)

### DIFF
--- a/docs/adr/0009-retract-cron-trigger-from-adr-0008.md
+++ b/docs/adr/0009-retract-cron-trigger-from-adr-0008.md
@@ -1,7 +1,7 @@
 # 0009. Retract the systemd-timer cron trigger from ADR 0008
 
 **Date:** 2026-05-03
-**Status:** Proposed
+**Status:** Accepted (2026-05-04 — cron / systemd-timer infrastructure was reverted in PR #76 and is intentionally absent from the current implementation; operator-pulled `cdr-job` / `cdr-exec` paths in `exe/scripts/` remain the sole job entry points)
 **Supersedes:** [0008](./0008-event-driven-workspace-runner.md) (partial — see Decision)
 
 ## Context

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,57 @@
+# Architecture Decision Records (ADR)
+
+This directory captures the **why** behind significant architecture
+and tooling decisions across the dotfiles repository (local IDE
+environment, Coder workspace, `exe.hironow.dev` stack, CI). Live
+documentation under `docs/`, `exe/docs/`, and `tofu/exe/` describes
+the **what** of the current implementation; this index points to the
+recorded decisions that shaped it.
+
+## Conventions
+
+- File naming: `NNNN-short-title.md` (sequential, lowercase, hyphens)
+- Status workflow: `Proposed` → `Accepted` → (`Deprecated` |
+  `Superseded by [NNNN]`)
+- Once `Accepted`, ADRs are **immutable**. To revisit a decision,
+  write a new ADR that supersedes the old one and update the old
+  ADR's status line — that is the only allowed modification.
+- Template lives in [`CLAUDE.md`](../../CLAUDE.md) under
+  `<adr-guidelines>`.
+
+## Index
+
+| #    | Title                                                                                       | Status                                       | Date       | Affects                          |
+| ---- | ------------------------------------------------------------------------------------------- | -------------------------------------------- | ---------- | -------------------------------- |
+| 0001 | [Migrate dev container to debian-12 + features (single SoT)](./0001-devcontainer-debian-features.md) | Accepted                                     | 2026-05-02 | `.devcontainer/`                 |
+| 0002 | [Coder workspace template uses a prebuilt dev container image](./0002-coder-prebuilt-image.md)       | Accepted                                     | 2026-05-02 | `exe/coder/templates/`           |
+| 0003 | [Pin GitHub Actions to commit SHAs and add Dependabot updates](./0003-actions-pin-sha.md)            | Accepted (PR #48)                            | 2026-05-02 | `.github/workflows/`             |
+| 0004 | [Workspace VMs reach the Coder control plane over the tailnet (B-plan)](./0004-workspace-tailnet-routing.md) | Accepted (PR #47)                    | 2026-05-02 | `exe/coder/templates/`, `exe/tailscale/acl.hujson` |
+| 0005 | [Rationalise install paths across Mac host and Coder workspace (Linux)](./0005-install-path-rationalization.md) | Accepted                          | 2026-05-02 | `install.sh`, `Brewfile`         |
+| 0006 | [mise tool version pinning strategy](./0006-mise-version-pinning.md)                                 | Accepted                                     | 2026-05-02 | `mise.toml`                      |
+| 0007 | [Coder server install hardening on the control-plane VM](./0007-coder-server-install-hardening.md)   | Accepted                                     | 2026-05-02 | `tofu/exe/coder.tf`, `tofu/exe/variables.tf` |
+| 0008 | [Event-driven Coder workspace runner (GHA-style without GHA)](./0008-event-driven-workspace-runner.md) | Superseded by [0009](./0009-retract-cron-trigger-from-adr-0008.md) (partial — trigger source 2 retracted) | 2026-05-03 | `exe/coder/templates/dotfiles-job/`, `exe/scripts/cdr-job` |
+| 0009 | [Retract the systemd-timer cron trigger from ADR 0008](./0009-retract-cron-trigger-from-adr-0008.md) | Accepted (2026-05-04 — cron infra reverted in PR #76, intentionally absent) | 2026-05-03 | retracts `tofu/exe` cron / systemd timer (none added) |
+| 0010 | [Cloud SQL Postgres for Coder data plane](./0010-cloud-sql-postgres-for-coder.md)                    | Proposed                                     | 2026-05-03 | `tofu/exe/cloudsql.tf`, `tofu/exe/coder.tf`, `tofu/exe/monitoring.tf` |
+
+## Reading order for newcomers
+
+1. [`0001`](./0001-devcontainer-debian-features.md) — why debian-12
+   with devcontainer features instead of an Alpine or Ubuntu base.
+2. [`0002`](./0002-coder-prebuilt-image.md) — why a prebuilt image
+   instead of envbuilder; same SoT as local IDE and CI.
+3. [`0007`](./0007-coder-server-install-hardening.md) — supply-chain
+   hardening on the control-plane VM (sha256 pin, no curl|bash).
+4. [`0010`](./0010-cloud-sql-postgres-for-coder.md) — current data
+   plane (Cloud SQL with IAM auth via CSAP `--auto-iam-authn`).
+5. [`0008`](./0008-event-driven-workspace-runner.md) followed by
+   [`0009`](./0009-retract-cron-trigger-from-adr-0008.md) — read as a
+   pair: 0008 framed the runner; 0009 retracted its cron trigger
+   while keeping the operator-pulled job runner.
+
+## Related
+
+- [`../../CLAUDE.md`](../../CLAUDE.md) — ADR template + when to write
+  one (`<adr-guidelines>` section)
+- [`../../exe/docs/architecture.md`](../../exe/docs/architecture.md)
+  — current `exe.hironow.dev` architecture
+- [`../../tofu/exe/README.md`](../../tofu/exe/README.md) — IaC overview

--- a/exe/coder/README.md
+++ b/exe/coder/README.md
@@ -13,7 +13,8 @@ Workspace == CI environment because the same
 
 | Path | Purpose |
 |---|---|
-| [`templates/dotfiles-devcontainer/`](./templates/dotfiles-devcontainer/) | Active workspace template (`main.tf` + lockfile + README) |
+| [`templates/dotfiles-devcontainer/`](./templates/dotfiles-devcontainer/) | Long-lived interactive workspace template (`main.tf` + lockfile + README). Operator's daily IDE / SSH target. |
+| [`templates/dotfiles-job/`](./templates/dotfiles-job/) | Ephemeral one-shot headless runner template (`main.tf` + lockfile + README) per [ADR 0008](../../docs/adr/0008-event-driven-workspace-runner.md). Driven by the [`cdr-job`](../scripts/cdr-job) wrapper. |
 
 ## Related docs
 

--- a/exe/coder/templates/dotfiles-devcontainer/README.md
+++ b/exe/coder/templates/dotfiles-devcontainer/README.md
@@ -1,15 +1,18 @@
-# Coder template — dotfiles devcontainer (prebuilt image)
+# Coder template — dotfiles-devcontainer (interactive prebuilt-image workspace)
 
-This template spawns a Coder workspace whose container image is the
-**dotfiles dev container** declared by `.devcontainer/devcontainer.json`
-(debian-12 + devcontainer features), prebuilt by CI and pulled from
-Artifact Registry. Same SoT as the local IDE and the CI sandbox, so
-all three environments stay aligned. Realises `docs/intent.md`:
+This template spawns a long-lived, interactive Coder workspace whose
+container image is the **dotfiles dev container** declared by
+`.devcontainer/devcontainer.json` (debian-12 + devcontainer features),
+prebuilt by GitHub Actions on each main merge and pulled from
+Artifact Registry. The same image is used by:
 
-> Coder workspace whose container image **is** the dotfiles Dev
-> Container.
+- the operator's local IDE (VS Code / Cursor / JetBrains via Dev
+  Containers extension), and
+- the CI sandbox in `.github/workflows/`,
 
-ADR: `docs/adr/0002-coder-prebuilt-image.md`
+so all three environments stay byte-identical.
+
+ADR: [`../../../../docs/adr/0002-coder-prebuilt-image.md`](../../../../docs/adr/0002-coder-prebuilt-image.md)
 
 ## How it works
 
@@ -96,16 +99,47 @@ feature, so a fresh workspace boots with these on PATH:
 Versions are pinned in [`mise.toml`](../../../../mise.toml) per
 [ADR 0006](../../../../docs/adr/0006-mise-version-pinning.md).
 
+## Lifecycle
+
+Unlike the sibling `dotfiles-job` template (which is one-shot), this
+template is meant for **long-lived interactive use**. There is no
+TTL set in the `.tf` source. To set one, the operator runs:
+
+```bash
+cdr templates edit exe-dotfiles-devcontainer --default-ttl 8h
+```
+
+Workspaces auto-stop after the TTL elapses; the boot disk is retained
+(`auto_delete = false` in `main.tf`) so a subsequent `cdr start` boots
+back into the same `/home/<user>` state.
+
+To delete a workspace explicitly:
+
+```bash
+cdr stop my-ws --yes
+cdr delete my-ws --yes
+```
+
 ## Smoke
 
 ```bash
 cdr workspaces list                # status: starting -> running (~30-60s)
-cdr ssh my-ws.dev -- just --list   # JustSandbox recipes available
+cdr ssh my-ws.dev -- just --list   # workspace recipes available
 cdr ssh my-ws.dev -- '
   for cli in codex gemini claude copilot pi; do
     printf "%s: " "$cli"; "$cli" --version 2>&1 | head -1
   done'
 ```
+
+## Differences from the sibling job template
+
+| Aspect | `dotfiles-devcontainer` (this) | `dotfiles-job` |
+|---|---|---|
+| Use case | Long-lived interactive IDE / SSH | One-shot headless command |
+| Interactive params | `instance_type`, `dotfiles_uri` | none |
+| Lifecycle | `default-ttl` via `cdr templates edit` | wrapper-trap (`cdr-job` `coder delete -y` on EXIT/INT/TERM) |
+| Hostname suffix | `-ws` | `-job` |
+| `coder dotfiles` install | yes (operator's repo on top of the prebuilt image) | no |
 
 ## Related docs
 

--- a/exe/coder/templates/dotfiles-job/README.md
+++ b/exe/coder/templates/dotfiles-job/README.md
@@ -1,17 +1,20 @@
-# Coder template — dotfiles-job (ephemeral runner)
+# Coder template — dotfiles-job (ephemeral headless runner)
 
-Headless workspace template for running a single command and
-exiting. Designed per [ADR 0008](../../../../docs/adr/0008-event-driven-workspace-runner.md)
-to give the operator a GitHub-Actions-style ephemeral runner
-without GitHub Actions in the loop.
+Headless workspace template for running a single shell command in a
+fresh GCE VM and tearing the VM down once the command exits. The
+operator's [`cdr-job`](../../../scripts/cdr-job) wrapper drives the
+create-poll-stream-delete cycle.
 
-Caller passes the command via the `job_command` parameter; the
-agent's startup_script runs it then the workspace stops. The
-[`cdr-job`](../../../scripts/cdr-job) wrapper handles the
-create-run-delete cycle with a `trap` so the workspace is always
-torn down.
+This template ships **no interactive parameters** and **no template-
+level TTL**. The caller passes the command via the `job_command`
+template parameter at create-time; lifecycle is owned by the wrapper's
+`trap` handler. See *Lifecycle and cost protection* below.
 
-## Push
+ADR: [`../../../../docs/adr/0008-event-driven-workspace-runner.md`](../../../../docs/adr/0008-event-driven-workspace-runner.md)
+(status: Superseded by 0009 partial — cron trigger source retracted,
+operator-pulled job runner retained)
+
+## Push the template
 
 ```bash
 cdr templates push exe-dotfiles-job \
@@ -23,27 +26,126 @@ cdr templates push exe-dotfiles-job \
   --yes
 ```
 
+| Variable | Default | Notes |
+|---|---|---|
+| `project_id` | `gen-ai-hironow` | GCP project hosting the job VMs |
+| `workspace_sa_email` | (required) | `just exe-output -raw exe_workspace_sa_email` — same SA as the interactive devcontainer template |
+| `coder_internal_url` | `http://exe-coder:7080` | tailnet-internal MagicDNS endpoint the job's coder-agent uses to reach the Coder server (bypasses CF Access) |
+| `workspace_authkey_secret_id` | `exe-tailscale-workspace-authkey` | Secret Manager secret holding the `tag:exe-workspace` tailnet authkey |
+| `image` | `asia-northeast1-docker.pkg.dev/gen-ai-hironow/dotfiles/devcontainer:main` | prebuilt dev container image; pin to `:<git-sha>` for reproducible runs |
+
 ## Run a job
+
+The intended entry point is the [`cdr-job`](../../../scripts/cdr-job)
+wrapper:
 
 ```bash
 cdr-job hello -- 'echo hello $(hostname); date'
 cdr-job tofu-plan -- 'cd /root/dotfiles/tofu/exe && just exe-plan'
 ```
 
-`cdr-job` polls the workspace agent until the startup_script
-exits, streams logs, then deletes the workspace. The trap
-handler also deletes on SIGINT / SIGTERM / failure.
+`cdr-job` issues:
 
-## Image and tool set
+```bash
+coder create <job-name> --template exe-dotfiles-job \
+  --parameter "job_command=<command...>" --yes
+```
 
-The job runs inside the same prebuilt dev container image
-(`devcontainer:main`) as the interactive `dotfiles-devcontainer`
-template, so the same tools are on PATH (just / mise / uv /
-gcloud / 5 AI CLIs / node / etc.).
+then polls the workspace agent until the agent's startup_script exits,
+streams the agent log to stdout, and finally `coder delete -y`s the
+workspace from a `trap` handler.
+
+You *can* also `cdr create ... --template exe-dotfiles-job` manually —
+but you become responsible for the delete step. The wrapper exists
+exactly to make that hard to forget.
+
+## Lifecycle and cost protection
+
+This template **does not** set `default_ttl_ms`, `dormancy_threshold_ms`,
+or any other auto-stop policy. The protection chain is:
+
+1. **Happy path** — the agent's startup_script runs the
+   `job_command`, exits, and `cdr-job`'s post-stream `coder delete -y`
+   tears the VM down (~30s).
+2. **SIGINT / SIGTERM** — `cdr-job`'s `trap '... coder delete -y' EXIT
+   INT TERM` fires and the VM is torn down.
+3. **Wrapper crash (SIGKILL, OOM, kernel panic on operator host)** —
+   no trap fires; the VM **leaks**. Operator must:
+
+   ```bash
+   cdr workspaces list                   # find the orphan
+   cdr delete <job-name> --yes
+   ```
+
+   Cost exposure of one leak is bounded by GCE preemption (~24h on
+   `e2-small` in `asia-northeast1`); a leaked VM stops itself by the
+   next maintenance event but is not deleted automatically. See ADR
+   0008 *"Lifecycle and cost protection"* for why we accept this
+   tradeoff over template-level TTL (TTL would race with long-running
+   jobs like `tofu-plan` and surface as silent failures).
+4. **`just exe-teardown vm`** — operator escape hatch that destroys
+   every workspace VM in the project regardless of state.
+
+## What's in the job VM
+
+The job VM is a debian-12 GCE `e2-small` (zone `asia-northeast1-a`)
+that:
+
+1. Joins the tailnet with `tag:exe-workspace` (Secret-Manager-backed
+   authkey).
+2. `docker pull`s the prebuilt dev container image from Artifact
+   Registry.
+3. `docker run`s the image with `--network host`, mounting
+   `/home/<user>:/root` and `/var/run/docker.sock`.
+4. The container's PID 1 is `coder agent`, which runs the
+   `job_command` as its `startup_script`.
+
+Tools available inside the container (from the prebuilt image):
+
+| Category | Tools |
+|---|---|
+| Core | `just`, `mise`, `uv`, `gcloud`, `git`, `docker` (cli-only) |
+| Lint / format | `ruff`, `shellcheck`, `markdownlint-cli2`, `prek` |
+| Runtime | `node` 24.15.0, `python` 3 (mise-pinned) |
+| AI agent CLIs | `codex`, `gemini`, `claude`, `copilot`, `pi` |
+
+Versions are pinned in [`mise.toml`](../../../../mise.toml) per
+[ADR 0006](../../../../docs/adr/0006-mise-version-pinning.md).
+The mise data dir is `/opt/mise`, baked into the image at build time
+and reachable with `MISE_OFFLINE=1`.
+
+## Smoke
+
+```bash
+# minimal: spin up, run hostname, tear down (~60s end-to-end)
+cdr-job smoke -- 'echo hello $(hostname); date'
+
+# verify the same tool set as the interactive workspace
+cdr-job smoke-tools -- '
+  for cli in just mise uv gcloud codex gemini claude copilot pi; do
+    printf "%s: " "$cli"
+    "$cli" --version 2>&1 | head -1
+  done'
+```
+
+## Differences from the sibling devcontainer template
+
+| Aspect | `dotfiles-job` (this) | `dotfiles-devcontainer` |
+|---|---|---|
+| Interactive params | none | `instance_type`, `dotfiles_uri` |
+| Lifecycle | wrapper-trap (this README §Lifecycle) | TTL via `coder templates edit` |
+| Hostname | `<ws>-job` | `<ws>-ws` |
+| `coder dotfiles` install | no | yes (operator's repo cloned over the prebuilt image) |
+| Default machine type | `e2-small` (fixed) | `e2-small` (operator-overridable) |
 
 ## Related docs
 
+- [`../../../scripts/cdr-job`](../../../scripts/cdr-job) — wrapper
+  source (read this for the trap semantics)
+- [`../dotfiles-devcontainer/README.md`](../dotfiles-devcontainer/README.md) —
+  sibling interactive template
+- [`../../../docs/runbook.md`](../../../docs/runbook.md) — operator
+  workflow including job-leak recovery
 - [`../../../../docs/adr/0008-event-driven-workspace-runner.md`](../../../../docs/adr/0008-event-driven-workspace-runner.md)
-- [`../dotfiles-devcontainer/README.md`](../dotfiles-devcontainer/README.md) — sibling interactive template
-- [`../../../scripts/cdr-job`](../../../scripts/cdr-job)
-- [`../../../docs/runbook.md`](../../../docs/runbook.md)
+- [`../../../../docs/adr/0009-retract-cron-trigger-from-adr-0008.md`](../../../../docs/adr/0009-retract-cron-trigger-from-adr-0008.md) —
+  why this template no longer has a cron trigger

--- a/exe/coder/templates/dotfiles-job/main.tf
+++ b/exe/coder/templates/dotfiles-job/main.tf
@@ -4,9 +4,15 @@
 # Differences from the sibling dotfiles-devcontainer template:
 #   - No interactive parameters. The caller passes the command to
 #     run via the `job_command` template parameter at create-time.
-#   - Short default_ttl_ms / dormancy_threshold_ms so a hung job
-#     does not leak the VM. The cdr-job wrapper additionally
-#     issues `coder delete -y` from a trap handler.
+#   - Lifecycle is owned entirely by the cdr-job wrapper:
+#       * `coder create --yes` blocks until the agent is up,
+#         streams the agent startup_script log, then issues
+#         `coder delete -y` from an EXIT/INT/TERM trap.
+#     This template does NOT set `default_ttl_ms`,
+#     `dormancy_threshold_ms`, or any auto-stop on the VM. If the
+#     wrapper is killed by SIGKILL or OOM (no trap fires), the
+#     job VM will leak — operator must `cdr delete <job-name> -y`
+#     manually. See ADR 0008 "Lifecycle and cost protection".
 #   - Same dev container image (`devcontainer:main`) so the job
 #     sees the same tool set the operator's interactive workspace
 #     does (mise pins, AI CLIs, gcloud, just, ...).

--- a/exe/docs/architecture.md
+++ b/exe/docs/architecture.md
@@ -22,12 +22,16 @@ This document describes the components currently provisioned by
                       +----------------------+
                       | exe-coder VM         |
                       | exe-vpc 10.10.0.0/24 |
-                      | debian-12, e2-small  |
+                      | ubuntu-24.04 LTS     |
+                      | e2-small, SPOT       |
                       | tag:exe-coder        |
-                      | cloudflared          |
-                      | tailscaled           |
-                      | cloud-sql-proxy      |
-                      | Coder server         |
+                      | systemd units:       |
+                      |   coder.service      |
+                      |   cloudflared-       |
+                      |     exe.service      |
+                      |   cloud-sql-proxy.   |
+                      |     service          |
+                      |   tailscaled         |
                       | CODER_HTTP_ADDRESS=  |
                       |   0.0.0.0:7080       |
                       +----+----+------------+
@@ -73,7 +77,8 @@ Legend / 凡例:
 - tailnet (WireGuard): exe-coder と workspace 間の internal channel
 - MagicDNS: tailnet 内 hostname 解決 (exe-coder → 100.x.x.x)
 - prebuilt dev container image: GitHub Actions が main merge 時に build + push (Artifact Registry)、workspace VM は docker pull のみ。envbuilder は ADR 0002 で廃止
-- debian-12: VM ホスト OS / dev container ベース (共通)
+- ubuntu-24.04 LTS: 制御プレーン VM (`exe-coder`) のホスト OS
+- debian-12: workspace VM のホスト OS、および dev container イメージのベース
 ```
 
 ## Boundaries and trust
@@ -86,7 +91,7 @@ Legend / 凡例:
 | Owner laptop → exe-coder | Owner identity | Tailscale `tag:owner` → `*:*` |
 | AI agent → exe-coder | Restricted role | Tailscale `tag:agent` → `tag:exe-coder:22,80,443,3000-3999` |
 | Workspace → exe-coder | Per-workspace role | Tailscale `tag:exe-workspace` → `tag:exe-coder:7080` (agent download + protocol) |
-| exe-coder → GCP APIs | VM identity | SA `exe-coder@…` (Secret Manager accessor on tailnet/tunnel secrets, compute.instanceAdmin, iam.serviceAccountUser, logging/monitoring) |
+| exe-coder → GCP APIs | VM identity | SA `exe-coder@…` (Secret Manager accessor on tailnet/tunnel/Postgres-admin secrets, `cloudsql.client` + `cloudsql.instanceUser` for CSAP `--auto-iam-authn`, `compute.instanceAdmin.v1`, `iam.serviceAccountUser`, `logging.logWriter`, `monitoring.metricWriter`) |
 | Workspace → GCP APIs | VM identity | SA `exe-workspace@…` (only the workspace authkey; logging/monitoring) |
 | Public internet → workspace VM | NONE | `deny_all_ingress` firewall + no public ports listening |
 | Workspace **container** → tailnet RPC | NONE (intentional) | `tailscaled` Unix socket is **not** mounted into the container; `tailscale` CLI is **not** installed in the dev container image |
@@ -188,12 +193,15 @@ loopback).
 
 ## Coder server
 
-Started by the VM startup-script as a background process (cos lacks
-systemd). The Coder binary is fetched at the pinned
-`var.coder_version` and verified against `var.coder_sha256`
-(ADR 0007 supply-chain hardening — replaces the curl-piped install
-script and the GitHub-API `latest` fallback). Configuration is
-purely env-var driven:
+Runs as a systemd unit (`/etc/systemd/system/coder.service`) on the
+ubuntu-24.04 control-plane VM. Three systemd units form the boot
+order: `tailscaled` (apt-installed) → `cloudflared-exe.service` and
+`cloud-sql-proxy.service` (both written by the startup-script) →
+`coder.service` (Requires both, EnvironmentFile-loaded). The Coder
+binary is fetched at the pinned `var.coder_version` and verified
+against `var.coder_sha256` (ADR 0007 supply-chain hardening —
+replaces the curl-piped install script and the GitHub-API `latest`
+fallback). Configuration is purely env-var driven:
 
 | Variable | Value | Purpose |
 |---|---|---|

--- a/exe/docs/runbook.md
+++ b/exe/docs/runbook.md
@@ -51,7 +51,9 @@ After the first apply succeeds:
 1. Visit `https://exe.hironow.dev/` — should redirect to Cloudflare
    Access OIDC.
 2. Log in as `owner_email` — the Coder UI loads (allow ~2 minutes on
-   first boot for the binary download + embedded postgres init).
+   first boot for the Coder binary download, sha256 verification,
+   and Cloud SQL Auth Proxy connection bootstrap; see architecture.md
+   §"Data plane — Cloud SQL Postgres" for the IAM-auth chain).
 3. Retrieve the auto-generated admin password from the VM:
 
    ```bash
@@ -580,8 +582,12 @@ once the VM is back).
 
 ## Cost monitoring
 
-GCS state bucket and Secret Manager are essentially free. The VM is
-the only meaningful cost line. To check this month's GCE spend:
+GCS state bucket, Secret Manager, and Cloud Monitoring uptime checks
+are essentially free. The two meaningful cost lines are the GCE VM
+(`exe-coder`, ~$5–7/mo on `e2-small` SPOT) and Cloud SQL
+(`exe-coder-pg`, ~$8–10/mo on `db-f1-micro` ZONAL with daily backup).
+See `architecture.md` §"Cost" for the full table. To check this
+month's spend:
 
 ```bash
 gcloud billing budgets list 2>/dev/null   # if budgets are configured

--- a/exe/docs/runbook.md
+++ b/exe/docs/runbook.md
@@ -118,10 +118,6 @@ Pre-merge testing of dev container changes:
 
 3. Once verified, push another version with `:main` to revert.
 
-The previous `git_branch` parameter (envbuilder-only) is gone:
-the prebuilt-image template doesn't clone at workspace boot;
-operator branch testing happens via the image tag instead.
-
 ## AI agent CLI authentication
 
 Five AI CLIs ship in the image with **no credentials baked in**.

--- a/exe/scripts/README.md
+++ b/exe/scripts/README.md
@@ -12,7 +12,7 @@ documents the file-level layout.
 |---|---|
 | [`cdr`](./cdr) | Wrapper around the upstream `coder` CLI. Fetches Cloudflare Access service-token credentials from Secret Manager (cached for 5 min), exports `CODER_HEADER_COMMAND`, then exec's `coder` with the original arguments. Symlinked into `~/.local/bin` via `just exe-cdr-install`. |
 | [`cdr-header`](./cdr-header) | Helper invoked by `cdr` via `CODER_HEADER_COMMAND` to emit the `CF-Access-*` headers Coder needs on every API call. |
-| [`cdr-job`](./cdr-job) | Run a single command in a fresh ephemeral Coder workspace per [ADR 0008](../../docs/adr/0008-event-driven-workspace-runner.md). Pure isolation, ~6 min boot tax. Trap-handler `coder delete` on exit. |
+| [`cdr-job`](./cdr-job) | Run a single command in a fresh ephemeral Coder workspace per [ADR 0008](../../docs/adr/0008-event-driven-workspace-runner.md) (status: Superseded by [0009](../../docs/adr/0009-retract-cron-trigger-from-adr-0008.md) partial — cron retracted, operator-pulled job runner retained). Pure isolation, ~6 min boot tax. Trap-handler `coder delete` on exit. |
 | [`cdr-exec`](./cdr-exec) | Run a command in an EXISTING long-lived workspace (warm reuse, ~10-30s start). State is NOT isolated between calls. See ADR 0008 amendment for the trade-off. |
 | [`bootstrap.sh`](./bootstrap.sh) | First-time provisioning helper (tofu apply + cloudflared tunnel login). Idempotent. |
 | [`teardown.sh`](./teardown.sh) | Destroys the GCE workspace VM and Coder template, retains Cloudflare + Tailscale state for re-bootstrap. Idempotent. |

--- a/tofu/README.md
+++ b/tofu/README.md
@@ -13,9 +13,10 @@ isolated stack with its own backend / state file.
 - Remote state in GCS bucket per stack; state encryption enabled.
 - `terraform.tfvars` is gitignored. Real values live in GCP Secret
   Manager and are wired in via `data "google_secret_manager_secret_version"`.
-- `.terraform.lock.hcl` IS tracked (HashiCorp recommends this; per
-  [PR #62](https://github.com/hironow/dotfiles/pull/62)). The
-  runtime cache dir `.terraform/` and state files stay ignored.
+- `.terraform.lock.hcl` IS tracked (HashiCorp recommends this so
+  every operator + CI run resolves the same provider plugin
+  versions). The runtime cache dir `.terraform/` and state files
+  stay ignored.
 - Run `tofu fmt -recursive` before commit.
 
 ## Related docs

--- a/tofu/exe/README.md
+++ b/tofu/exe/README.md
@@ -4,29 +4,61 @@ OpenTofu stack provisioning `exe.hironow.dev`.
 
 ## Inputs
 
+Source of truth: [`variables.tf`](./variables.tf). Defaults shown are
+the values currently committed; values without a default are
+operator-supplied via `terraform.tfvars`.
+
+### Deployment scope
+
 | Variable | Default | Description |
 |---|---|---|
 | `gcp_project_id` | `gen-ai-hironow` | GCP project (single-project, single-stack) |
 | `gcp_region` | `asia-northeast1` | Primary region |
 | `gcp_zone` | `asia-northeast1-a` | Primary zone |
 | `domain` | `exe.hironow.dev` | Cloudflare-managed apex |
-| `tailnet` | (from `terraform.tfvars`, e.g. `hironow.github`) | Tailscale tailnet identifier |
+| `sandbox_subdomain` | `sandbox.hironow.dev` | Wildcard parent for Coder app preview hostnames |
+| `cf_zone_name` | `hironow.dev` | Cloudflare zone holding both `domain` and `sandbox_subdomain` |
+| `cf_zone_id` | (required, `terraform.tfvars`) | Cloudflare zone identifier |
+| `cf_account_id` | (required, `terraform.tfvars`) | Cloudflare account identifier |
+| `tailnet` | (required, `terraform.tfvars`, e.g. `hironow.github`) | Tailscale tailnet identifier |
+| `owner_email` | `hironow365@gmail.com` | CF Access allowlist + uptime alert recipient |
+
+### Control-plane VM
+
+| Variable | Default | Description |
+|---|---|---|
+| `machine_type` | `e2-small` | GCE machine type for the `exe-coder` VM |
+| `preemptible` | `true` | Use SPOT (24h auto-stop, ~70% discount) |
+| `vm_image` | `projects/ubuntu-os-cloud/global/images/family/ubuntu-2404-lts-amd64` | Control-plane VM image (ubuntu-24.04 LTS) |
+| `boot_disk_size_gb` | `30` | Boot disk GiB (validated 20-200) |
 | `coder_version` | `v2.31.11` | Pinned Coder server release tag (see [ADR 0007](../../docs/adr/0007-coder-server-install-hardening.md)) |
-| `coder_sha256` | (see `variables.tf`) | Sha256 of `coder_<ver>_linux_amd64.tar.gz` from the release's `checksums.txt` |
+| `coder_sha256` | (in `variables.tf`) | sha256 of `coder_<ver>_linux_amd64.tar.gz` from release's `checksums.txt` |
+
+### Cloud SQL data plane (ADR 0010)
+
+| Variable | Default | Description |
+|---|---|---|
+| `cloud_sql_tier` | `db-f1-micro` | Postgres instance tier (ENTERPRISE edition; ENTERPRISE_PLUS rejects f1-micro) |
+| `cloud_sql_postgres_version` | `POSTGRES_16` | Postgres major version |
+| `cloud_sql_disk_size_gb` | `10` | Initial SSD disk size; auto-resize is enabled |
+| `cloud_sql_proxy_version` | `v2.21.3` | Pinned cloud-sql-proxy v2 release |
+| `cloud_sql_proxy_sha256` | (in `variables.tf`) | sha256 of the linux/amd64 binary |
 
 ## Files
 
 | Path | Purpose |
 |---|---|
-| [`main.tf`](./main.tf) | Backend (GCS), providers, locals |
-| [`variables.tf`](./variables.tf) | Input variables (incl. Coder pin) |
-| [`outputs.tf`](./outputs.tf) | Workspace SA email, AR repo, control-plane URL |
-| [`coder.tf`](./coder.tf) | Control-plane VM startup_script (Coder server install + cloudflared + tailscaled, with apt-key fingerprint pin) |
-| [`tailscale.tf`](./tailscale.tf) | Tagged auth keys, ACL bootstrap, 90-day rotation |
-| [`cloudflare.tf`](./cloudflare.tf) | Tunnel + Access policy + DNS records |
+| [`main.tf`](./main.tf) | Backend (GCS), providers, VPC/subnet/Service-Networking-API enablement |
+| [`variables.tf`](./variables.tf) | Input variables (incl. Coder + cloud-sql-proxy pins) |
+| [`outputs.tf`](./outputs.tf) | Workspace SA email, AR repo, control-plane URL, Cloud SQL connection name, IAM DB user, uptime check / alert policy names |
+| [`coder.tf`](./coder.tf) | Control-plane VM + startup_script: systemd units for `coder.service`, `cloudflared-exe.service`, `cloud-sql-proxy.service` (apt-key fingerprint pinned), `deny-all-ingress` firewall, `roles/{logging.logWriter,monitoring.metricWriter,compute.instanceAdmin.v1,iam.serviceAccountUser}` on the VM SA |
+| [`cloudsql.tf`](./cloudsql.tf) | Cloud SQL Postgres instance (`exe-coder-pg`, ENTERPRISE, ZONAL, private-IP-only via VPC peering), IAM DB user (`google_sql_user.coder_iam` for `--auto-iam-authn`), `cloudsql.client` + `cloudsql.instanceUser` on the VM SA, Postgres-admin bootstrap secret (ADR 0010) |
+| [`monitoring.tf`](./monitoring.tf) | Cloud Monitoring uptime check on `/healthz` (5 min, 3 regions), email alert policy on 2 consecutive failures |
+| [`tailscale.tf`](./tailscale.tf) | Tagged auth keys (`tag:exe-coder` / `tag:exe-workspace` / `tag:agent`), ACL bootstrap, 90-day rotation |
+| [`cloudflare.tf`](./cloudflare.tf) | Tunnel + Access policy + DNS records + CF Access service tokens |
 | [`artifact_registry.tf`](./artifact_registry.tf) | Dev container image AR repo (`devcontainer:main` + `devcontainer:<sha>`) |
-| [`iam.tf`](./iam.tf) | Workload Identity Federation (GHA → AR) + workspace SA |
-| [`locals.tf`](./locals.tf) | Hostnames, tag names |
+| [`iam.tf`](./iam.tf) | Workload Identity Federation (GHA → AR) + workspace SA + AR reader/writer grants |
+| [`locals.tf`](./locals.tf) | Hostnames, tag names, common labels |
 | [`.terraform.lock.hcl`](./.terraform.lock.hcl) | Provider plugin lockfile (tracked) |
 
 ## State


### PR DESCRIPTION
Comprehensive doc audit + correction sweep across `exe/`, `tofu/`, and `docs/adr/` after the recent Cloud SQL migration (PR #79–#82), uptime-check landing (PR #83–#84), and ADR 0008 cron retraction (PR #76). Goal: every line in `exe/**/*.md`, `tofu/**/*.md`, and `docs/adr/**/*.md` reflects the **currently deployed** stack — no historical fragments, no future plans, no false claims.

## Commits (5)

1. `058a2b4 docs(exe): correct architecture against ubuntu-24.04 + systemd + Cloud SQL grants`
   - Control-plane VM is **ubuntu-24.04 LTS**, not debian-12 (`var.vm_image` default; only the workspace VM template stays on debian-12).
   - Coder server / cloudflared / cloud-sql-proxy run as **systemd units**, not as background processes (the cos-lacks-systemd note was a leftover from the abandoned cos approach in `coder.tf` L13-23).
   - `exe-coder@` SA carries `roles/cloudsql.client` + `roles/cloudsql.instanceUser` for CSAP `--auto-iam-authn` (`cloudsql.tf:211,217`); the original architecture.md grant list was missing both.

2. `2119ac5 docs(exe): correct runbook and READMEs to current data plane`
   - runbook.md first-boot note: drop "embedded postgres init" (gone per ADR 0010); replace with the actual chain (Coder binary download, sha256 verify, CSAP IAM-auth bootstrap).
   - runbook.md cost monitoring: VM is no longer the sole meaningful line — Cloud SQL on db-f1-micro is comparable.
   - `exe/coder/README.md`: list `dotfiles-job` alongside `dotfiles-devcontainer` (both active).
   - `tofu/exe/README.md`: split inputs into deployment-scope / control-plane-VM / Cloud-SQL sections covering all 18 variables; add `cloudsql.tf` + `monitoring.tf` to the files table; expand per-file purpose strings.

3. `1f8bc56 docs: drop historical references per docs-guidelines`
   - runbook.md: remove the "previous git_branch parameter (envbuilder-only) is gone" paragraph.
   - tofu/README.md: drop the `per PR #62` citation; keep the rule with the rationale inline.
   - exe/scripts/README.md: annotate the ADR 0008 link with its `Superseded by 0009 partial` status.

4. `732de92 docs(exe): align template READMEs and main.tf with actual lifecycle`
   - `dotfiles-job/main.tf` header: remove the false `default_ttl_ms / dormancy_threshold_ms` claim. Lifecycle is owned entirely by the `cdr-job` wrapper's `EXIT/INT/TERM` trap; SIGKILL/OOM leak case documented.
   - `dotfiles-job/README.md`: rewrite as a self-contained reference (push command, full variables table, lifecycle and cost-protection section, VM contents, smoke commands, diff table vs sibling).
   - `dotfiles-devcontainer/README.md`: tighten the SoT statement (local IDE / CI sandbox / Coder workspace), drop gitignored `intent.md` link, add Lifecycle section and diff table.

5. `8345df0 docs(adr): add index README; accept 0009 (cron intentionally absent)`
   - New `docs/adr/README.md` index of all ten ADRs (status / date / affected paths / reading order / immutability conventions).
   - `0009`: Proposed → **Accepted (2026-05-04)** — cron / systemd-timer scaffolding was reverted in PR #76 and is intentionally absent from the current implementation; operator-pulled `cdr-job` / `cdr-exec` are the sole job entry points. The status field records that the absence is the decision, not a pending task.
   - `0010` left as Proposed — Cloud SQL data plane is deployed and stable but kept under soak (~1 week target).

## Verification

- `just exe-test`: 48 passed, 1 skipped (incl. `test_template_terraform_plan` and `test_template_tofu_fmt` exercising the modified `dotfiles-job/main.tf` header)
- prek pre-commit hooks pass on every commit (markdownlint-cli2, ruff, just fmt/lint)
- All ADR cross-references and inter-doc links verified against the live filesystem

## Notes

- No code changes; pure docs.
- ADR 0010 (Cloud SQL) intentionally remains `Proposed`; will be flipped to `Accepted` in a separate one-line PR after the soak window.
- This PR is the second wave of the post-Cloud-SQL doc-coherence sweep (first wave was the runbook sections added inline alongside PR #79–#84).