### PR TITLE
feat(exe): Cloud SQL production hardening (deletion-protection, structured-logs, health-check, retention)

### DIFF
--- a/tests/exe/test_startup_script.py
+++ b/tests/exe/test_startup_script.py
@@ -1527,8 +1527,13 @@ def test_cloud_sql_security_posture_no_regression() -> None:
     body = inst.group(1)
     retained = re.search(r"retained_backups\s*=\s*(\d+)", body)
     assert retained is not None, "must declare retained_backups"
-    assert int(retained.group(1)) >= 7, (
-        f"backup retention is {retained.group(1)} day(s); minimum is 7 days"
+    # 30 days is the 2026 Cloud SQL production guidance for
+    # compliance-grade safety nets — long enough to detect data
+    # corruption that wasn't immediately obvious (typical
+    # detection window for slow-burning bugs is 1–4 weeks).
+    assert int(retained.group(1)) >= 30, (
+        f"backup retention is {retained.group(1)} day(s); minimum is 30 days\n"
+        "(2026 production best practice for compliance-grade safety net)"
     )
     assert re.search(r'retention_unit\s*=\s*"COUNT"', body), (
         "backup retention_unit must be COUNT (count of backups, not bytes)"

--- a/tests/exe/test_startup_script.py
+++ b/tests/exe/test_startup_script.py
@@ -1357,6 +1357,26 @@ def test_cloud_sql_proxy_systemd_unit_emitted(startup_script: str) -> None:
         "Logging can parse severity/error fields (2026 production\n"
         "best practice)."
     )
+    # 2026 production best practice: enable the HTTP health-check
+    # endpoint so an external watchdog (or coder.service ExecStartPre)
+    # can probe /readiness before treating the proxy as up. Without
+    # this flag the only signal CSAP gives is the systemd unit's
+    # main-PID — a forked-but-stuck proxy looks healthy to systemd.
+    assert "--health-check" in body, (
+        "CSAP MUST run with --health-check so /startup, /readiness,\n"
+        "and /liveness are exposed for watchdogs and ExecStartPre\n"
+        "probes (2026 production best practice)."
+    )
+    # The health-check listener defaults to :9090. The unit must bind
+    # it to localhost so the endpoint is not exposed to the tailnet
+    # or any other interface.
+    assert re.search(r"--http-address[= ]\s*127\.0\.0\.1\b", body) or (
+        "--http-address=127.0.0.1" in body
+    ), (
+        "CSAP --health-check listener MUST bind to 127.0.0.1 so the\n"
+        "endpoints stay loopback-only (the tailnet IP would otherwise\n"
+        "expose /readiness / /liveness to every workspace)."
+    )
 
     # And coder.service must declare Requires + After cloud-sql-proxy.
     coder_unit = re.search(

--- a/tests/exe/test_startup_script.py
+++ b/tests/exe/test_startup_script.py
@@ -1347,6 +1347,16 @@ def test_cloud_sql_proxy_systemd_unit_emitted(startup_script: str) -> None:
         "CSAP MUST run with --private-ip — the instance has no public\n"
         "IP and CSAP defaults to PUBLIC otherwise (fails closed)."
     )
+    # 2026 production best practice: emit JSON-formatted structured
+    # logs so journald + Cloud Logging can parse fields (severity,
+    # timestamp, message, error) instead of free-text. Without this
+    # flag CSAP writes plain text and Cloud Logging cannot key on
+    # severity/error reliably.
+    assert "--structured-logs" in body, (
+        "CSAP MUST run with --structured-logs so journald and Cloud\n"
+        "Logging can parse severity/error fields (2026 production\n"
+        "best practice)."
+    )
 
     # And coder.service must declare Requires + After cloud-sql-proxy.
     coder_unit = re.search(

--- a/tests/exe/test_startup_script.py
+++ b/tests/exe/test_startup_script.py
@@ -1008,6 +1008,17 @@ def test_cloud_sql_resources_present() -> None:
     assert re.search(r"deletion_protection\s*=\s*true", body), (
         "Cloud SQL instance MUST have deletion_protection = true"
     )
+    # Two-layer deletion protection: the resource-level
+    # deletion_protection above guards against `tofu destroy`, while
+    # settings.deletion_protection_enabled guards against the GCP API
+    # itself (gcloud / Console / direct REST). 2026 Cloud SQL best
+    # practice is to enable both — Terraform-only protection is
+    # bypassable from outside Terraform.
+    assert re.search(r"deletion_protection_enabled\s*=\s*true", body), (
+        "Cloud SQL instance MUST set settings.deletion_protection_enabled = true\n"
+        "as a second protection layer at the GCP API level (Console / gcloud\n"
+        "deletion is otherwise unprotected)."
+    )
     assert re.search(r"ipv4_enabled\s*=\s*false", body), (
         "Cloud SQL instance MUST have ipv4_enabled = false (private IP only)"
     )

--- a/tofu/exe/cloudsql.tf
+++ b/tofu/exe/cloudsql.tf
@@ -57,9 +57,24 @@ resource "google_sql_database_instance" "coder" {
 
   # Mandatory: protects against tofu destroy taking the DB with it.
   # Operator must flip this to false explicitly to delete.
+  # This is the *Terraform-resource-level* guard — it only stops
+  # `tofu destroy`. The GCP API itself (Console / gcloud / direct
+  # REST) can still issue a delete. settings.deletion_protection_enabled
+  # below adds the second layer at the GCP API level so a deletion
+  # attempt from outside Terraform also fails.
   deletion_protection = true
 
   settings {
+    # GCP-API-level deletion protection. Two-layer best practice
+    # (2026 Cloud SQL Postgres). To delete the instance, the
+    # operator must:
+    #   1. flip this flag to false and `tofu apply`
+    #   2. flip the resource-level deletion_protection to false and apply
+    #   3. then `tofu destroy` the instance
+    # Each layer is independent, so a misclick / single-line
+    # diff in either field does not unlock destruction.
+    deletion_protection_enabled = true
+
     # ENTERPRISE edition supports the legacy shared-core tiers
     # (db-f1-micro, db-g1-small, db-custom-N-RAMMB). New instances
     # default to ENTERPRISE_PLUS, which only accepts the more

--- a/tofu/exe/cloudsql.tf
+++ b/tofu/exe/cloudsql.tf
@@ -96,7 +96,14 @@ resource "google_sql_database_instance" "coder" {
       start_time                     = "18:00" # 18:00 UTC = 03:00 JST (off-hours)
       point_in_time_recovery_enabled = true
       backup_retention_settings {
-        retained_backups = 7 # 1 week of daily backups
+        # 30 daily backups (2026 Cloud SQL production guidance).
+        # Slow-burning data corruption (silent table truncations,
+        # off-by-one migrations, accidental UPDATEs without WHERE)
+        # is typically detected 1–4 weeks after the fact. 7 days
+        # leaves no margin against that detection window. 30 daily
+        # backups on a 10 GiB instance is still well under $1/month
+        # in storage.
+        retained_backups = 30
         retention_unit   = "COUNT"
       }
     }

--- a/tofu/exe/coder.tf
+++ b/tofu/exe/coder.tf
@@ -410,10 +410,14 @@ locals {
     # (private IP only). Without this flag CSAP tries the public
     # IP path first and fails with `instance does not have IP of
     # type "PUBLIC"`.
+    # --structured-logs: emit JSON lines instead of free text. journald
+    # + Cloud Logging can then key on severity/error/message fields
+    # for alerting rather than substring matching the message body.
     ExecStart=/usr/local/bin/cloud-sql-proxy \
       --address 127.0.0.1 --port 5432 \
       --auto-iam-authn \
       --private-ip \
+      --structured-logs \
       $PG_CONNECTION_NAME
     Restart=on-failure
     RestartSec=5

--- a/tofu/exe/coder.tf
+++ b/tofu/exe/coder.tf
@@ -413,11 +413,19 @@ locals {
     # --structured-logs: emit JSON lines instead of free text. journald
     # + Cloud Logging can then key on severity/error/message fields
     # for alerting rather than substring matching the message body.
+    # --health-check + --http-address=127.0.0.1: expose
+    # /startup, /readiness, /liveness on loopback :9090 so an
+    # external watchdog (or ExecStartPre on coder.service) can probe
+    # actual proxy readiness instead of just the systemd main-PID
+    # state. Loopback-only so the endpoints are not reachable from
+    # the tailnet IP.
     ExecStart=/usr/local/bin/cloud-sql-proxy \
       --address 127.0.0.1 --port 5432 \
       --auto-iam-authn \
       --private-ip \
       --structured-logs \
+      --health-check \
+      --http-address=127.0.0.1 \
       $PG_CONNECTION_NAME
     Restart=on-failure
     RestartSec=5


### PR DESCRIPTION
## What

Apply 2026 GCP Cloud SQL production-readiness recommendations to the
exe.hironow.dev stack, **excluding HA-related changes** (REGIONAL
availability / ENTERPRISE_PLUS / db-perf-optimized tier) which are
deferred for cost reasons. The stack stays on db-f1-micro / ZONAL.

Series of 4 atomic ``feat(exe):`` commits:

| # | Commit | Effect |
|---|---|---|
| 1 | ``0745122`` add GCP-API-level deletion_protection_enabled | Console / gcloud / direct REST DELETE attempts now also fail. Two-layer protection. |
| 2 | ``605d4bb`` add CSAP --structured-logs | journald + Cloud Logging can key on severity/error fields. |
| 3 | ``12f558b`` expose CSAP --health-check on loopback :9090 | /startup, /readiness, /liveness reachable for watchdogs (loopback-only). |
| 4 | ``c8c5db4`` bump backup retention 7 -> 30 days | Compliance-grade safety net for slow-burning corruption. |

## Why

A 2026/05 production-readiness audit against current GCP best
practices found four gaps relative to the current implementation:

1. ``deletion_protection`` only guarded ``tofu destroy`` — not Console
   / gcloud DELETE.
2. CSAP emitted free-text logs, brittle to substring-grep alerting.
3. CSAP exposed no health endpoints; ``Restart=on-failure`` does not
   detect a deadlocked-but-alive proxy.
4. 7-day backup retention left no margin against slow-burning data
   corruption (typical detection window: 1-4 weeks).

HA-related findings (REGIONAL availability / ENTERPRISE_PLUS edition /
db-perf-optimized tiers) are intentionally **not** addressed in this
PR — they are valid recommendations but out of budget for a personal
single-operator stack. ADR 0010 already captures this trade-off.

## How (verification)

- ``tofu fmt -check`` + ``tofu validate`` — pass
- ``pytest tests/exe/ -m exe`` (38 passed, 1 skipped) — full suite
  including Docker-based startup_script execution validation
- All assertions in ``tests/exe/test_startup_script.py`` for Cloud SQL
  posture extended to require the new flags / values, so a regression
  to any of the four hardening points fails the test loudly.

## Out of scope

- Availability mode (ZONAL retained intentionally)
- Cloud SQL edition (ENTERPRISE retained — db-f1-micro requires it)
- PITR retention window (default left as-is; daily backup retention is
  the relevant lever for slow-burning detection windows)
- ADR update — these changes refine the implementation of ADR 0010
  without changing the decision; no superseding ADR needed