### PR TITLE
chore(exe): bump pi-coding-agent to @earendil-works fork (0.74.0)

### DIFF
--- a/.devcontainer/features/dotfiles-tools/install.sh
+++ b/.devcontainer/features/dotfiles-tools/install.sh
@@ -251,7 +251,7 @@ node = "24.15.0"
 "npm:@google/gemini-cli" = "0.40.1"
 "npm:@anthropic-ai/claude-code" = "2.1.126"
 "npm:@github/copilot" = "1.0.40"
-"npm:@mariozechner/pi-coding-agent" = "0.72.1"
+"npm:@earendil-works/pi-coding-agent" = "0.74.0"
 EOF
 echo "[dotfiles-tools] pre-installing mise.toml tools at build time (MISE_DATA_DIR=/opt/mise, system config /etc/mise/config.toml)"
 (

--- a/mise.toml
+++ b/mise.toml
@@ -32,7 +32,7 @@ node = "24.15.0"
 "npm:@google/gemini-cli" = "0.40.1"
 "npm:@anthropic-ai/claude-code" = "2.1.126"
 "npm:@github/copilot" = "1.0.40"
-"npm:@mariozechner/pi-coding-agent" = "0.72.1"
+"npm:@earendil-works/pi-coding-agent" = "0.74.0"
 
 # `~/.npmrc` may set `min-release-age=7` (7-day quarantine, mirrors
 # uv's `exclude-newer = "7 days"`). That blocks `mise install` of


### PR DESCRIPTION
## Summary

`@mariozechner/pi-coding-agent` が npm registry で deprecated 化したため、 同 author の新パッケージ `@earendil-works/pi-coding-agent` (latest 0.74.0) に切替。

## Deprecation message (npm registry direct query 2026-05-08)

```
please use @earendil-works/pi-coding-agent instead going forward
```

(source: `https://registry.npmjs.org/@mariozechner%2Fpi-coding-agent` の latest version 含む全 version metadata に同 message)

## Compatibility

- 同じ `bin: pi` (CLI 名は変わらず)
- 同じ `piConfig.configDir: .pi` (設定ディレクトリ互換)
- 同じ Node engine 要件 (>= 20.0.0)
- 0.72.1 → 0.74.0 の minor bump、 既存 user セッションへの影響は低い

## Files

- `mise.toml` (host 用 mise pin)
- `.devcontainer/features/dotfiles-tools/install.sh` (devcontainer build 時 `/etc/mise/config.toml` に焼き込み)

## Out of scope

- `@earendil-works` org の signing key / SLSA 検証 (今は npm registry の trust に依拠、 将来 ADR で扱う)