### PR TITLE
feat(actortype): implement ADR 0012 Paths A/B/C/D — workspace-daemon / cdr-job / cdr-exec / claude-code env injection

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -150,12 +150,19 @@ fi
 
 
 # Claude Code
-alias cc='~/.local/bin/claude'
-alias cc-p='CLAUDE_CONFIG_DIR=~/.claude ~/.local/bin/claude'
-alias cc-a='CLAUDE_CONFIG_DIR=~/.claude-work-a ~/.local/bin/claude'
-alias cc-b='CLAUDE_CONFIG_DIR=~/.claude-work-b ~/.local/bin/claude'
-alias cc-c='CLAUDE_CONFIG_DIR=~/.claude-work-c ~/.local/bin/claude'
-alias cc-d='CLAUDE_CONFIG_DIR=~/.claude-work-d ~/.local/bin/claude'
+# Each cc* alias is the runner-specific launcher per dotfiles ADR 0012
+# Path D: prepend RUNOPS_ACTOR_TYPE=ai-agent so any 5-tool CLI invoked
+# from inside Claude Code sees the correct caller classification
+# (gateway ADR 0035 architectural pin). The env is set in alias scope
+# only (= context-specific override), so a parent shell value is never
+# inherited and the runbook-only "local human-operator direct" path
+# stays uncontaminated.
+alias cc='RUNOPS_ACTOR_TYPE=ai-agent ~/.local/bin/claude'
+alias cc-p='RUNOPS_ACTOR_TYPE=ai-agent CLAUDE_CONFIG_DIR=~/.claude ~/.local/bin/claude'
+alias cc-a='RUNOPS_ACTOR_TYPE=ai-agent CLAUDE_CONFIG_DIR=~/.claude-work-a ~/.local/bin/claude'
+alias cc-b='RUNOPS_ACTOR_TYPE=ai-agent CLAUDE_CONFIG_DIR=~/.claude-work-b ~/.local/bin/claude'
+alias cc-c='RUNOPS_ACTOR_TYPE=ai-agent CLAUDE_CONFIG_DIR=~/.claude-work-c ~/.local/bin/claude'
+alias cc-d='RUNOPS_ACTOR_TYPE=ai-agent CLAUDE_CONFIG_DIR=~/.claude-work-d ~/.local/bin/claude'
 
 # eza for ls replacement
 alias ls='eza --icons --git'

