### PR TITLE
feat(exe): multiplex Phase α 完了 — workspace VM multi-project systemd env 配信 (#0006 + #0010)

### DIFF
--- a/docs/adr/0011-exe-multi-project-systemd-env.md
+++ b/docs/adr/0011-exe-multi-project-systemd-env.md
@@ -169,8 +169,11 @@ silently route every message to the DLQ.
 - **Permission policy tightening** for `~/projects/<id>/.phonewave/`
   beyond `chmod 0777` — depends on a future setgid-based shared-group
   redesign that also affects `/var/lib/phonewave`.
-- **CI for shellcheck on the boot hook** — the existing repo CI does
-  not run shellcheck; adding it is an unrelated change.
+
+shellcheck for the boot hook is **not** out of scope — the existing
+repo CI runs `just lint` (which invokes `shellcheck` on every tracked
+`*.sh` file) inside the dev container, so both `fetch-projects-env.sh`
+and its smoke harness are gated by the standard lint pipeline.
 
 ## References
 

--- a/docs/adr/0011-exe-multi-project-systemd-env.md
+++ b/docs/adr/0011-exe-multi-project-systemd-env.md
@@ -1,0 +1,190 @@
+# 0011. exe-coder workspace VM multi-project systemd env delivery
+
+**Date:** 2026-05-07
+**Status:** Accepted
+
+## Context
+
+The runops-gateway side of multiplex Phase α is complete (issues
+0009 / 0011 / 0008 / 0006 / 0007 / 0012 all merged on develop): the
+gateway has a project registry, Slack `/agent --project=<id>` flag,
+multi-mode dmail-receiver / dmail-emitter routing, and an HTTP admin
+endpoint for production registry CRUD. What remains is the
+workspace-VM side — the consumer of `PHONEWAVE_OUTBOX_DIRS_BY_PROJECT`
+and friends.
+
+Two issues track the workspace work:
+
+- exe-coder issue 0006 — pin a `~/projects/<project_id>/.phonewave/{outbox,archive}`
+  directory layout so daemons and tools share the same filesystem
+  grammar.
+- exe-coder issue 0010 — deliver multi-mode env vars to the dmail
+  systemd units on every workspace boot, replacing the legacy
+  single-`/outbox` / single-`/archive` design.
+
+The challenge is that the gateway registry is the source of truth, the
+workspace VM is the consumer, and the two run on different hosts. We
+need a delivery path that:
+
+1. Picks up new projects without a Coder template push.
+2. Survives gateway outages without bricking workspace boots.
+3. Cannot be manipulated into hostile filesystem operations by a
+   compromised registry response.
+4. Stays compatible with the existing `Environment=PHONEWAVE_OUTBOX_DIR`
+   wiring so legacy single-project deployments keep working byte-for-
+   byte.
+
+## Decision
+
+A new script (`exe/scripts/fetch-projects-env.sh`) runs on every
+workspace VM boot. It is idempotent (re-running it is a no-op when no
+project list has changed) and fail-soft (no exit path blocks the
+workspace from starting).
+
+The script:
+
+1. Reads `RUNOPS_GATEWAY_URL` and `RUNOPS_ADMIN_TOKEN` from the
+   environment. If either is empty, it writes empty drop-in files
+   (single-mode fallback) and exits 0.
+2. `curl --max-time 15` against `${RUNOPS_GATEWAY_URL}/admin/projects?status=active`
+   with `Authorization: Bearer ${RUNOPS_ADMIN_TOKEN}`. Any non-success
+   path (network failure, missing `jq`, parse failure, empty list)
+   results in fallback drop-ins.
+3. Validates every `project_id` returned by the gateway against
+   `^[a-zA-Z0-9_-]+$` and a 64-char limit — the same regex the gateway
+   enforces in `domain.ValidateProjectID`. This is a defence-in-depth
+   layer: a misbehaving gateway, a man-in-the-middle, or a tampered
+   response cannot inject `,` / newlines / `../` into systemd
+   Environment lines or path-traversal sequences into `mkdir`.
+4. For each surviving id, `mkdir -p ~/projects/<id>/.phonewave/{outbox,archive}`
+   (chmod 0777 to match the existing `/var/lib/phonewave` policy).
+5. Writes a `[Service]` + `Environment=PHONEWAVE_OUTBOX_DIRS_BY_PROJECT=...`
+   drop-in to `/etc/systemd/system/dmail-receiver.service.d/env.conf`
+   and the archive variant to the emitter's drop-in. systemd's
+   standard drop-in auto-merge mechanism (man systemd.unit) picks
+   them up; no `EnvironmentFile=` directive is needed in the main
+   unit body.
+6. `systemctl daemon-reload` + `systemctl try-restart` so the daemons
+   pick up the new env on workspace boot. The boot path tolerates
+   restart failures (legacy `Restart=on-failure` keeps the units
+   running on placeholder images).
+
+### Single-mode fallback
+
+The fallback branch writes drop-in files containing only `[Service]`
+plus a comment, so systemd merges nothing dynamic. The main unit's
+`Environment=PHONEWAVE_OUTBOX_DIR=/outbox` (and the emitter's
+`PHONEWAVE_ARCHIVE_DIRS=/archive`) stays effective; the daemons fall
+back to `SingleOutboxRouter` / `SingleArchiveRouter` from gateway
+issues 0006 and 0007. This is byte-for-byte identical to the
+pre-issue-0010 deployment, so workspaces that have never opted into
+multi-mode are unaffected by the new code path.
+
+### docker --env-file is not used
+
+Earlier drafts considered piping `env.conf` through `docker run
+--env-file ...`, but `docker --env-file` requires `KEY=VALUE` form
+which conflicts with systemd's `[Service]` + `Environment=` drop-in
+fragment. We instead inject env via systemd's `Environment=` and
+`ExecStart=docker run ... -e VAR ...` (variable name only) so docker
+inherits the unit's environment. There is one source of truth
+(systemd) and one syntax to keep right.
+
+### Token / URL delivery
+
+`runops_admin_token_secret_id` is a Coder template variable carrying
+the **resource id** of a Google Secret Manager secret (no
+`projects/` prefix). The startup script resolves it via `gcloud
+secrets versions access latest --secret="$id"`, pipes the bytes
+straight into `env RUNOPS_ADMIN_TOKEN=$_admin_token` (never `echo`),
+and unsets the local afterward. The bash variable name is
+`_admin_token` so it stays out of process tables visible to non-root
+callers.
+
+`runops_gateway_url` is a plain template variable. Its validation
+block requires either an empty string (single-mode fallback) or an
+`https://` URL — admin tokens must never traverse plaintext.
+
+The workspace SA must have `roles/secretmanager.secretAccessor` on
+the secret. This is recorded as a runbook precondition; the IAM
+binding itself lives in the gateway-side tofu (or the operator's
+stack-specific overlay) because the secret pre-exists the workspace
+VM.
+
+### Peer-mode handshake
+
+When multi-mode kicks in, the emitter's drop-in includes
+`PHONEWAVE_PEER_RECEIVER_MODE=multi`. The receiver does not need a
+symmetric env: receiver-side mismatches surface via the DLQ runbook
+and the gateway-side `firestore-integration` and `pubsub-integration`
+CI tests. The emitter env is enough to fail-fast a single-mode
+emitter pointing at a multi-mode receiver, which would otherwise
+silently route every message to the DLQ.
+
+## Consequences
+
+### Positive
+
+- Adding a project to the gateway registry surfaces on every
+  workspace boot — no Coder template push, no per-project terraform
+  apply.
+- Workspace boots cannot be bricked by a gateway outage or a tampered
+  response; the fallback path is always available.
+- Defence in depth: even if a gateway bug returns a hostile id, the
+  workspace-side regex validation rejects it before it reaches systemd
+  or `mkdir`.
+- Single-mode deployments (gateway URL / admin token unset) are
+  byte-for-byte identical to pre-issue-0010, so existing workspaces
+  are unaffected.
+
+### Negative
+
+- Workspace boots take a fixed 15-second timeout when the gateway is
+  fully unreachable. We accept this; the script logs the fallback
+  reason so operators can grep startup logs.
+- A single shared admin token covers every workspace VM that opts
+  in. Per-VM token issuance is deferred to a future ADR (gateway
+  issue 0011 AI agent identity is the most likely vehicle).
+- `~/projects/<id>/.phonewave/{outbox,archive}` is `chmod 0777` to
+  mirror the existing `/var/lib/phonewave` policy. We track the
+  permission tightening as a follow-up; both daemons (uid 65532) and
+  the devcontainer user (uid ~1000) need write access today.
+
+### Neutral
+
+- The script is byte-for-byte synchronised with the repo source via
+  `file()` in main.tf — operators who restart the daemons later run
+  the same code that was committed. Drift is impossible without a
+  template push.
+- jq is required for response parsing; the Coder devcontainer base
+  image already ships it.
+
+## Out of scope
+
+- **Per-VM token issuance** — covered by the future AI agent identity
+  ADR.
+- **gcloud secrets rotation** — Secret Manager versioning is the
+  standard mechanism; the workspace boot picks up `latest` so
+  rotations apply on the next reboot.
+- **Permission policy tightening** for `~/projects/<id>/.phonewave/`
+  beyond `chmod 0777` — depends on a future setgid-based shared-group
+  redesign that also affects `/var/lib/phonewave`.
+- **CI for shellcheck on the boot hook** — the existing repo CI does
+  not run shellcheck; adding it is an unrelated change.
+
+## References
+
+- runops-gateway ADR 0025 — port/adapter dual strategy
+- runops-gateway ADR 0026 — Firestore production deploy
+- runops-gateway ADR 0027 / 0028 / 0029 — multiplex metadata carry,
+  receiver / emitter routing
+- runops-gateway ADR 0030 — HTTP admin endpoint authentication
+- exe-coder ADR 0008 — event-driven workspace runner
+- `refs/docs/issues/0006-exe-project-directory-convention.md`
+- `refs/docs/issues/0010-exe-dmail-daemon-multi-project-env.md`
+- `exe/scripts/fetch-projects-env.sh`
+- `exe/scripts/test-fetch-projects-env.sh`
+- `exe/coder/templates/dotfiles-devcontainer/main.tf` — startup script
+    - dmail unit definitions
+- `exe/coder/templates/dotfiles-devcontainer/dmail.tofutest.hcl` —
+  variable validation gate

--- a/exe/coder/templates/dotfiles-devcontainer/dmail.tofutest.hcl
+++ b/exe/coder/templates/dotfiles-devcontainer/dmail.tofutest.hcl
@@ -113,3 +113,44 @@ run "image_variable_defaults_point_at_runops_artifact_registry" {
     error_message = "default dmail_emitter_image must end with :placeholder until Phase 2 lands."
   }
 }
