### PR TITLE
chore: bump codex model reference 5.3 → 5.5

### DIFF
--- a/ROOT_AGENTS.md
+++ b/ROOT_AGENTS.md
@@ -975,7 +975,7 @@ def test_api_endpoint(input_data, expected_status, expected_result):
         </mandatory-rule>
 
         <codex-configuration>
-            <recommended-model>gpt-5.3-codex</recommended-model>
+            <recommended-model>gpt-5.5</recommended-model>
             <required-flags>-m {model}, --skip-git-repo-check</required-flags>
             <prompt-discipline>
                 <must-include>瑣末な点へのクソリプはしないで。致命的な点だけ指摘して。</must-include>
@@ -986,12 +986,12 @@ def test_api_endpoint(input_data, expected_status, expected_result):
         <review-commands>
             <initial-review>
                 <description>First review request for a new plan</description>
-                <command><![CDATA[codex exec -m gpt-5.3-codex --skip-git-repo-check "このプランをレビューして。瑣末な点へのクソリプはしないで。致命的な点だけ指摘して: {plan_full_path} (ref: {CLAUDE.md full_path})"]]></command>
+                <command><![CDATA[codex exec -m gpt-5.5 --skip-git-repo-check "このプランをレビューして。瑣末な点へのクソリプはしないで。致命的な点だけ指摘して: {plan_full_path} (ref: {CLAUDE.md full_path})"]]></command>
             </initial-review>
             <updated-review>
                 <description>Review request for an updated plan (requires context retention)</description>
                 <rule>Must use `resume --last` to maintain the context of the previous review</rule>
-                <command><![CDATA[codex exec resume --skip-git-repo-check --last -m gpt-5.3-codex "プランを更新したからレビューして。瑣末な点へのクソリプはしないで。致命的な点だけ指摘して: {plan_full_path} (ref: {CLAUDE.md full_path})"]]></command>
+                <command><![CDATA[codex exec resume --skip-git-repo-check --last -m gpt-5.5 "プランを更新したからレビューして。瑣末な点へのクソリプはしないで。致命的な点だけ指摘して: {plan_full_path} (ref: {CLAUDE.md full_path})"]]></command>
             </updated-review>
         </review-commands>
 

--- a/plugins/paintress/skills/review-gate/SKILL.md
+++ b/plugins/paintress/skills/review-gate/SKILL.md
@@ -56,7 +56,7 @@ Examples:
 
 ```yaml
 # Using codex
-review_cmd: "codex exec -m gpt-5.3-codex --skip-git-repo-check 'Review the diff on the current branch against main.'"
+review_cmd: "codex exec -m gpt-5.5 --skip-git-repo-check 'Review the diff on the current branch against main.'"
 
 # Using a custom linter
 review_cmd: "make lint && make typecheck"


### PR DESCRIPTION
## Summary

dotfiles 内 codex model 指定を `gpt-5.3-codex` → `gpt-5.5` に bump。 hironow 指示 (2026-05-08)。

## Files

- `ROOT_AGENTS.md` (planning-and-review-standards) 4 箇所
- `plugins/paintress/skills/review-gate/SKILL.md` (sample `review_cmd`) 1 箇所

## Related

並行で以下も同 bump 済:
- `/Users/nino/.claude-work-a/CLAUDE.md` (user global)
- `/Users/nino/.claude/CLAUDE.md` (plugin)
- `/Users/nino/tap/CLAUDE.md` (tap project)
- auto memory `feedback_codex_model.md` 保存 (将来セッション継承)