--- a/docs/adr/0012-exe-actor-type-env-injection.md
+++ b/docs/adr/0012-exe-actor-type-env-injection.md
@@ -1,0 +1,138 @@
+# 0012. exe-coder workspace VM RUNOPS_ACTOR_TYPE env injection (per caller path)
+
+**Date:** 2026-05-09
+**Status:** Accepted
+
+## Context
+
+The runops-gateway `0011 architectural pin` (= AI agent cannot approve another AI agent's 4-eyes approval) is complete on the gateway side: ADR 0035 (architectural pin), ADR 0036 (Phase 4a effective_requester_actor_type rule), and ADR 0037 (4-axes producer-side classification) are all main-merged.
+
+The producer-side rollout is also complete on the 4 producer tools that emit D-Mails (sightjack / paintress / amadeus / dominator — phonewave is relay-only and out of scope per phonewave ADR 0005). Each producer reads `RUNOPS_ACTOR_TYPE` env via the canonical `internal/platform/actortype/` helper and injects `metadata.requester_actor_type` (+ optional `metadata.initiating_actor_type` when actor=workspace-daemon) into D-Mail frontmatter. Invalid env values (= not one of the 4 canonical values: `human-operator` / `gateway-service` / `ai-agent` / `workspace-daemon`) cause the emit to fail with no filesystem side effect — silent escalation guard per gateway ADR 0037 §Producer-side validation.
+
+What is missing is the **delivery path** for `RUNOPS_ACTOR_TYPE` itself. The producer helpers read the env, but if the env is not set when the producer runs, two failure modes happen:
+
+1. **HIGH severity 4-eyes approval path**: gateway ADR 0036 fails closed at the 4-layer gate. Every HIGH approval stops working until the env is delivered.
+2. **Non-HIGH severity path (dispatch / canary)**: the gateway-side migration window applies a `CallerHumanOperator` fallback, which means **the audit trail records every AI-driven dispatch as `human-operator`**. This is a silent classification failure that survives until the eventual fail-closed flip (gateway ADR 0038 candidate).
+
+The challenge is that the producer tools run in **multiple caller contexts** on the workspace VM, and each context has a different injection layer:
+
+- `dmail-receiver` and `dmail-emitter` daemons run inside Docker containers spawned by host-OS systemd units. systemd `Environment=` lines are merged from the unit + drop-ins, but the `docker run` invocation explicitly allowlists which env vars get propagated into the container. Drop-in alone is insufficient.
+- `cdr-job` is a wrapper script, but the actual command runs inside an ephemeral Coder workspace via the agent startup_script and a separate `docker run` for the devcontainer image. Adding `--env` to the wrapper does not propagate into the eventual `job_command` execution process.
+- `cdr-exec` is a wrapper that calls `coder ssh -- sh -c "$EXEC_COMMAND"`. The wrapper layer can prefix the command directly with `env RUNOPS_ACTOR_TYPE=...`, and that does propagate.
+- AI agent runners launched locally (e.g., `claude-code`) have a fundamentally different concern: a globally-set `RUNOPS_ACTOR_TYPE=human-operator` in `~/.zshenv` would silently misclassify every AI invocation. Context-specific override is required.
+
+Refs `0020-exe-actor-type-env-injection.md` enumerated these mismatches and broke the work into a per-path table. This ADR captures the chosen design contract.
+
+## Decision
+
+`RUNOPS_ACTOR_TYPE` is injected per caller path with **path-specific layer** discipline, not a single global wrapper. There are 4 in-scope paths and 2 explicitly out-of-scope paths.
+
+### Path A — `dmail-receiver` / `dmail-emitter` daemons (workspace-daemon)
+
+Two-layer injection in `exe/coder/templates/dotfiles-devcontainer/main.tf`:
+
+1. systemd unit body adds `Environment=RUNOPS_ACTOR_TYPE=workspace-daemon` next to the existing `Environment=` lines (the dmail-receiver section currently ends at the OTEL block; the same pattern is mirrored in dmail-emitter).
+2. The `docker run -e RUNOPS_ACTOR_TYPE` allowlist entry is appended to the `ExecStart=docker run ...` command for both units. This is the layer codex specifically flagged: drop-in / `Environment=` alone does not reach the container because the dotfiles unit declares each propagated env var explicitly via `-e VAR` (value-less form so docker inherits the unit env).
+
+Rationale for hardcoding the value at the systemd layer (not via `fetch-projects-env.sh` drop-in): the env is **constant per workspace VM** (= every dmail daemon on the VM is, by definition, a `workspace-daemon`). It does not vary per project. ADR 0011's drop-in path is reserved for project-scoped multi-mode env (`PHONEWAVE_OUTBOX_DIRS_BY_PROJECT` and friends).
+
+Initiating-actor carry (`RUNOPS_INITIATING_ACTOR_TYPE`) is **not** set at this layer because the daemons currently relay D-Mails (phonewave ADR 0005 invariant) rather than emitting their own. If a future feature has the daemons emit alerts (= phonewave ADR 0005 §2 deferred path), initiating-actor will be added at the same two layers.
+
+### Path B — `cdr-job` (AI agent dispatch via ephemeral workspace)
+
+`dotfiles-job/main.tf` does **not** have a systemd unit body. The runtime layers in the job template are (a) the VM startup script that runs `docker run` to launch the devcontainer image, and (b) the in-container `coder_agent.job.startup_script` that runs `${data.coder_parameter.job_command.value}` after the agent is up. Injection happens at both layers in `exe/coder/templates/dotfiles-job/main.tf`, not in the `cdr-job` wrapper script:
+
+1. The VM startup script `docker run` invocation adds `--env RUNOPS_ACTOR_TYPE=ai-agent` (value form, not value-less `-e RUNOPS_ACTOR_TYPE`). Value-less form would require the VM-side shell to have `RUNOPS_ACTOR_TYPE` exported beforehand, which the cdr-job VM does not.
+2. The agent `startup_script` (in-container) adds `export RUNOPS_ACTOR_TYPE=ai-agent` before invoking `${data.coder_parameter.job_command.value}`. Even though the docker run already injected the env into the container, restating it in the agent startup_script makes the contract self-evident and survives any future restructuring that splits the agent into a separate container.
+
+Two layers are needed because the boundary between docker run env propagation and the agent's startup_script execution context is not always identical (e.g., when the agent runs as a separate process group or under a sub-shell that scrubs env). Belt-and-suspenders: both layers carry the value verbatim.
+
+`RUNOPS_INITIATING_ACTOR_TYPE` is not set by default. If a human operator wants to be recorded as the initiator, they pass an explicit `--initiating-actor=human-operator` (or equivalent) flag through `cdr-job`'s parameter chain in a follow-up enhancement. Out of scope for this ADR.
+
+### Path C — `cdr-exec` (long-lived workspace, human operator)
+
+Injection in `exe/scripts/cdr-exec`:
+
+1. The `coder ssh "$WS_NAME" -- sh -c "$EXEC_COMMAND"` invocation is rewritten to prefix the command with `env RUNOPS_ACTOR_TYPE=human-operator` **always**, regardless of any pre-existing `RUNOPS_ACTOR_TYPE` in the operator's parent shell. `cdr-exec` is by contract a human-operator dispatch path; honoring an inherited `ai-agent` value (e.g., from a runner the operator forgot to exit) would silently misclassify the action.
+
+The override is hardcoded at the wrapper level. If a future feature needs `cdr-exec` to forward an alternate caller-type, that requires an explicit flag + canonical value validation (= 4-canonical-value gate inside `cdr-exec` before forwarding), and is out of scope for this ADR.
+
+This path completes inside the wrapper because `cdr-exec`'s contract is "execute one command in an existing workspace and stream output back." There is no template / startup_script layer below it that would otherwise lose the env.
+
+### Path D — Local AI agent runners (e.g., `claude-code`)
+
+`claude-code` and similar AI runners must override `RUNOPS_ACTOR_TYPE=ai-agent` at runner-launch time, regardless of the host shell's value. The override happens in the runner-specific launcher (likely a shell function or wrapper script in dotfiles, scope to be confirmed), not in `~/.zshenv`.
+
+Explicit non-decision: **a global `~/.zshenv` / `.envrc` default of `RUNOPS_ACTOR_TYPE=human-operator` is rejected.** A global default that is "usually right" but silently mis-classifies AI invocations whenever the runner forgets to override it would create the exact audit-laundering risk that gateway ADR 0035 was written to prevent. Documentation in the runbook will instead instruct operators to export `RUNOPS_ACTOR_TYPE=human-operator` explicitly when running the 5 tools directly from the local Mac.
+
+### Path E — phonewave courier daemon (out of scope)
+
+phonewave is relay-only (= phonewave ADR 0005). The 4 producer tools have already injected actor-type metadata into the D-Mail at emit time; phonewave's job is to preserve those bytes during relay, not to inject anything new. No env is needed at this layer today. The deferred case in phonewave ADR 0005 §2 (= daemon-generated emit) re-opens this.
+
+### Path F — gateway-service internal emit (out of scope)
+
+Gateway-internal D-Mail emit paths attest `actor_type=gateway-service` from inside the gateway process, not via env. This ADR does not touch them.
+
+### Migration semantics
+
+- Existing env vars on every path are not modified or unset by this ADR. Only `RUNOPS_ACTOR_TYPE` (and, in Path B's eventual extension, `RUNOPS_INITIATING_ACTOR_TYPE`) are added.
+- `RUNOPS_ACTOR_TYPE` is always set explicitly per context. Inheriting whatever the parent shell happened to have is forbidden because actor classification is a security control: silent inheritance produces silent misclassification.
+- No ADR for `~/.zshenv` defaults is created. The runbook covers the local-direct case as a documented operator action, not as a system default.
+- Until all 4 in-scope paths are deployed, the gateway non-HIGH path's migration-window fallback continues to apply. The eventual fail-closed flip is tracked separately as the gateway ADR 0038 candidate referenced in refs `0018`.
+
+## Enforcement inventory
+
+This ADR pins a system-level invariant (= the actor classification cannot be silently misclassified during boot or dispatch). Per the .claude/CLAUDE.md ADR template requirement:
+
+### Entry points
+
+- `exe/coder/templates/dotfiles-devcontainer/main.tf` — dmail-receiver + dmail-emitter unit bodies + `docker run` allowlists (Path A)
+- `exe/coder/templates/dotfiles-job/main.tf` — devcontainer startup_script + `docker run` allowlist (Path B)
+- `exe/scripts/cdr-exec` — `coder ssh` command prefix (Path C)
+- `exe/scripts/<claude-code-launcher>` — runner-specific override (Path D, location TBD per scope follow-up)
+
+### Persistent / carried data needed at each enforcement point
+
+- `RUNOPS_ACTOR_TYPE` ∈ {`human-operator`, `gateway-service`, `ai-agent`, `workspace-daemon`} (4 canonical values, exact match)
+- `RUNOPS_INITIATING_ACTOR_TYPE` (optional, only when actor=workspace-daemon and a human operator initiated the action) — Path B follow-up only
+
+### Bypass candidates
+
+- systemd drop-in alone (ADR 0011 path) without `docker run -e` — Path A first-failure mode, mitigated by two-layer test
+- `coder create --env` on `cdr-job` wrapper — does not propagate to job_command process, mitigated by template-side injection in Path B
+- inheriting `RUNOPS_ACTOR_TYPE` from parent shell — mitigated by explicit per-context set, never via default
+- a forgotten `~/.zshenv` default of `human-operator` masking AI invocations — mitigated by deliberate non-decision (Path D)
+- env value typo (e.g., `ai_agent` instead of `ai-agent`) — already mitigated by producer-side `ErrInvalidActorType` in actortype helper (gateway ADR 0037 §Producer-side validation), but operators should treat producer emit-fail as a hard signal, not retry without a fix
+
+### Tests proving coverage
+
+| Test | Layer | Verifies |
+|---|---|---|
+| `printenv RUNOPS_ACTOR_TYPE` inside dmail-receiver container | Path A integration | container process sees `workspace-daemon` (drop-in + docker run -e both present) |
+| `printenv RUNOPS_ACTOR_TYPE` inside dmail-emitter container | Path A integration | container process sees `workspace-daemon` |
+| `cdr-job <name> -- printenv RUNOPS_ACTOR_TYPE` | Path B end-to-end | job_command process sees `ai-agent` (template startup_script + docker run -e both present) |
+| `cdr-exec <ws> -- printenv RUNOPS_ACTOR_TYPE` | Path C wrapper | command prefix produces `human-operator` |
+| Path D launcher integration test (TBD) | Path D | claude-code child process always sees `ai-agent` regardless of parent shell value |
+
+Implementation lands in follow-up PRs (one per path is permissible). This ADR is the design contract; mapping ADR Acceptance to a single rollout PR is intentionally not required — codex review of each follow-up PR will check this ADR's enforcement inventory as the spec.
+
+## Consequences
+
+### Positive
+
+- Each caller path has a verified end-to-end env path, not a partially-wired drop-in.
+- Audit-laundering via global `human-operator` default is structurally prevented.
+- Producer-side actor-type emit (refs `0018` rollout: sj #205 / pt #207 / am #208 / pw #143 main merged + dom #21 OPEN) becomes operationally complete as soon as the systemd + template layers ship.
+- Aligns with ADR 0011's "no `--env-file`, env via `Environment=` + `-e VAR`" pattern.
+
+### Negative
+
+- Touch points span 3 different files (dotfiles-devcontainer/main.tf, dotfiles-job/main.tf, exe/scripts/cdr-exec) plus a future Path D launcher. There is no single place to grep for the env contract; this ADR is the contract.
+- A typo in `Environment=` value (e.g., `workspace_daemon` instead of `workspace-daemon`) silently disables the daemon's emit until producer emit-fail telemetry surfaces it. Mitigation: producer-side `ErrInvalidActorType` will fail loudly during the first emit.
+- Path D scope (claude-code launcher) is not yet finalized in this ADR. The follow-up may require a separate ADR if the launcher lives in a different repo.
+
+### Neutral
+
+- The dotfiles `~/.zshenv` is intentionally left unchanged; operators running 5 tools directly from the local Mac must `export RUNOPS_ACTOR_TYPE=human-operator` themselves (or wrap the invocation with `env`). This is documented in the runbook, not enforced via shell init.
+- Eventual gateway ADR 0038 (= non-HIGH path fail-closed flip) is gated on this ADR's full rollout + observed `requester_actor_type=empty` telemetry hitting zero. The flip itself is gateway-side and not part of this ADR.
+- The ADR follows existing dotfiles ADR cadence (Proposed → Accepted via codex review). Implementation PRs reference this ADR by number.

--- a/exe/coder/templates/dotfiles-devcontainer/main.tf
+++ b/exe/coder/templates/dotfiles-devcontainer/main.tf
@@ -540,6 +540,11 @@ Environment=OTEL_EXPORTER_OTLP_PROTOCOL=grpc
 Environment=OTEL_SERVICE_NAME=dmail-receiver
 Environment=OTEL_TRACES_SAMPLER=parentbased_traceidratio
 Environment=OTEL_TRACES_SAMPLER_ARG=${var.otel_traces_sampler_arg}
+# Actor type (ADR 0012 Path A): producer-side requester_actor_type
+# injection per gateway ADR 0035-0037. Both Environment= and the
+# `docker run -e RUNOPS_ACTOR_TYPE` allowlist below are required;
+# drop-in alone does not reach the container.
+Environment=RUNOPS_ACTOR_TYPE=workspace-daemon
 # Multi-mode (#0010) drop-in env is auto-merged by systemd from
 # /etc/systemd/system/dmail-receiver.service.d/*.conf if present;
 # fetch-projects-env.sh writes it on every workspace boot.
@@ -553,6 +558,7 @@ ExecStart=/usr/bin/docker run --rm --name dmail-receiver \
   -e GOOGLE_CLOUD_PROJECT \
   -e OTEL_EXPORTER_OTLP_ENDPOINT -e OTEL_EXPORTER_OTLP_PROTOCOL \
   -e OTEL_SERVICE_NAME -e OTEL_TRACES_SAMPLER -e OTEL_TRACES_SAMPLER_ARG \
+  -e RUNOPS_ACTOR_TYPE \
   ${var.dmail_receiver_image}
 ExecStop=/usr/bin/docker stop -t 30 dmail-receiver
 KillSignal=SIGTERM
@@ -582,6 +588,11 @@ Environment=OTEL_EXPORTER_OTLP_PROTOCOL=grpc
 Environment=OTEL_SERVICE_NAME=dmail-emitter
 Environment=OTEL_TRACES_SAMPLER=parentbased_traceidratio
 Environment=OTEL_TRACES_SAMPLER_ARG=${var.otel_traces_sampler_arg}
+# Actor type (ADR 0012 Path A): producer-side requester_actor_type
+# injection per gateway ADR 0035-0037. Both Environment= and the
+# `docker run -e RUNOPS_ACTOR_TYPE` allowlist below are required;
+# drop-in alone does not reach the container.
+Environment=RUNOPS_ACTOR_TYPE=workspace-daemon
 # Multi-mode (#0010) drop-in env is auto-merged from
 # /etc/systemd/system/dmail-emitter.service.d/*.conf if present.
 ExecStartPre=-/usr/bin/docker rm -f dmail-emitter
@@ -595,6 +606,7 @@ ExecStart=/usr/bin/docker run --rm --name dmail-emitter \
   -e GOOGLE_CLOUD_PROJECT \
   -e OTEL_EXPORTER_OTLP_ENDPOINT -e OTEL_EXPORTER_OTLP_PROTOCOL \
   -e OTEL_SERVICE_NAME -e OTEL_TRACES_SAMPLER -e OTEL_TRACES_SAMPLER_ARG \
+  -e RUNOPS_ACTOR_TYPE \
   ${var.dmail_emitter_image}
 ExecStop=/usr/bin/docker stop -t 30 dmail-emitter
 KillSignal=SIGTERM

--- a/exe/coder/templates/dotfiles-job/main.tf
+++ b/exe/coder/templates/dotfiles-job/main.tf
@@ -216,6 +216,7 @@ locals {
       --volume "/var/run/docker.sock:/var/run/docker.sock" \
       --env "CODER_AGENT_TOKEN=${try(coder_agent.job[0].token, "")}" \
       --env "CODER_AGENT_URL=${var.coder_internal_url}" \
+      --env "RUNOPS_ACTOR_TYPE=ai-agent" \
       '${var.image}' \
       sh -c 'echo ${base64encode(try(coder_agent.job[0].init_script, ""))} | base64 -d | sh'
   META
@@ -271,6 +272,10 @@ resource "coder_agent" "job" {
   startup_script = <<-EOT
     set -eu
     export MISE_DATA_DIR=/opt/mise
+    # Actor type (ADR 0012 Path B): cdr-job is the AI agent dispatch
+    # path. Belt-and-suspenders with the docker run --env on the VM
+    # startup script so any sub-shell scrub does not lose the value.
+    export RUNOPS_ACTOR_TYPE=ai-agent
     cd /root
     echo "[dotfiles-job] starting at $(date -u +%Y-%m-%dT%H:%M:%SZ)"
     echo "[dotfiles-job] command: ${data.coder_parameter.job_command.value}"

--- a/exe/scripts/cdr-exec
+++ b/exe/scripts/cdr-exec
@@ -109,4 +109,10 @@ while true; do
 done
 
 log "command: $EXEC_COMMAND"
-exec cdr ssh "$WS_NAME" -- sh -c "$EXEC_COMMAND"
+# Actor type (ADR 0012 Path C): cdr-exec is, by contract, the human
+# operator dispatch path. Always override RUNOPS_ACTOR_TYPE=human-operator
+# regardless of any inherited value (e.g., from a runner the operator
+# forgot to exit) — silent inheritance from the parent shell would
+# misclassify the action against the gateway-side ADR 0035 architectural
+# pin.
+exec cdr ssh "$WS_NAME" -- sh -c "export RUNOPS_ACTOR_TYPE=human-operator; $EXEC_COMMAND"


### PR DESCRIPTION
## Summary

Implement ADR 0012 Paths A / B / C / D — the workspace-VM, cdr-job, cdr-exec, and Claude Code runner injection layers for `RUNOPS_ACTOR_TYPE`. **All 4 paths complete in this PR.**

This PR is **stacked on PR #96** (ADR 0012). After PR #96 merges to main, this PR rebases trivially (the ADR commit lands on main; this PR's 4 implementation commits remain).

## What this PR ships

| Path | File | Change |
|---|---|---|
| **A** | `exe/coder/templates/dotfiles-devcontainer/main.tf` | dmail-receiver + dmail-emitter unit body adds `Environment=RUNOPS_ACTOR_TYPE=workspace-daemon`; `docker run` allowlist appends `-e RUNOPS_ACTOR_TYPE` |
| **B** | `exe/coder/templates/dotfiles-job/main.tf` | VM startup script `docker run` adds `--env "RUNOPS_ACTOR_TYPE=ai-agent"` (value form); agent startup_script adds `export RUNOPS_ACTOR_TYPE=ai-agent` before invoking `job_command` |
| **C** | `exe/scripts/cdr-exec` | wrapper rewrites `cdr ssh -- sh -c "$EXEC_COMMAND"` to `cdr ssh -- sh -c "export RUNOPS_ACTOR_TYPE=human-operator; $EXEC_COMMAND"` (always override, regardless of inherited value) |
| **D** | `.zshrc` (cc* aliases) | each `cc*` alias gains `RUNOPS_ACTOR_TYPE=ai-agent` prefix — alias-scope override means context-specific (only when launching Claude Code via these aliases), never bleeds into parent shell |

## Why each Path uses its specific layer

- **Path A**: the dmail unit invokes `docker run -e VAR` in value-less form (= "propagate this env name from the unit to the container"). Without `Environment=RUNOPS_ACTOR_TYPE=workspace-daemon` on the unit body, the value-less `-e` resolves to empty and the container does not see the value. Both layers required.
- **Path B**: `dotfiles-job/main.tf` has no systemd unit body. Runtime is VM startup_script + in-container agent startup_script. Both layers carry the value verbatim — belt-and-suspenders against future restructuring.
- **Path C**: cdr-exec is by contract a human-operator dispatch path. Honoring an inherited `RUNOPS_ACTOR_TYPE=ai-agent` from a runner the operator forgot to exit would silently misclassify the action against gateway ADR 0035. Always override.
- **Path D**: Claude Code internally invokes the 5 producer tools while running. The `cc*` aliases are the canonical operator launchers (cc, cc-p, cc-a..cc-d), so injecting `RUNOPS_ACTOR_TYPE=ai-agent` at the alias level resolves the ADR 0012 §Path D "scope to be confirmed" open question without a separate launcher script. Alias-scope is context-specific by construction.

## Migration semantics (= ADR 0012 contract)

- Existing env vars on each path are not modified by this PR. Only `RUNOPS_ACTOR_TYPE` is added.
- `RUNOPS_ACTOR_TYPE` is always set explicitly per context. Inheritance from parent shell is forbidden because actor classification is a security control (silent inheritance = silent misclassification).
- No `~/.zshenv` / `.envrc` global default is introduced. Operators running 5 tools directly from local Mac (or running `claude` outside the `cc*` aliases) take the runbook-documented path and export `RUNOPS_ACTOR_TYPE=human-operator` themselves.

## Verification

- `bash -n exe/scripts/cdr-exec` syntax OK
- `mise x -- shellcheck exe/scripts/cdr-exec` clean
- `tofu fmt -check -diff` clean for both `dotfiles-devcontainer/main.tf` and `dotfiles-job/main.tf`
- `zsh -n .zshrc` syntax OK
- prek hooks all pass on each commit (markdownlint, gitleaks, etc.)

End-to-end runtime verification (= integration tests inside an actual VM / container) requires a real Coder workspace deployment and is beyond local lint scope. Operator-facing smoke tests after merge:

```bash
# Path A: inside dmail-receiver container after workspace boot
docker exec dmail-receiver printenv RUNOPS_ACTOR_TYPE
# expected: workspace-daemon

# Path B: from cdr-job
cdr-job smoke-actortype -- 'printenv RUNOPS_ACTOR_TYPE'
# expected: ai-agent

# Path C: from cdr-exec
cdr-exec runner -- 'printenv RUNOPS_ACTOR_TYPE'
# expected: human-operator (regardless of operator's parent shell)

# Path D: launching Claude Code via cc* alias and checking child env
cc -- 'printenv RUNOPS_ACTOR_TYPE'   # or via Claude Code's terminal subagent
# expected: ai-agent
```

## Commit structure (Tidy First, one Conventional Commit type per commit)

- `6e96111` `feat(dmail-systemd): inject RUNOPS_ACTOR_TYPE into dmail daemon containers` — Path A
- `7f345cc` `feat(cdr-job): inject RUNOPS_ACTOR_TYPE in template VM startup + agent startup_script` — Path B
- `36c8d2a` `feat(cdr-exec): always override RUNOPS_ACTOR_TYPE=human-operator in wrapper` — Path C
- `74453a4` `feat(claude-code): prepend RUNOPS_ACTOR_TYPE=ai-agent in cc* aliases` — Path D

Each commit is independently revertable per path.

## Out of scope (= follow-up)

- **Path A initiating-actor carry**: future feature for `RUNOPS_INITIATING_ACTOR_TYPE` when daemons emit alerts (phonewave ADR 0005 §2 deferred path). Not needed today.
- **Path B initiating-actor carry**: explicit flag to record initiating human via `cdr-job --initiating-actor=human-operator`. Out of scope.
- **gateway ADR 0038 candidate**: non-HIGH path fail-closed flip after this rollout + observed `requester_actor_type=empty` telemetry hits zero.

## Related

- **Stacked on**: dotfiles PR #96 (ADR 0012 — design contract, codex v1→v2 卒業)
- refs/docs/issues/0020-exe-actor-type-env-injection.md (= 詳細 SoT、 path 別実装層)
- refs/docs/issues/0018-multi-actor-type-rollout-completion.md (= 親 tracker、 0011 fix-up)
- sightjack docs/adr/0017 (= producer-side spec)
- runops-gateway docs/adr/0035 / 0036 / 0037 (= architectural pin / Phase 4a / 4 axes)
- dotfiles docs/adr/0011 (= multi-project systemd env、 本 PR が拡張する対象)