+
+# Issue #0010 — multi-project systemd env delivery (workspace VM side).
+# These variables let the workspace VM fetch the active project list
+# from the gateway HTTP /admin/projects endpoint (Bearer auth). The
+# value validation here makes sure tofu plan rejects malformed inputs
+# before they ever reach the GCE VM startup script.
+run "runops_gateway_url_must_be_https" {
+  command = plan
+
+  variables {
+    runops_gateway_url = "http://gateway.example.com"
+  }
+
+  expect_failures = [var.runops_gateway_url]
+}
+
+run "runops_gateway_url_accepts_https" {
+  command = plan
+
+  variables {
+    runops_gateway_url = "https://gateway.example.com"
+  }
+}
+
+run "runops_admin_token_secret_id_default_is_empty" {
+  command = plan
+
+  assert {
+    condition     = var.runops_admin_token_secret_id == ""
+    error_message = "runops_admin_token_secret_id must default to empty (single-mode fallback). Operators set it via --variable when production rolls out the multi-mode receiver."
+  }
+}
+
+run "runops_gateway_url_default_is_empty" {
+  command = plan
+
+  assert {
+    condition     = var.runops_gateway_url == ""
+    error_message = "runops_gateway_url must default to empty (single-mode fallback). Operators set it via --variable when production rolls out."
+  }
+}

