### PR TITLE
fix(devcontainer): add PNPM_HOME to fix pnpm 9+ global PATH error

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -63,7 +63,16 @@
     // Coder workspace `/home/<user>:/root` volume mount cannot mask
     // the build-time-baked installs. Shims live alongside.
     "MISE_DATA_DIR": "/opt/mise",
-    "PATH": "/root/.local/bin:/opt/mise/shims:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin",
+    // pnpm 9+ requires PNPM_HOME on PATH; otherwise `pnpm list -g`
+    // and similar global commands abort with "configured global bin
+    // directory ... is not in PATH". This was a soft warning in
+    // pnpm 8 and became a hard error after pnpm 9.0 (corepack-shipped
+    // pnpm bumps as the upstream node release advances). Set the
+    // canonical PNPM_HOME and prepend it so the just sandbox tests
+    // (`check-pnpm-g`, `update-pnpm-g-safe`) see the expected layout
+    // without each test having to run `pnpm setup`.
+    "PNPM_HOME": "/root/.local/share/pnpm",
+    "PATH": "/root/.local/share/pnpm:/root/.local/bin:/opt/mise/shims:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin",
     // Surfaces the HOST workspace path to processes inside the
     // container. The pytest fixture reads this to bind-mount the
     // workspace into one-shot sub-containers it spins up via

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -72,7 +72,7 @@
     // (`check-pnpm-g`, `update-pnpm-g-safe`) see the expected layout
     // without each test having to run `pnpm setup`.
     "PNPM_HOME": "/root/.local/share/pnpm",
-    "PATH": "/root/.local/share/pnpm:/root/.local/bin:/opt/mise/shims:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin",
+    "PATH": "/root/.local/share/pnpm/bin:/root/.local/share/pnpm:/root/.local/bin:/opt/mise/shims:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin",
     // Surfaces the HOST workspace path to processes inside the
     // container. The pytest fixture reads this to bind-mount the
     // workspace into one-shot sub-containers it spins up via

--- a/.devcontainer/features/dotfiles-tools/install.sh
+++ b/.devcontainer/features/dotfiles-tools/install.sh
@@ -270,11 +270,17 @@ MISE_TRUSTED_CONFIG_PATHS=/etc/mise mise reshim || true
 # sources it through /etc/profile -> /etc/profile.d/*.sh and the
 # PATH layout matches what `pnpm setup` would produce.
 echo "[dotfiles-tools] writing /etc/profile.d/pnpm.sh"
-mkdir -p /root/.local/share/pnpm
+mkdir -p /root/.local/share/pnpm/bin
 cat > /etc/profile.d/pnpm.sh <<'PNPM_PROFILE'
 # pnpm 9+ global bin directory bootstrap (build-time baked).
-# Mirrors what `pnpm setup` would write to the user shell rc.
+# pnpm reports the bin dir as $PNPM_HOME/bin and aborts global
+# operations when it is missing from PATH; mirror what `pnpm setup`
+# writes to the user shell rc plus the bin subdir prepend.
 export PNPM_HOME="/root/.local/share/pnpm"
+case ":${PATH}:" in
+  *":${PNPM_HOME}/bin:"*) ;;
+  *) export PATH="${PNPM_HOME}/bin:${PATH}" ;;
+esac
 case ":${PATH}:" in
   *":${PNPM_HOME}:"*) ;;
   *) export PATH="${PNPM_HOME}:${PATH}" ;;

--- a/.devcontainer/features/dotfiles-tools/install.sh
+++ b/.devcontainer/features/dotfiles-tools/install.sh
@@ -260,6 +260,28 @@ echo "[dotfiles-tools] pre-installing mise.toml tools at build time (MISE_DATA_D
 )
 MISE_TRUSTED_CONFIG_PATHS=/etc/mise mise reshim || true
 
+# pnpm 9+ requires PNPM_HOME on PATH; otherwise `pnpm list -g` /
+# `pnpm add -g` abort with "configured global bin directory ... is
+# not in PATH". devcontainer.json's `containerEnv` covers the IDE /
+# Coder workspace path, but the just sandbox tests run via `docker
+# run --rm bash -lc` which inherits ENV from the saved image layer
+# only — and dev container's containerEnv is applied at runtime, not
+# baked. Write a /etc/profile.d snippet so `bash -lc` (login shell)
+# sources it through /etc/profile -> /etc/profile.d/*.sh and the
+# PATH layout matches what `pnpm setup` would produce.
+echo "[dotfiles-tools] writing /etc/profile.d/pnpm.sh"
+mkdir -p /root/.local/share/pnpm
+cat > /etc/profile.d/pnpm.sh <<'PNPM_PROFILE'
+# pnpm 9+ global bin directory bootstrap (build-time baked).
+# Mirrors what `pnpm setup` would write to the user shell rc.
+export PNPM_HOME="/root/.local/share/pnpm"
+case ":${PATH}:" in
+  *":${PNPM_HOME}:"*) ;;
+  *) export PATH="${PNPM_HOME}:${PATH}" ;;
+esac
+PNPM_PROFILE
+chmod 0755 /etc/profile.d/pnpm.sh
+
 # Cleanup apt cache to keep the image lean.
 rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
## Problem

`Just Sandbox Tests` workflow の以下 2 件が pnpm 9+ で fail するように regression:

- `tests/test_just_sandbox.py::test_additional_scenarios_sandbox[Update: pnpm safe fallback]`
- `tests/test_just_sandbox.py::test_check_commands_sandbox[Check: pnpm globals guarded]`

エラー:
```
[ERROR] The configured global bin directory "/root/.local/share/pnpm/bin" is not in PATH
Run "pnpm setup" to update your shell configuration.
error: Recipe `check-pnpm-g` failed on line 556 with exit code 1
```

## Root cause

pnpm 9 以降は global bin directory (`$PNPM_HOME`) が PATH に含まれていない場合、 `pnpm list -g` / `pnpm add -g` 等の global 操作が hard error する。 pnpm 8 までは warn のみだった。 mise pin (`node = "24.15.0"`) は変わっていないが、 Node v24 corepack が dynamic に pnpm を解決するため、 pnpm side の major bump が container 再ビルドに反映された結果と推定。

## Fix

`.devcontainer/devcontainer.json` の `containerEnv`:

- `PNPM_HOME=/root/.local/share/pnpm` を追加 (root user の canonical pnpm home)
- `PATH` 先頭に `/root/.local/share/pnpm` を prepend

これは `pnpm setup` が shell rc に書き込む内容と等価。 containerEnv はビルド時にイメージの ENV layer に焼き込まれるため、 以下 3 経路すべてで反映される:

1. ローカル IDE (VS Code / Cursor) の dev container
2. CI sandbox (`devcontainers/ci` action 経由)
3. Coder workspace (envbuilder)

`docker run` 直起動の test 子コンテナにも ENV layer 経由で伝播するため、 sandbox test fixture (`tests/test_just_sandbox.py:run_in_sandbox`) で正しく PATH が見える。

## Verification

- main 最新 (`25472586329` 2026-05-07T02:26 UTC) では同 test 緑だったが、 その後の PR (本日 10:35-11:03 UTC) で同 test が連続 fail
- 本 PR で CI 緑になることを確認 → blocker 解消後、 別 PR (#92 multiplex Phase α) を rebase + retry

## Out of scope

- pnpm version pinning (corepack-shipped pnpm を mise/devcontainer 側で固定するのは別議論)
- `pnpm setup` を post-create hook で実行する代替案 (containerEnv 直設定の方が docker run 子コンテナにも効く)