### PR TITLE
feat(exe): operator IAM DB user for Cloud SQL Studio read-only audit

### DIFF
--- a/exe/docs/architecture.md
+++ b/exe/docs/architecture.md
@@ -246,7 +246,9 @@ authenticates to Cloud SQL using the VM's `exe-coder@` SA with
 |---|---|
 | `google_sql_database_instance.coder` | `exe-coder-pg` instance, Postgres 16, ZONAL, private IP only, deletion_protection=true, `cloudsql.iam_authentication=on` flag |
 | `google_sql_database.coder` | Schema Coder writes to |
-| `google_sql_user.coder_iam` | IAM service-account user mapped to `exe-coder@`. NO password — auth is via OAuth tokens fetched by CSAP at connection time. |
+| `google_sql_user.coder_iam` | IAM service-account user mapped to `exe-coder@`. NO password — auth is via OAuth tokens fetched by CSAP at connection time. Schema-level GRANTs: CONNECT + USAGE/CREATE on schema public + ALL on tables/sequences (full read/write). |
+| `google_sql_user.operator_iam` | IAM individual-user mapped to `var.owner_email`. **Read-only audit user** for Cloud SQL Studio (Console UI). Schema-level GRANTs: CONNECT + USAGE on schema public + SELECT on tables/sequences only. No CREATE / INSERT / UPDATE / DELETE — write traffic stays exclusive to `coder.service` via `coder_iam`. |
+| `google_project_iam_member.operator_cloudsql_instance_user` | Grants `roles/cloudsql.instanceUser` to the operator's `user:` principal. Deliberately no `cloudsql.client` — Studio handles the transport internally and the smaller grant surface is fine. |
 | `google_compute_global_address.exe_psa_range` + `google_service_networking_connection.exe_psa` | /20 reserved + VPC peering for private IP — no public Cloud SQL IP, no firewall rule |
 | `roles/cloudsql.client` + `roles/cloudsql.instanceUser` on the VM SA | The two grants required for CSAP `--auto-iam-authn`: `client` for the TLS cert to dial the instance, `instanceUser` for the OAuth token exchange at the DB layer. |
 | `cloud-sql-proxy.service` (systemd, on the VM) | Listens on 127.0.0.1:5432, exec'd from `/usr/local/bin/cloud-sql-proxy --auto-iam-authn ...` (pinned `var.cloud_sql_proxy_version` + `var.cloud_sql_proxy_sha256`) |

--- a/exe/docs/runbook.md
+++ b/exe/docs/runbook.md
@@ -190,6 +190,48 @@ gcloud secrets versions list exe-tailscale-coder-authkey
 gcloud secrets versions destroy <N> --secret=exe-tailscale-coder-authkey
 ```
 
+## Inspect Coder data via Cloud SQL Studio
+
+For read-only debugging of Coder's internal tables (workspaces,
+templates, users, audit log, ...) without SSHing into the VM. Auth
+is the operator's personal IAM identity — actions land in audit log
+under `var.owner_email`, not the service account.
+
+1. Open <https://console.cloud.google.com/sql/instances/exe-coder-pg/studio?project=gen-ai-hironow>.
+2. Click **Open Cloud SQL Studio** → **Authenticate** → choose
+   **IAM authentication** with your account (`hironow365@gmail.com`).
+3. Database: `coder`. Run SQL — only SELECT works. Examples:
+
+   ```sql
+   SELECT id, name, owner_id, created_at, deleted
+     FROM workspaces ORDER BY created_at DESC LIMIT 20;
+
+   SELECT name, version, latest_template_version_id
+     FROM templates WHERE deleted = false;
+
+   SELECT email, username, created_at, last_seen_at
+     FROM users ORDER BY last_seen_at DESC NULLS LAST LIMIT 50;
+   ```
+
+If you try `INSERT` / `UPDATE` / `DELETE` / `CREATE` you get
+`permission denied` — that is by design (per ADR 0010 follow-up).
+Write operations belong to `coder.service` only.
+
+To revoke this access (e.g. on suspected compromise):
+
+```bash
+# 1. drop the project-level grant
+gcloud projects remove-iam-policy-binding gen-ai-hironow \
+  --member="user:hironow365@gmail.com" \
+  --role="roles/cloudsql.instanceUser"
+# 2. drop the DB user
+gcloud sql users delete hironow365@gmail.com \
+  --instance=exe-coder-pg --project=gen-ai-hironow
+```
+
+(`tofu apply` will recreate them next run; comment out the resources
+in `cloudsql.tf` first if you want the revocation to stick.)
+
 ## Cloud SQL backup and restore
 
 Per [ADR 0010](../../docs/adr/0010-cloud-sql-postgres-for-coder.md)

--- a/exe/docs/usage.md
+++ b/exe/docs/usage.md
@@ -119,6 +119,16 @@ This makes VS Code emit the same `CF-Access-Client-Id=...` /
 `CF-Access-Client-Secret=...` headers `cdr` does, so the extension
 can reach `https://exe.hironow.dev` through Cloudflare Access.
 