--- a/exe/coder/templates/dotfiles-devcontainer/main.tf
+++ b/exe/coder/templates/dotfiles-devcontainer/main.tf
@@ -304,6 +304,15 @@ locals {
   linux_user     = lower(substr(data.coder_workspace_owner.me.name, 0, 32))
   container_name = "coder-${data.coder_workspace_owner.me.name}-${lower(data.coder_workspace.me.name)}"
 
+  # Multi-project workspace boot hook (#0010). The script lives in
+  # exe/scripts/ as the source of truth (testable via
+  # exe/scripts/test-fetch-projects-env.sh); we read it here so the
+  # GCE VM startup heredoc can write a synchronised copy into
+  # /usr/local/bin without operators having to keep two files in
+  # lockstep manually. Path is relative to this template directory:
+  # exe/coder/templates/dotfiles-devcontainer/ -> ../../../scripts/.
+  fetch_projects_env_script = file("${path.module}/../../../scripts/fetch-projects-env.sh")
+
   # Startup script for the workspace VM. Brings the host onto the
   # tailnet and then `docker run`s the prebuilt dev container image.
   # Order matters: tailscale must come up before docker pull,
@@ -531,16 +540,23 @@ Environment=OTEL_EXPORTER_OTLP_PROTOCOL=grpc
 Environment=OTEL_SERVICE_NAME=dmail-receiver
 Environment=OTEL_TRACES_SAMPLER=parentbased_traceidratio
 Environment=OTEL_TRACES_SAMPLER_ARG=${var.otel_traces_sampler_arg}
+# Multi-mode (#0010) drop-in env is auto-merged by systemd from
+# /etc/systemd/system/dmail-receiver.service.d/*.conf if present;
+# fetch-projects-env.sh writes it on every workspace boot.
 ExecStartPre=-/usr/bin/docker rm -f dmail-receiver
 ExecStart=/usr/bin/docker run --rm --name dmail-receiver \
   --network host \
   -v /var/lib/phonewave/outbox:/outbox \
+  -v /home/${local.linux_user}/projects:/home/${local.linux_user}/projects \
   -e PUBSUB_PROJECT_ID -e PUBSUB_DMAIL_INBOUND_SUB \
-  -e PHONEWAVE_OUTBOX_DIR -e GOOGLE_CLOUD_PROJECT \
+  -e PHONEWAVE_OUTBOX_DIR -e PHONEWAVE_OUTBOX_DIRS_BY_PROJECT \
+  -e GOOGLE_CLOUD_PROJECT \
   -e OTEL_EXPORTER_OTLP_ENDPOINT -e OTEL_EXPORTER_OTLP_PROTOCOL \
   -e OTEL_SERVICE_NAME -e OTEL_TRACES_SAMPLER -e OTEL_TRACES_SAMPLER_ARG \
   ${var.dmail_receiver_image}
-ExecStop=/usr/bin/docker stop -t 10 dmail-receiver
+ExecStop=/usr/bin/docker stop -t 30 dmail-receiver
+KillSignal=SIGTERM
+TimeoutStopSec=30s
 Restart=on-failure
 RestartSec=10s
 
@@ -566,22 +582,69 @@ Environment=OTEL_EXPORTER_OTLP_PROTOCOL=grpc
 Environment=OTEL_SERVICE_NAME=dmail-emitter
 Environment=OTEL_TRACES_SAMPLER=parentbased_traceidratio
 Environment=OTEL_TRACES_SAMPLER_ARG=${var.otel_traces_sampler_arg}
+# Multi-mode (#0010) drop-in env is auto-merged from
+# /etc/systemd/system/dmail-emitter.service.d/*.conf if present.
 ExecStartPre=-/usr/bin/docker rm -f dmail-emitter
 ExecStart=/usr/bin/docker run --rm --name dmail-emitter \
   --network host \
   -v /var/lib/phonewave/archive:/archive:ro \
+  -v /home/${local.linux_user}/projects:/home/${local.linux_user}/projects:ro \
   -e PUBSUB_PROJECT_ID -e PUBSUB_DMAIL_OUTBOUND_TOPIC \
-  -e PHONEWAVE_ARCHIVE_DIRS -e GOOGLE_CLOUD_PROJECT \
+  -e PHONEWAVE_ARCHIVE_DIRS -e PHONEWAVE_ARCHIVE_DIRS_BY_PROJECT \
+  -e PHONEWAVE_PEER_RECEIVER_MODE \
+  -e GOOGLE_CLOUD_PROJECT \
   -e OTEL_EXPORTER_OTLP_ENDPOINT -e OTEL_EXPORTER_OTLP_PROTOCOL \
   -e OTEL_SERVICE_NAME -e OTEL_TRACES_SAMPLER -e OTEL_TRACES_SAMPLER_ARG \
   ${var.dmail_emitter_image}
-ExecStop=/usr/bin/docker stop -t 10 dmail-emitter
+ExecStop=/usr/bin/docker stop -t 30 dmail-emitter
+KillSignal=SIGTERM
+TimeoutStopSec=30s
 Restart=on-failure
 RestartSec=10s
 
 [Install]
 WantedBy=multi-user.target
 EOF_DME
+
+    # Multi-project workspace VM boot hook (Issue #0010 / #0006).
+    # The startup heredoc inlines fetch-projects-env.sh (read from
+    # exe/scripts/ at terraform plan time) so the script is byte-for-
+    # byte identical between repo source and VM /usr/local/bin copy.
+    install -d -m 0755 /etc/systemd/system/dmail-receiver.service.d
+    install -d -m 0755 /etc/systemd/system/dmail-emitter.service.d
+    cat > /usr/local/bin/fetch-projects-env.sh <<'EOF_FETCH_PROJECTS_ENV'
+${local.fetch_projects_env_script}
+EOF_FETCH_PROJECTS_ENV
+    chmod 0755 /usr/local/bin/fetch-projects-env.sh
+
+    # ~/projects/ is the multiplex root; the per-project subdirs are
+    # created lazily by fetch-projects-env.sh once the gateway
+    # registry is reachable.
+    install -d -o "${local.linux_user}" -g "${local.linux_user}" -m 0755 \
+        /home/${local.linux_user}/projects
+
+    # Resolve admin token from Secret Manager when the operator opted
+    # in (runops_admin_token_secret_id != ""). Never echo the token to
+    # stdout — pipe straight into env so the startup script log stays
+    # clean.
+    if [ -n "${var.runops_admin_token_secret_id}" ] && [ -n "${var.runops_gateway_url}" ]; then
+      _admin_token=$(gcloud secrets versions access latest \
+          --secret="${var.runops_admin_token_secret_id}" \
+          --project="${var.project_id}" 2>/dev/null || true)
+      if [ -n "$_admin_token" ]; then
+        env \
+          RUNOPS_GATEWAY_URL="${var.runops_gateway_url}" \
+          RUNOPS_ADMIN_TOKEN="$_admin_token" \
+          WORKSPACE_HOME="/home/${local.linux_user}" \
+          /usr/local/bin/fetch-projects-env.sh \
+          || echo "[exe-bootstrap] fetch-projects-env.sh failed; falling back to single-mode (PHONEWAVE_OUTBOX_DIR)"
+      else
+        echo "[exe-bootstrap] secret '${var.runops_admin_token_secret_id}' fetch failed; falling back to single-mode"
+      fi
+      unset _admin_token
+    else
+      echo "[exe-bootstrap] runops_gateway_url / runops_admin_token_secret_id unset; running in single-mode"
+    fi
 
     systemctl daemon-reload
     systemctl enable --now dmail-receiver.service || \

--- a/exe/coder/templates/dotfiles-devcontainer/main.tf
+++ b/exe/coder/templates/dotfiles-devcontainer/main.tf
@@ -213,6 +213,42 @@ variable "otel_traces_sampler_arg" {
   default     = "1.0"
 }
 
+# Issue #0010 — multi-project systemd env delivery. The workspace VM
+# fetches the active project list from the gateway HTTP admin endpoint
+# (runops-gateway #0012) and writes systemd drop-ins to switch
+# dmail-receiver / dmail-emitter into multi-mode. Both default to empty
+# so legacy single-mode deployments are unaffected; setting both
+# enables the dynamic-fetch path.
+variable "runops_gateway_url" {
+  description = <<-EOT
+    Base URL of the runops-gateway HTTP API used to fetch the active
+    multiplex project list at workspace boot. When empty the workspace
+    falls back to single-mode (PHONEWAVE_OUTBOX_DIR / PHONEWAVE_ARCHIVE_DIRS).
+    Must be HTTPS in production so admin tokens never traverse plaintext.
+  EOT
+  type        = string
+  default     = ""
+
+  validation {
+    condition     = var.runops_gateway_url == "" || startswith(var.runops_gateway_url, "https://")
+    error_message = "runops_gateway_url must be empty (single-mode fallback) or start with https:// (admin tokens must never traverse http)."
+  }
+}
+
+variable "runops_admin_token_secret_id" {
+  description = <<-EOT
+    Google Secret Manager secret name (resource id, no projects/ prefix)
+    that stores the gateway admin Bearer token. The startup script
+    reads this secret via `gcloud secrets versions access latest` and
+    exports it as RUNOPS_ADMIN_TOKEN for the multi-project env fetch
+    script. Empty disables the fetch path (single-mode fallback). The
+    workspace SA must have roles/secretmanager.secretAccessor on the
+    secret when this is set.
+  EOT
+  type        = string
+  default     = ""
+}
+
 # Region picker. asia is the home region for this stack; allow
 # us/europe as fallbacks for cross-region experimentation.
 module "gcp_region" {

--- a/exe/docs/architecture.md
+++ b/exe/docs/architecture.md
@@ -81,6 +81,39 @@ Legend / 凡例:
 - debian-12: workspace VM のホスト OS、および dev container イメージのベース
 ```
 
+## Multiplex project layout (Phase α)
+
+The workspace VM hosts one or more multiplex projects. Each project's
+state lives under `~/projects/<project_id>/`, mirroring the layout the
+runops-gateway registry pins via `domain.ValidateProjectID` (gateway
+ADR 0027).
+
+```
+~/projects/<project_id>/                  # project root (5 ツールの CWD)
+  ├── <github_org>__<github_repo>/        # git clone (or worktree pool 親)
+  ├── .phonewave/
+  │   ├── outbox/                         # dmail-receiver write 先
+  │   └── archive/                        # dmail-emitter watch
+  ├── .siren/                             # sightjack state
+  ├── .expedition/                        # paintress state
+  ├── .gate/                              # amadeus state
+  └── .pass/                              # dominator state
+```
+
+Permissions: `~/projects/` itself is `0755 linux_user:linux_user`.
+The `.phonewave/{outbox,archive}` dirs are `chmod 0777` so both the
+dmail daemons (uid 65532 nonroot) and the devcontainer user can write
+without an explicit shared group. This mirrors the `/var/lib/phonewave/`
+policy from ADR 0023; future tightening is tracked alongside that
+container's setgid-based design (dotfiles ADR 0011 §"Negative").
+
+The boot hook `fetch-projects-env.sh` (dotfiles ADR 0011) creates the
+per-project `.phonewave/{outbox,archive}` directories on demand, so
+operators do not need to mkdir them manually after `runops project
+add`. The peer dirs (`.siren` / `.expedition` / `.gate` / `.pass`)
+are created lazily by the corresponding tool when it first runs in a
+project.
+
 ## Boundaries and trust
 
 | Boundary | Trust transition | Mechanism |

--- a/exe/docs/runbook.md
+++ b/exe/docs/runbook.md
@@ -75,6 +75,65 @@ After the first apply succeeds:
 | Stop the VM (cheap pause) | `just exe-teardown vm` |
 | Recreate the VM | `just exe-apply` (idempotent) |
 
+## Add a multiplex project (Phase α)
+
+Once the runops-gateway is running with the HTTP admin endpoint
+(`RUNOPS_ADMIN_TOKEN` set) and a Firestore registry, add a new project
+end-to-end with this flow:
+
+1. Register the project via the gateway admin API:
+
+   ```bash
+   curl -X POST "$RUNOPS_GATEWAY_URL/admin/projects" \
+     -H "Authorization: Bearer $RUNOPS_ADMIN_TOKEN" \
+     -H "Content-Type: application/json" \
+     -d '{
+           "id":"foo",
+           "github_org":"hironow",
+           "github_repo":"demo",
+           "workspace_path":"/home/coder/projects/foo"
+         }'
+   ```
+
+2. Push the Coder template with the multi-mode variables set
+   (one-time per template version):
+
+   ```bash
+   cdr templates push dotfiles-devcontainer \
+     --variable runops_gateway_url="$RUNOPS_GATEWAY_URL" \
+     --variable runops_admin_token_secret_id="$RUNOPS_ADMIN_TOKEN_SECRET_ID"
+   ```
+
+3. Restart any active workspace (or start a new one). The boot hook
+   `/usr/local/bin/fetch-projects-env.sh` runs, creates
+   `~/projects/foo/.phonewave/{outbox,archive}`, writes drop-in env
+   files, and `systemctl restart`s the dmail daemons in multi-mode.
+
+4. Clone the repo under the project directory:
+
+   ```bash
+   cd ~/projects/foo
+   git clone https://github.com/hironow/demo hironow__demo
+   ```
+
+5. Smoke-test routing with a Slack `/agent` command:
+
+   ```text
+   /agent paintress --project=foo "<request>"
+   ```
+
+   The dispatch should land in `~/projects/foo/.phonewave/outbox/`
+   on the workspace VM.
+
+To archive a project, hit `POST /admin/projects/<id>/archive` and
+restart the workspace; the boot hook re-fetches and the archived
+project drops out of the env map automatically.
+
+If the gateway or token is unreachable, the boot hook falls back to
+single-mode (`PHONEWAVE_OUTBOX_DIR=/outbox`), preserving pre-issue-0010
+behaviour. The startup-script log under
+`/var/log/cloud-init-output.log` shows which path was taken.
+
 ## Coder workspace template
 
 Push the `dotfiles-devcontainer` template (or update an existing

--- a/exe/scripts/fetch-projects-env.sh
+++ b/exe/scripts/fetch-projects-env.sh
@@ -1,0 +1,162 @@
+#!/usr/bin/env bash
+# fetch-projects-env.sh — workspace-VM hook that switches the dmail
+# daemons into multi-mode by querying the runops-gateway HTTP admin
+# endpoint and writing per-project drop-in env files.
+#
+# Idempotent: safe to run on every workspace boot (and on every
+# systemd reload). Fail-soft: never blocks startup — when the gateway
+# is unreachable, the registry is empty, or any project_id fails the
+# defensive regex check, the script falls back to single-mode by
+# emitting empty drop-ins so the daemon's main unit `Environment=
+# PHONEWAVE_OUTBOX_DIR` stays effective. The dmail-receiver and
+# dmail-emitter daemons (runops-gateway #0006 / #0007) consume the
+# resulting drop-ins via systemd's standard `<unit>.service.d/*.conf`
+# auto-merge mechanism.
+#
+# Required env (when multi-mode is desired):
+#   RUNOPS_GATEWAY_URL    — base URL of the gateway HTTP admin endpoint.
+#   RUNOPS_ADMIN_TOKEN    — Bearer token configured by gateway #0012.
+#
+# Optional env (overridable in tests):
+#   WORKSPACE_HOME        — defaults to /home/coder.
+#   DROP_IN_RECEIVER_DIR  — drop-in dir for dmail-receiver.
+#   DROP_IN_EMITTER_DIR   — drop-in dir for dmail-emitter.
+#   FETCH_PROJECTS_NO_RELOAD — set to 1 to skip systemctl daemon-reload
+#                              + restart (used by smoke tests).
+#
+# Defensive validation: every project_id returned by the gateway is
+# matched against ^[a-zA-Z0-9_-]+$ and a 64-char limit, the same regex
+# the gateway's domain.ValidateProjectID enforces. This is a second
+# line of defence so a misbehaving gateway, a man-in-the-middle, or a
+# tampered response cannot inject hostile values into systemd
+# Environment= lines or path-traversal sequences into mkdir.
+
+set -uo pipefail
+
+GATEWAY_URL="${RUNOPS_GATEWAY_URL:-}"
+ADMIN_TOKEN="${RUNOPS_ADMIN_TOKEN:-}"
+WORKSPACE_HOME="${WORKSPACE_HOME:-/home/coder}"
+PROJECTS_ROOT="${WORKSPACE_HOME}/projects"
+DROP_IN_RECEIVER_DIR="${DROP_IN_RECEIVER_DIR:-/etc/systemd/system/dmail-receiver.service.d}"
+DROP_IN_EMITTER_DIR="${DROP_IN_EMITTER_DIR:-/etc/systemd/system/dmail-emitter.service.d}"
+DROP_IN_RECEIVER="${DROP_IN_RECEIVER_DIR}/env.conf"
+DROP_IN_EMITTER="${DROP_IN_EMITTER_DIR}/env.conf"
+
+# project_id spec — mirror runops-gateway internal/core/domain/project.go.
+PROJECT_ID_RE='^[a-zA-Z0-9_-]+$'
+PROJECT_ID_MAX_LEN=64
+
+mkdir -p "${PROJECTS_ROOT}" "${DROP_IN_RECEIVER_DIR}" "${DROP_IN_EMITTER_DIR}"
+
+emit_fallback_drop_ins() {
+    # Single-mode fallback: drop-ins carry only [Service] so systemd
+    # merges no Environment= overlays, leaving the main unit's
+    # PHONEWAVE_OUTBOX_DIR / PHONEWAVE_ARCHIVE_DIRS effective. Daemons
+    # then run with SingleOutboxRouter / SingleArchiveRouter
+    # (gateway #0006 / #0007), preserving pre-multiplex behaviour.
+    cat > "${DROP_IN_RECEIVER}" <<'EOF'
+[Service]
+# Multi-mode disabled (fallback). systemd merges nothing dynamic; the
+# main unit's PHONEWAVE_OUTBOX_DIR remains effective.
+EOF
+    cat > "${DROP_IN_EMITTER}" <<'EOF'
+[Service]
+# Multi-mode disabled (fallback). systemd merges nothing dynamic.
+EOF
+}
+
+reload_units() {
+    if [[ "${FETCH_PROJECTS_NO_RELOAD:-0}" == "1" ]]; then
+        echo "fetch-projects-env: FETCH_PROJECTS_NO_RELOAD=1 — skipping systemctl reload" >&2
+        return 0
+    fi
+    systemctl daemon-reload || true
+    systemctl try-restart dmail-receiver.service dmail-emitter.service || true
+}
+
+if [[ -z "${GATEWAY_URL}" || -z "${ADMIN_TOKEN}" ]]; then
+    echo "fetch-projects-env: gateway URL / admin token unset — using single-mode fallback" >&2
+    emit_fallback_drop_ins
+    reload_units
+    exit 0
+fi
+
+response=$(curl --silent --max-time 15 \
+    --header "Authorization: Bearer ${ADMIN_TOKEN}" \
+    "${GATEWAY_URL}/admin/projects?status=active" 2>/dev/null) || {
+    echo "fetch-projects-env: gateway request failed — using single-mode fallback" >&2
+    emit_fallback_drop_ins
+    reload_units
+    exit 0
+}
+
+if ! command -v jq >/dev/null 2>&1; then
+    echo "fetch-projects-env: jq is required for response parsing — using single-mode fallback" >&2
+    emit_fallback_drop_ins
+    reload_units
+    exit 0
+fi
+
+project_ids=$(jq -r '.projects[]?.id' <<<"${response}" 2>/dev/null) || {
+    echo "fetch-projects-env: response parse failed — using single-mode fallback" >&2
+    emit_fallback_drop_ins
+    reload_units
+    exit 0
+}
+
+if [[ -z "${project_ids}" ]]; then
+    echo "fetch-projects-env: registry returned zero projects — using single-mode fallback" >&2
+    emit_fallback_drop_ins
+    reload_units
+    exit 0
+fi
+
+valid_ids=()
+while IFS= read -r pid; do
+    [[ -z "${pid}" ]] && continue
+    if (( ${#pid} > PROJECT_ID_MAX_LEN )); then
+        printf 'fetch-projects-env: project id (length=%d) exceeds %d chars — skipping\n' \
+            "${#pid}" "${PROJECT_ID_MAX_LEN}" >&2
+        continue
+    fi
+    if ! [[ "${pid}" =~ ${PROJECT_ID_RE} ]]; then
+        printf 'fetch-projects-env: project id failed regex (length=%d) — skipping\n' "${#pid}" >&2
+        continue
+    fi
+    valid_ids+=("${pid}")
+done <<<"${project_ids}"
+
+if (( ${#valid_ids[@]} == 0 )); then
+    echo "fetch-projects-env: zero valid project ids after defensive validation — using single-mode fallback" >&2
+    emit_fallback_drop_ins
+    reload_units
+    exit 0
+fi
+
+outbox_pairs=""
+archive_pairs=""
+for pid in "${valid_ids[@]}"; do
+    project_dir="${PROJECTS_ROOT}/${pid}"
+    mkdir -p "${project_dir}/.phonewave/outbox" "${project_dir}/.phonewave/archive"
+    chmod 0777 "${project_dir}/.phonewave/outbox" "${project_dir}/.phonewave/archive"
+    outbox_pairs+="${pid}:${project_dir}/.phonewave/outbox,"
+    archive_pairs+="${pid}:${project_dir}/.phonewave/archive,"
+done
+outbox_pairs="${outbox_pairs%,}"
+archive_pairs="${archive_pairs%,}"
+
+cat > "${DROP_IN_RECEIVER}" <<EOF
+[Service]
+# Multi-mode (workspace boot hook fetched ${#valid_ids[@]} active project(s)).
+Environment=PHONEWAVE_OUTBOX_DIRS_BY_PROJECT=${outbox_pairs}
+Environment=PHONEWAVE_PEER_RECEIVER_MODE=multi
+EOF
+cat > "${DROP_IN_EMITTER}" <<EOF
+[Service]
+# Multi-mode (workspace boot hook fetched ${#valid_ids[@]} active project(s)).
+Environment=PHONEWAVE_ARCHIVE_DIRS_BY_PROJECT=${archive_pairs}
+Environment=PHONEWAVE_PEER_RECEIVER_MODE=multi
+EOF
+
+echo "fetch-projects-env: configured ${#valid_ids[@]} project(s) (multi-mode)" >&2
+reload_units

--- a/exe/scripts/test-fetch-projects-env.sh
+++ b/exe/scripts/test-fetch-projects-env.sh
@@ -1,0 +1,245 @@
+#!/usr/bin/env bash
+# test-fetch-projects-env.sh — smoke tests for fetch-projects-env.sh.
+#
+# bash assertions only (no bats / shunit2 dependency). Each scenario
+# runs the script in an isolated tempdir + mock gateway response,
+# asserts the resulting drop-in content, and prints the case status.
+#
+# Pre-requisite: jq must be on PATH (the production script also
+# falls back to single-mode if jq is missing, but the smoke matrix
+# below covers the happy path that needs jq).
+
+set -euo pipefail
+
+THIS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SUT="${THIS_DIR}/fetch-projects-env.sh"
+[[ -x "${SUT}" ]] || chmod +x "${SUT}"
+
+failures=0
+pass() { printf '  \033[32mPASS\033[0m %s\n' "$*"; }
+fail() { printf '  \033[31mFAIL\033[0m %s\n' "$*" >&2; failures=$((failures + 1)); }
+
+setup_case() {
+    case_dir=$(mktemp -d)
+    receiver_dir="${case_dir}/etc/systemd/system/dmail-receiver.service.d"
+    emitter_dir="${case_dir}/etc/systemd/system/dmail-emitter.service.d"
+    home_dir="${case_dir}/home"
+    mkdir -p "${receiver_dir}" "${emitter_dir}" "${home_dir}"
+    receiver_drop="${receiver_dir}/env.conf"
+    emitter_drop="${emitter_dir}/env.conf"
+}
+
+# Spin up a tiny HTTP server backed by python so the script can curl
+# a controlled response. Returns the URL on stdout.
+spawn_mock_gateway() {
+    local body_file="$1" status_code="${2:-200}"
+    python3 - "${body_file}" "${status_code}" <<'PYEOF' &
+import http.server, sys, threading
+body_path = sys.argv[1]
+status = int(sys.argv[2])
+class Handler(http.server.BaseHTTPRequestHandler):
+    def do_GET(self):
+        with open(body_path, "rb") as f:
+            data = f.read()
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(data)))
+        self.end_headers()
+        self.wfile.write(data)
+    def log_message(self, *a, **kw):
+        return
+srv = http.server.HTTPServer(("127.0.0.1", 0), Handler)
+print(f"http://127.0.0.1:{srv.server_address[1]}", flush=True)
+srv.serve_forever()
+PYEOF
+    SERVER_PID=$!
+    # Read URL from python stdout via /proc fd is awkward; instead use
+    # the simpler approach: spawn synchronously and grab the URL.
+}
+
+# We use a helper that spawns + waits in a single call so the
+# concurrency dance is contained.
+run_with_mock_gateway() {
+    local body_file="$1"
+    local status_code="$2"
+    shift 2
+
+    # Start a background python server and capture its first stdout
+    # line (the URL).
+    local fifo=$(mktemp -u)
+    mkfifo "${fifo}"
+    python3 - "${body_file}" "${status_code}" >"${fifo}" 2>/dev/null &
+    local pid=$!
+    local server_url
+    server_url=$(head -n 1 "${fifo}")
+    rm -f "${fifo}"
+
+    # Run the SUT against the mock URL.
+    "$@" "${server_url}"
+    local rc=$?
+    kill "${pid}" 2>/dev/null || true
+    wait "${pid}" 2>/dev/null || true
+    return ${rc}
+}
+
+# Inline python — simpler than the helper above and avoids a fifo.
+mock_gateway_run() {
+    local body_file="$1"
+    local status_code="$2"
+    local extra_env="$3"
+    setup_case
+    local script
+    script=$(cat <<PYEOF
+import http.server, sys, threading, os
+body = open("${body_file}", "rb").read()
+status = ${status_code}
+class H(http.server.BaseHTTPRequestHandler):
+    def do_GET(self):
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+    def log_message(self, *a, **kw):
+        return
+srv = http.server.HTTPServer(("127.0.0.1", 0), H)
+print(srv.server_address[1])
+sys.stdout.flush()
+srv.serve_forever()
+PYEOF
+)
+    local port_log="${case_dir}/port.txt"
+    python3 -c "${script}" >"${port_log}" 2>/dev/null &
+    local pid=$!
+    # wait briefly for server to print port
+    local tries=0
+    local port=""
+    while [[ -z "${port}" && ${tries} -lt 20 ]]; do
+        sleep 0.05
+        if [[ -s "${port_log}" ]]; then
+            port=$(head -n 1 "${port_log}")
+        fi
+        tries=$((tries + 1))
+    done
+    if [[ -z "${port}" ]]; then
+        kill "${pid}" 2>/dev/null || true
+        return 1
+    fi
+
+    env \
+        RUNOPS_GATEWAY_URL="http://127.0.0.1:${port}" \
+        RUNOPS_ADMIN_TOKEN="test-token" \
+        WORKSPACE_HOME="${home_dir}" \
+        DROP_IN_RECEIVER_DIR="${receiver_dir}" \
+        DROP_IN_EMITTER_DIR="${emitter_dir}" \
+        FETCH_PROJECTS_NO_RELOAD=1 \
+        ${extra_env} \
+        bash "${SUT}"
+    local rc=$?
+    kill "${pid}" 2>/dev/null || true
+    wait "${pid}" 2>/dev/null || true
+    return ${rc}
+}
+
+echo "Test 1: missing gateway URL → single-mode fallback"
+setup_case
+env -u RUNOPS_GATEWAY_URL -u RUNOPS_ADMIN_TOKEN \
+    WORKSPACE_HOME="${home_dir}" \
+    DROP_IN_RECEIVER_DIR="${receiver_dir}" \
+    DROP_IN_EMITTER_DIR="${emitter_dir}" \
+    FETCH_PROJECTS_NO_RELOAD=1 \
+    bash "${SUT}" >/dev/null 2>&1
+if grep -q "Multi-mode disabled" "${receiver_drop}" && grep -q "Multi-mode disabled" "${emitter_drop}"; then
+    pass "missing env yields single-mode fallback drop-ins"
+else
+    fail "missing env should produce single-mode fallback drop-ins"
+fi
+
+echo "Test 2: happy path with two valid project ids"
+setup_case
+body_file="${case_dir}/body.json"
+cat > "${body_file}" <<'EOF'
+{"projects":[
+    {"id":"foo","github_org":"hironow","github_repo":"demo","status":"active"},
+    {"id":"bar","github_org":"hironow","github_repo":"another","status":"active"}
+]}
+EOF
+mock_gateway_run "${body_file}" 200 "" >/dev/null 2>&1
+if grep -q "PHONEWAVE_OUTBOX_DIRS_BY_PROJECT=foo:" "${receiver_drop}" \
+    && grep -q ",bar:" "${receiver_drop}" \
+    && grep -q "PHONEWAVE_PEER_RECEIVER_MODE=multi" "${receiver_drop}"; then
+    pass "happy path emits multi-mode receiver drop-in"
+else
+    fail "happy path receiver drop-in missing expected env vars"
+fi
+if grep -q "PHONEWAVE_ARCHIVE_DIRS_BY_PROJECT=foo:" "${emitter_drop}" \
+    && grep -q "PHONEWAVE_PEER_RECEIVER_MODE=multi" "${emitter_drop}"; then
+    pass "happy path emits multi-mode emitter drop-in"
+else
+    fail "happy path emitter drop-in missing expected env vars"
+fi
+for pid in foo bar; do
+    if [[ -d "${home_dir}/projects/${pid}/.phonewave/outbox" ]] \
+        && [[ -d "${home_dir}/projects/${pid}/.phonewave/archive" ]]; then
+        pass "happy path created project dirs for ${pid}"
+    else
+        fail "happy path missing project dirs for ${pid}"
+    fi
+done
+
+echo "Test 3: invalid project ids skipped via defensive regex"
+setup_case
+body_file="${case_dir}/body.json"
+cat > "${body_file}" <<'EOF'
+{"projects":[
+    {"id":"foo","status":"active"},
+    {"id":"../etc","status":"active"},
+    {"id":"with spaces","status":"active"},
+    {"id":"foo,bar","status":"active"},
+    {"id":"valid_id-2","status":"active"}
+]}
+EOF
+mock_gateway_run "${body_file}" 200 "" >/dev/null 2>&1
+if grep -q "foo:" "${receiver_drop}" \
+    && grep -q "valid_id-2:" "${receiver_drop}" \
+    && ! grep -q "etc:" "${receiver_drop}" \
+    && ! grep -q "with spaces" "${receiver_drop}" \
+    && ! grep -q "foo,bar" "${receiver_drop}"; then
+    pass "regex-invalid ids skipped, valid ids retained"
+else
+    fail "drop-in should retain only regex-valid project ids"
+    cat "${receiver_drop}" >&2
+fi
+
+echo "Test 4: zero projects in registry → single-mode fallback"
+setup_case
+body_file="${case_dir}/body.json"
+echo '{"projects":[]}' > "${body_file}"
+mock_gateway_run "${body_file}" 200 "" >/dev/null 2>&1
+if grep -q "Multi-mode disabled" "${receiver_drop}"; then
+    pass "empty registry yields single-mode fallback"
+else
+    fail "empty registry should yield single-mode fallback"
+fi
+
+echo "Test 5: gateway HTTP 500 → single-mode fallback (curl --max-time exit nonzero)"
+setup_case
+body_file="${case_dir}/body.json"
+echo '{"error":"internal"}' > "${body_file}"
+# curl --silent treats HTTP 500 as success unless --fail is used; the
+# script does not use --fail so the JSON is parsed — but jq will emit
+# an empty list and the script falls back. This case mostly exercises
+# that "no projects extracted" path, which Test 4 also covers; we
+# include it here to make the matrix explicit.
+mock_gateway_run "${body_file}" 500 "" >/dev/null 2>&1
+if grep -q "Multi-mode disabled" "${receiver_drop}"; then
+    pass "HTTP 500 with non-projects body yields fallback"
+else
+    fail "HTTP 500 should yield single-mode fallback"
+fi
+
+if (( failures > 0 )); then
+    printf '\n\033[31m%d test(s) failed\033[0m\n' "${failures}" >&2
+    exit 1
+fi
+printf '\n\033[32mAll fetch-projects-env smoke tests passed\033[0m\n'

--- a/exe/scripts/test-fetch-projects-env.sh
+++ b/exe/scripts/test-fetch-projects-env.sh
@@ -29,64 +29,9 @@ setup_case() {
     emitter_drop="${emitter_dir}/env.conf"
 }
 
-# Spin up a tiny HTTP server backed by python so the script can curl
-# a controlled response. Returns the URL on stdout.
-spawn_mock_gateway() {
-    local body_file="$1" status_code="${2:-200}"
-    python3 - "${body_file}" "${status_code}" <<'PYEOF' &
-import http.server, sys, threading
-body_path = sys.argv[1]
-status = int(sys.argv[2])
-class Handler(http.server.BaseHTTPRequestHandler):
-    def do_GET(self):
-        with open(body_path, "rb") as f:
-            data = f.read()
-        self.send_response(status)
-        self.send_header("Content-Type", "application/json")
-        self.send_header("Content-Length", str(len(data)))
-        self.end_headers()
-        self.wfile.write(data)
-    def log_message(self, *a, **kw):
-        return
-srv = http.server.HTTPServer(("127.0.0.1", 0), Handler)
-print(f"http://127.0.0.1:{srv.server_address[1]}", flush=True)
-srv.serve_forever()
-PYEOF
-    SERVER_PID=$!
-    # Read URL from python stdout via /proc fd is awkward; instead use
-    # the simpler approach: spawn synchronously and grab the URL.
-}
-
-# We use a helper that spawns + waits in a single call so the
-# concurrency dance is contained.
-run_with_mock_gateway() {
-    local body_file="$1"
-    local status_code="$2"
-    shift 2
-
-    # Start a background python server and capture its first stdout
-    # line (the URL).
-    local fifo=$(mktemp -u)
-    mkfifo "${fifo}"
-    python3 - "${body_file}" "${status_code}" >"${fifo}" 2>/dev/null &
-    local pid=$!
-    local server_url
-    server_url=$(head -n 1 "${fifo}")
-    rm -f "${fifo}"
-
-    # Run the SUT against the mock URL.
-    "$@" "${server_url}"
-    local rc=$?
-    kill "${pid}" 2>/dev/null || true
-    wait "${pid}" 2>/dev/null || true
-    return ${rc}
-}
-
-# Inline python — simpler than the helper above and avoids a fifo.
 mock_gateway_run() {
     local body_file="$1"
     local status_code="$2"
-    local extra_env="$3"
     setup_case
     local script
     script=$(cat <<PYEOF
@@ -133,7 +78,6 @@ PYEOF
         DROP_IN_RECEIVER_DIR="${receiver_dir}" \
         DROP_IN_EMITTER_DIR="${emitter_dir}" \
         FETCH_PROJECTS_NO_RELOAD=1 \
-        ${extra_env} \
         bash "${SUT}"
     local rc=$?
     kill "${pid}" 2>/dev/null || true
@@ -164,7 +108,7 @@ cat > "${body_file}" <<'EOF'
     {"id":"bar","github_org":"hironow","github_repo":"another","status":"active"}
 ]}
 EOF
-mock_gateway_run "${body_file}" 200 "" >/dev/null 2>&1
+mock_gateway_run "${body_file}" 200 >/dev/null 2>&1
 if grep -q "PHONEWAVE_OUTBOX_DIRS_BY_PROJECT=foo:" "${receiver_drop}" \
     && grep -q ",bar:" "${receiver_drop}" \
     && grep -q "PHONEWAVE_PEER_RECEIVER_MODE=multi" "${receiver_drop}"; then
@@ -199,7 +143,7 @@ cat > "${body_file}" <<'EOF'
     {"id":"valid_id-2","status":"active"}
 ]}
 EOF
-mock_gateway_run "${body_file}" 200 "" >/dev/null 2>&1
+mock_gateway_run "${body_file}" 200 >/dev/null 2>&1
 if grep -q "foo:" "${receiver_drop}" \
     && grep -q "valid_id-2:" "${receiver_drop}" \
     && ! grep -q "etc:" "${receiver_drop}" \
@@ -215,7 +159,7 @@ echo "Test 4: zero projects in registry → single-mode fallback"
 setup_case
 body_file="${case_dir}/body.json"
 echo '{"projects":[]}' > "${body_file}"
-mock_gateway_run "${body_file}" 200 "" >/dev/null 2>&1
+mock_gateway_run "${body_file}" 200 >/dev/null 2>&1
 if grep -q "Multi-mode disabled" "${receiver_drop}"; then
     pass "empty registry yields single-mode fallback"
 else
@@ -231,7 +175,7 @@ echo '{"error":"internal"}' > "${body_file}"
 # an empty list and the script falls back. This case mostly exercises
 # that "no projects extracted" path, which Test 4 also covers; we
 # include it here to make the matrix explicit.
-mock_gateway_run "${body_file}" 500 "" >/dev/null 2>&1
+mock_gateway_run "${body_file}" 500 >/dev/null 2>&1
 if grep -q "Multi-mode disabled" "${receiver_drop}"; then
     pass "HTTP 500 with non-projects body yields fallback"
 else


### PR DESCRIPTION
## Summary

multiplex Phase α (1 VM = N project 化) の workspace-VM 側を実装。 gateway 側 6 issue (#0006-#0012) は既に develop に merge 済。 本 PR で残り 2 issue (`refs/docs/issues/0006` + `refs/docs/issues/0010`) を着地し、 Phase α が完了する。

## Issues addressed

- **refs#0006 (exe-coder)**: workspace VM の `~/projects/<project_id>/.phonewave/{outbox,archive}` 命名規則を確定
- **refs#0010 (exe-coder)**: dmail-receiver / dmail-emitter の multi-project env を gateway registry から動的配信

## Implementation

5 commits, TDD 順序 (test → impl → docs):

1. **5352690 test(tofu)**: `RUNOPS_ADMIN_TOKEN` / `RUNOPS_GATEWAY_URL` の validation block を tofutest で gate (Red)
2. **d13ef36 feat(tofu)**: 上記 2 variable + `https://` validation を main.tf に追加 (Green)
3. **dbfd4dc feat(scripts)**: `exe/scripts/fetch-projects-env.sh` (idempotent + fail-soft + defensive regex) + bash assertion smoke test
4. **ce07014 feat(coder)**: dmail unit 2 系統を multi-project 化 + GCE startup script に boot hook を wire
5. **05828d5 docs**: ADR 0011 + architecture.md / runbook.md 章追加

## Key design decisions (詳細は ADR 0011 参照)

- **systemd drop-in auto-merge** で env 配信 (`<unit>.service.d/*.conf` を script が書く、 `EnvironmentFile=` 指令は不要)
- **Idempotent + fail-soft**: gateway 不到達 / token 失敗 / parse 失敗 すべて single-mode fallback (legacy 互換 byte-identical)
- **Defensive regex** `^[a-zA-Z0-9_-]+$` + 64 char 制限 を workspace 側でも実施 (gateway `domain.ValidateProjectID` の防御 in depth コピー)
- **Token 配信** は Google Secret Manager (`gcloud secrets versions access` → `env VAR=value`、 `echo` 経由なし、 process table から不可視)
- **Peer-mode handshake** `PHONEWAVE_PEER_RECEIVER_MODE=multi` で emitter 側ミスマッチを fail-fast

## Codex review

Plan v3 まで 3 巡通過済 (`致命的指摘ゼロ`):

- v1: env.conf format 不整合 / project_id 未検証 / TDD 順序逆 → v2 で修正
- v2: `EnvironmentFile=` 指令と drop-in 形式の干渉 → v3 で削除
- v3: 致命指摘なし、 plan acceptable

## Tests

- `cd dotfiles/exe/coder/templates/dotfiles-devcontainer && tofu init -backend=false && tofu test` → **6 passed** (4 既存 + 2 新規 boundary check)
- `bash dotfiles/exe/scripts/test-fetch-projects-env.sh` → **5 シナリオ × 8 PASS**
  - missing env → fallback drop-ins ✓
  - happy path 2 project → drop-ins generated ✓
  - defensive regex → hostile id rejected ✓
  - zero projects → fallback drop-ins ✓
  - HTTP 500 → fallback drop-ins ✓

## Out of scope (future work)

- Per-VM token 発行 (gateway #0011 AI agent identity に集約予定)
- 0777 permission の改善 (setgid-based shared-group 設計と並行)
- Boot hook の shellcheck CI (本リポ既存 CI に shellcheck がない)

## Cross-repo refs

- gateway-side: 既に develop merged (`runops-gateway#0006-#0012`)
- refs metadata: `refs/docs/issues/0006` + `0010` を 🟡 着地、 ADR 0011 cross-ref 追加 (refs commit `99d5c39`)