+## Inspect the Coder DB via Cloud SQL Studio (read-only)
+
+For ad-hoc SQL against Coder's tables without SSHing into the VM,
+open Cloud SQL Studio in the GCP Console and authenticate with your
+own IAM identity (`hironow365@gmail.com`). The operator's IAM DB
+user is **read-only** — `SELECT` works, anything else returns
+`permission denied` (write traffic stays with `coder.service`). See
+[`runbook.md` › Inspect Coder data via Cloud SQL Studio](./runbook.md#inspect-coder-data-via-cloud-sql-studio)
+for the URL, query examples, and revocation procedure.
+
 ## Data persists across VM rebuilds
 
 Per [ADR 0010](../../docs/adr/0010-cloud-sql-postgres-for-coder.md)

--- a/tests/exe/test_startup_script.py
+++ b/tests/exe/test_startup_script.py
@@ -78,6 +78,7 @@ HCL_SUBSTITUTIONS: dict[str, str] = {
         "gen-ai-hironow:asia-northeast1:exe-coder-pg"
     ),
     r"\$\{local\.cloud_sql_iam_db_user\}": "exe-coder@gen-ai-hironow.iam",
+    r"\$\{local\.cloud_sql_operator_db_user\}": "hironow365@gmail.com",
     r"\$\{local\.cloud_sql_private_ip\}": "10.130.224.3",
     r"\$\{google_secret_manager_secret\.postgres_admin\.secret_id\}": (
         "exe-postgres-admin-password"
@@ -1138,6 +1139,132 @@ def test_cloud_sql_resources_present() -> None:
 
 
 @pytest.mark.exe
+def test_operator_iam_db_user_provisioned_for_studio_access() -> None:
+    """ADR 0010 follow-up: an additional IAM DB user mapped to the
+    operator's personal email is provisioned so the operator can
+    inspect Coder's tables via Cloud SQL Studio (Console UI) without
+    impersonating the exe-coder@ service account.
+
+    Posture: the user is intended for *read-only debugging* — the
+    bootstrap GRANT step gives CONNECT + USAGE on schema public +
+    SELECT on existing and future tables, but NOT CREATE/INSERT/UPDATE.
+    Write traffic stays exclusive to coder.service via the SA user.
+    """
+    cloudsql_tf = (ROOT / "tofu" / "exe" / "cloudsql.tf").read_text()
+
+    # The operator user is a CLOUD_IAM_USER (individual email), not a
+    # CLOUD_IAM_SERVICE_ACCOUNT. Cloud SQL distinguishes the two by
+    # the `type` field; getting it wrong creates a user that cannot
+    # actually authenticate.
+    user_block = re.search(
+        r'resource\s+"google_sql_user"\s+"operator_iam"\s*\{(.*?)^\}',
+        cloudsql_tf,
+        re.DOTALL | re.MULTILINE,
+    )
+    assert user_block is not None, (
+        "Missing google_sql_user.operator_iam — ADR 0010 follow-up\n"
+        "requires an IAM DB user mapped to the operator's personal\n"
+        "email so Cloud SQL Studio (Console UI) can authenticate as\n"
+        "the human, not the service account."
+    )
+    body = user_block.group(1)
+    assert re.search(r'type\s*=\s*"CLOUD_IAM_USER"', body), (
+        'operator_iam user MUST have type = "CLOUD_IAM_USER" (individual\n'
+        "email). CLOUD_IAM_SERVICE_ACCOUNT is the wrong type for a human."
+    )
+    assert "var.owner_email" in body, (
+        "operator_iam user name MUST come from var.owner_email so a\n"
+        "single source of truth drives both the CF Access allowlist and\n"
+        "the Cloud SQL DB user."
+    )
+    assert "time_sleep.cloud_sql_iam_role_settle" in body, (
+        "operator_iam MUST depend_on the same time_sleep as coder_iam —\n"
+        "both share the asynchronous cloudsql-iam-* role bootstrap race."
+    )
+
+    # Project-level IAM: operator needs roles/cloudsql.instanceUser to
+    # exchange ADC for a DB access token. (cloudsql.client is required
+    # only for proxy/cert path; Cloud SQL Studio handles that internally
+    # so we deliberately do NOT grant it here.)
+    instance_user_grant = re.search(
+        r'resource\s+"google_project_iam_member"\s+"operator_cloudsql_instance_user"\s*\{(.*?)^\}',
+        cloudsql_tf,
+        re.DOTALL | re.MULTILINE,
+    )
+    assert instance_user_grant is not None, (
+        "Missing google_project_iam_member.operator_cloudsql_instance_user.\n"
+        "Without roles/cloudsql.instanceUser on the operator account,\n"
+        "Cloud SQL Studio's IAM-auth login fails closed."
+    )
+    grant_body = instance_user_grant.group(1)
+    assert "cloudsql.instanceUser" in grant_body
+    assert "user:" in grant_body, (
+        "operator IAM grant MUST use a `user:` member prefix (individual\n"
+        "principal), not `serviceAccount:`."
+    )
+    assert "var.owner_email" in grant_body, (
+        "operator IAM grant member MUST be derived from var.owner_email."
+    )
+
+
+@pytest.mark.exe
+def test_operator_iam_user_grants_are_read_only(startup_script: str) -> None:
+    """The operator's IAM DB user is provisioned for read-only audit.
+    The bootstrap GRANT step in coder.tf must give CONNECT + USAGE +
+    SELECT, but MUST NOT grant CREATE / INSERT / UPDATE / DELETE
+    privileges. Write traffic stays exclusive to coder.service via
+    the SA user (google_sql_user.coder_iam)."""
+    # The startup script picks the operator email from a shell var
+    # rendered from var.owner_email at apply time; spot-check a SELECT
+    # GRANT exists for it without the dangerous verbs.
+    assert "PG_OPERATOR_DB_USER=" in startup_script, (
+        "startup_script MUST export PG_OPERATOR_DB_USER (operator email)\n"
+        "before the GRANT block, mirroring PG_IAM_DB_USER for the SA."
+    )
+    # The GRANT line for the operator must be SELECT-shaped, not ALL.
+    assert re.search(
+        r'GRANT\s+CONNECT\s+ON\s+DATABASE\s+coder\s+TO\s+"\$PG_OPERATOR_DB_USER"',
+        startup_script,
+    ), "Missing CONNECT GRANT for the operator IAM DB user."
+    assert re.search(
+        r'GRANT\s+USAGE\s+ON\s+SCHEMA\s+public\s+TO\s+"\$PG_OPERATOR_DB_USER"',
+        startup_script,
+    ), "Missing USAGE GRANT on schema public for the operator IAM DB user."
+    assert re.search(
+        r"GRANT\s+SELECT\s+ON\s+ALL\s+TABLES\s+IN\s+SCHEMA\s+public\s+"
+        r'TO\s+"\$PG_OPERATOR_DB_USER"',
+        startup_script,
+    ), "Missing SELECT GRANT on all tables for the operator IAM DB user."
+    # Default privileges so SELECT also covers tables Coder creates
+    # AFTER the bootstrap (every Coder upgrade adds new tables).
+    assert re.search(
+        r"ALTER\s+DEFAULT\s+PRIVILEGES\s+IN\s+SCHEMA\s+public\s+"
+        r'GRANT\s+SELECT\s+ON\s+TABLES\s+TO\s+"\$PG_OPERATOR_DB_USER"',
+        startup_script,
+    ), (
+        "Missing ALTER DEFAULT PRIVILEGES ... GRANT SELECT for operator —\n"
+        "without it, tables Coder creates after the bootstrap are\n"
+        "invisible to the operator's read-only user."
+    )
+    # Negative pin: forbid CREATE / INSERT / UPDATE / DELETE / ALL on
+    # the operator user. Match only inside operator-targeted GRANT
+    # statements.
+    operator_grants = re.findall(
+        r"GRANT\s+(\w+(?:\s*,\s*\w+)*)\s+ON\s+[^;]*?"
+        r'TO\s+"\$PG_OPERATOR_DB_USER"',
+        startup_script,
+    )
+    assert operator_grants, "Found no operator-targeted GRANT statements"
+    for verbs in operator_grants:
+        for forbidden in ("CREATE", "INSERT", "UPDATE", "DELETE", "ALL"):
+            assert forbidden not in verbs.upper(), (
+                f"Operator IAM DB user MUST NOT receive {forbidden} —\n"
+                "this user is for read-only audit; write traffic stays\n"
+                "with coder.service via the SA user."
+            )
+
+
+@pytest.mark.exe
 def test_cloud_sql_proxy_install_pinned(startup_script: str) -> None:
     """CSAP install mirrors the ADR 0007 hardening pattern: pinned
     version + sha256 + sha256sum -c verification before install. The
@@ -1413,12 +1540,16 @@ def test_cloud_sql_security_posture_no_regression() -> None:
     )
 
     # Permitted google_sql_user resources:
-    #   - coder_iam (CLOUD_IAM_SERVICE_ACCOUNT) — runtime
+    #   - coder_iam (CLOUD_IAM_SERVICE_ACCOUNT) — runtime, full schema
+    #     access
+    #   - operator_iam (CLOUD_IAM_USER, var.owner_email) — read-only
+    #     audit via Cloud SQL Studio. SELECT only; no CREATE/INSERT/
+    #     UPDATE/DELETE per the bootstrap GRANTs in coder.tf
     #   - postgres (BUILT_IN, password) — bootstrap-only, grants the
-    #     IAM user CREATE on public schema once at VM start
-    # Anything beyond these two is a regression (no application
+    #     two IAM users their respective privileges once at VM start
+    # Anything beyond these three is a regression (no application
     # password account, no shared "coder" password user).
-    permitted_users = {"coder_iam", "postgres"}
+    permitted_users = {"coder_iam", "operator_iam", "postgres"}
     other_users = set(
         re.findall(
             r'resource\s+"google_sql_user"\s+"([^"]+)"',
@@ -1427,9 +1558,24 @@ def test_cloud_sql_security_posture_no_regression() -> None:
     )
     extra = other_users - permitted_users
     assert not extra, (
-        f"Only the IAM SA user (coder_iam) and the bootstrap-only\n"
-        f"postgres superuser are permitted. Found additional users:\n"
+        f"Only the IAM SA user (coder_iam), the read-only operator IAM\n"
+        f"user (operator_iam), and the bootstrap-only postgres superuser\n"
+        f"are permitted. Found additional users:\n"
         f"  {sorted(extra)!r}"
+    )
+
+    # operator_iam must be CLOUD_IAM_USER (not BUILT_IN, not SA).
+    op_block = re.search(
+        r'resource\s+"google_sql_user"\s+"operator_iam"\s*\{(.*?)^\}',
+        cloudsql_tf,
+        re.DOTALL | re.MULTILINE,
+    )
+    assert op_block is not None
+    assert 'type = "BUILT_IN"' not in op_block.group(1), (
+        "operator_iam must NOT be BUILT_IN (no password user for the operator)."
+    )
+    assert 'type = "CLOUD_IAM_SERVICE_ACCOUNT"' not in op_block.group(1), (
+        "operator_iam must be CLOUD_IAM_USER (individual email), not a SA."
     )
 
     # --- Connection URL must NOT carry a real password --------------

--- a/tofu/exe/cloudsql.tf
+++ b/tofu/exe/cloudsql.tf
@@ -220,6 +220,50 @@ resource "google_project_iam_member" "exe_coder_cloudsql_instance_user" {
   member  = "serviceAccount:${google_service_account.exe_coder.email}"
 }
 
+# ----- Operator IAM DB user (read-only audit via Cloud SQL Studio) ----
+#
+# The exe-coder@ SA above is the runtime identity coder.service uses
+# for read/write traffic. For the operator to inspect the same data
+# (Coder workspace list, audit log, etc.) without impersonating that
+# SA, we provision a second IAM DB user mapped to the operator's
+# personal email (var.owner_email).
+#
+# Auth path:
+#   1. Operator opens Cloud Console -> SQL -> exe-coder-pg ->
+#      Cloud SQL Studio.
+#   2. Studio uses the operator's Console identity to mint a DB
+#      access token via the cloudsql.instanceUser project IAM grant
+#      below.
+#   3. Cloud SQL maps the token to this CLOUD_IAM_USER row and
+#      authenticates the connection.
+#
+# Posture: read-only. The bootstrap GRANT step in coder.tf gives
+# CONNECT + USAGE on schema public + SELECT on existing and future
+# tables — never CREATE / INSERT / UPDATE / DELETE. Write traffic
+# stays exclusive to coder.service via google_sql_user.coder_iam.
+#
+# We deliberately do NOT grant roles/cloudsql.client to the operator
+# at the project level: cloudsql.client is needed only for the
+# proxy/cert TLS path used by CSAP. Cloud SQL Studio handles its own
+# transport, so cloudsql.instanceUser alone is sufficient and the
+# attack surface stays smaller.
+
+resource "google_sql_user" "operator_iam" {
+  name     = var.owner_email
+  instance = google_sql_database_instance.coder.name
+  type     = "CLOUD_IAM_USER"
+
+  # Same race fix as coder_iam: the internal Cloud SQL IAM role is
+  # provisioned asynchronously after the instance reports READY.
+  depends_on = [time_sleep.cloud_sql_iam_role_settle]
+}
+
+resource "google_project_iam_member" "operator_cloudsql_instance_user" {
+  project = var.gcp_project_id
+  role    = "roles/cloudsql.instanceUser"
+  member  = "user:${var.owner_email}"
+}
+
 # ----- locals exposed to coder.tf --------------------------------------
 #
 # Connection name is what CSAP takes as instance argument. Format is
@@ -228,9 +272,10 @@ resource "google_project_iam_member" "exe_coder_cloudsql_instance_user" {
 # duplicating the trimsuffix logic.
 
 locals {
-  cloud_sql_connection_name = google_sql_database_instance.coder.connection_name
-  cloud_sql_iam_db_user     = google_sql_user.coder_iam.name
-  cloud_sql_private_ip      = google_sql_database_instance.coder.private_ip_address
+  cloud_sql_connection_name  = google_sql_database_instance.coder.connection_name
+  cloud_sql_iam_db_user      = google_sql_user.coder_iam.name
+  cloud_sql_operator_db_user = google_sql_user.operator_iam.name
+  cloud_sql_private_ip       = google_sql_database_instance.coder.private_ip_address
   cloud_sql_proxy_url = format(
     "https://storage.googleapis.com/cloud-sql-connectors/cloud-sql-proxy/%s/cloud-sql-proxy.linux.amd64",
     var.cloud_sql_proxy_version,

--- a/tofu/exe/coder.tf
+++ b/tofu/exe/coder.tf
@@ -178,6 +178,7 @@ locals {
     CSAP_URL='${local.cloud_sql_proxy_url}'
     PG_CONNECTION_NAME='${local.cloud_sql_connection_name}'
     PG_IAM_DB_USER='${local.cloud_sql_iam_db_user}'
+    PG_OPERATOR_DB_USER='${local.cloud_sql_operator_db_user}'
     PG_PRIVATE_IP='${local.cloud_sql_private_ip}'
     PG_ADMIN_SECRET='${google_secret_manager_secret.postgres_admin.secret_id}'
 
@@ -482,6 +483,16 @@ locals {
     GRANT USAGE, CREATE ON SCHEMA public TO "$PG_IAM_DB_USER";
     ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON TABLES TO "$PG_IAM_DB_USER";
     ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON SEQUENCES TO "$PG_IAM_DB_USER";
+    -- Operator IAM DB user — read-only audit via Cloud SQL Studio.
+    -- Intentionally narrower than the SA user above: no CREATE on
+    -- schema, no ALL on tables/sequences. Write traffic stays
+    -- exclusive to coder.service via $PG_IAM_DB_USER.
+    GRANT CONNECT ON DATABASE coder TO "$PG_OPERATOR_DB_USER";
+    GRANT USAGE ON SCHEMA public TO "$PG_OPERATOR_DB_USER";
+    GRANT SELECT ON ALL TABLES IN SCHEMA public TO "$PG_OPERATOR_DB_USER";
+    GRANT SELECT ON ALL SEQUENCES IN SCHEMA public TO "$PG_OPERATOR_DB_USER";
+    ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT ON TABLES TO "$PG_OPERATOR_DB_USER";
+    ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT ON SEQUENCES TO "$PG_OPERATOR_DB_USER";
     SQL
     unset PG_ADMIN_PASSWORD
 
@@ -649,6 +660,7 @@ resource "google_compute_instance" "exe_coder" {
     google_project_iam_member.exe_coder_cloudsql_client,
     google_project_iam_member.exe_coder_cloudsql_instance_user,
     google_sql_user.coder_iam,
+    google_sql_user.operator_iam,
     google_sql_database.coder,
     # The privilege-bootstrap path needs the postgres BUILT_IN user
     # password + Secret Manager grant in place before the VM boots


### PR DESCRIPTION
## What

Add a second IAM database user on `exe-coder-pg` mapped to `var.owner_email`, so the operator can inspect Coder's internal tables (workspaces, templates, audit log, ...) via **Cloud SQL Studio** (Console UI) without impersonating the `exe-coder@` service account. Cloud SQL stays **private-IP-only** — Studio handles the transport internally.

## Why

After the Cloud SQL migration (PR #79–#82) the only authenticated path into the database was the VM's `exe-coder@` SA via CSAP. That works for `coder.service` runtime but produces audit-log entries under the SA, not the human operator, and means any debugging session impersonates the runtime principal. This PR opens a **read-only** audit path under the operator's individual IAM identity.

Why Cloud SQL Studio specifically: the instance is `private-IP-only`, so a local `psql` + CSAP from the operator's Mac cannot reach it (the private IP is only routable from inside `exe-vpc`). Studio runs inside Google's network and connects natively, while still authenticating via IAM (no password, audit log records `hironow365@gmail.com`).

## Security posture

| Aspect | Choice | Rationale |
|---|---|---|
| User type | `CLOUD_IAM_USER` | Individual email; not BUILT_IN (no password) and not SA |
| DB privileges | `CONNECT` + `USAGE` on `public` + `SELECT` on tables/sequences (existing + future via `ALTER DEFAULT PRIVILEGES`) | Read-only; tests reject any of `CREATE`/`INSERT`/`UPDATE`/`DELETE`/`ALL` |
| Project IAM | `roles/cloudsql.instanceUser` only | No `roles/cloudsql.client` — Studio doesn't need it; smaller surface |
| `cloudsql.tf` | Same `time_sleep` race fix as `coder_iam` | Asynchronous internal `cloudsqliamuser` role bootstrap |
| `coder.tf` | `depends_on` adds `google_sql_user.operator_iam` | VM bootstrap GRANT cannot fire before user exists |

## Files

- `tofu/exe/cloudsql.tf` — `google_sql_user.operator_iam` + `google_project_iam_member.operator_cloudsql_instance_user` + `local.cloud_sql_operator_db_user`
- `tofu/exe/coder.tf` — `PG_OPERATOR_DB_USER` shell var + 6-line read-only `GRANT` block + `depends_on`
- `tests/exe/test_startup_script.py` — 2 new tests + extension to `test_cloud_sql_security_posture_no_regression` (permitted-user set + type pin)
- `exe/docs/architecture.md` — Cloud SQL data plane table extended
- `exe/docs/runbook.md` — new 'Inspect Coder data via Cloud SQL Studio' section with URL, auth steps, 3 example queries, revocation snippet
- `exe/docs/usage.md` — short pointer to the runbook section

## Verification

- `just exe-test` — **50 passed, 1 skipped** (incl. `test_template_terraform_plan` exercising `tofu validate`)
- `tofu fmt -recursive` clean
- prek pre-commit hooks pass (markdownlint-cli2, ruff, just fmt/lint)

## Apply impact

When this lands, `just exe-apply` will:
1. Create `google_sql_user.operator_iam` (~10s, one Cloud SQL Admin API call)
2. Create the project IAM grant (instant)
3. Trigger VM startup_script re-run (next preempt cycle / manual replace) which re-runs the bootstrap GRANT idempotently, adding the operator's read GRANTs

No schema migration, no downtime, fully reversible (drop the two resources, `tofu apply`).

## Closes

(no specific issue; follow-up requested in conversation after the Cloud SQL migration was stabilised)