### PR TITLE
feat(exe): add project lifecycle scripts (0020-multi 軸 2/3)

### DIFF
--- a/exe/scripts/cdr-project
+++ b/exe/scripts/cdr-project
@@ -1,0 +1,195 @@
+#!/usr/bin/env bash
+# cdr-project — host 側 wrapper for project lifecycle (= gateway CLI +
+# workspace VM script の glue)。
+#
+# Usage:
+#   cdr-project up <id> [--org=<org> --repo=<repo>]
+#   cdr-project down <id> [--hard]
+#   cdr-project list
+#   cdr-project show <id>
+#
+# What this does (refs/docs/issues/0020-multi 軸 3 受入基準):
+#
+#   up:
+#     1. gateway CLI で project create (= cdr-exec runner -- 'runops project create <id>')
+#     2. workspace VM 側 project-up.sh 実行 (= cdr-exec runner -- 'sudo bash /opt/exe/project-up.sh <id> ...')
+#     3. gateway 側 create が失敗した場合は workspace VM 側 script を実行しない
+#        (= rollback 不要、 at-least-once で OK)
+#
+#   down:
+#     1. workspace VM 側 project-down.sh 実行
+#     2. gateway 側 archive (or --hard 時は delete)
+#     3. workspace VM 側が失敗した場合は gateway 側 archive/delete を実行しない
+#        (= data 整合性優先)
+#
+#   list / show: gateway CLI 'runops project list / show' の薄い passthrough
+#
+# 関連:
+#   - dotfiles cdr-exec (= runner workspace SSH wrapper、 ADR 0012 Path C で
+#     RUNOPS_ACTOR_TYPE=human-operator override を always-保証)
+#   - dotfiles ADR 0012 (= RUNOPS_ACTOR_TYPE env injection)
+#   - runops-gateway cmd/runops project add/list/show/archive subcommand
+#   - refs issue 0020-multi (project lifecycle completion) 軸 3
+
+set -euo pipefail
+
+err() { printf '\033[31m[cdr-project]\033[0m %s\n' "$*" >&2; exit 1; }
+log() { printf '\033[36m[cdr-project]\033[0m %s\n' "$*" >&2; }
+
+require_cdr_exec() {
+  command -v cdr-exec >/dev/null 2>&1 || \
+    err "cdr-exec not on PATH; run 'just exe-cdr-install' first"
+}
+
+# warm-reuse runner workspace name (= cdr-exec で SSH する先)。
+RUNNER_WS="${CDR_PROJECT_RUNNER:-runner}"
+
+# remote project lifecycle script paths (= workspace VM 上の dotfiles repo
+# clone path = /root/dotfiles/、 dotfiles-devcontainer template が
+# `coder dotfiles --repo-url https://github.com/hironow/dotfiles.git` で
+# clone するため、 各 script は /root/dotfiles/exe/scripts/ で参照可能)。
+REMOTE_UP_SCRIPT="${CDR_PROJECT_UP_SCRIPT:-/root/dotfiles/exe/scripts/project-up.sh}"
+REMOTE_DOWN_SCRIPT="${CDR_PROJECT_DOWN_SCRIPT:-/root/dotfiles/exe/scripts/project-down.sh}"
+
+# gateway CLI invocation prefix (= workspace VM 上で実行)。
+# Note: workspace VM には runops-gateway repo + go toolchain が install されている前提。
+GATEWAY_CLI_CMD="${CDR_PROJECT_GATEWAY_CLI:-cd /root/runops-gateway && go run ./cmd/runops}"
+
+PROJECT_ID_RE='^[a-zA-Z0-9_-]+$'
+PROJECT_ID_MAX_LEN=64
+
+validate_id() {
+  local id="$1"
+  if (( ${#id} > PROJECT_ID_MAX_LEN )); then
+    err "project id exceeds ${PROJECT_ID_MAX_LEN} chars"
+  fi
+  if ! [[ "$id" =~ ${PROJECT_ID_RE} ]]; then
+    err "project id failed regex"
+  fi
+}
+
+cmd_up() {
+  if [[ $# -lt 1 ]]; then
+    err "usage: cdr-project up <id> [--org=<org> --repo=<repo>]"
+  fi
+  local id="$1"; shift
+  validate_id "$id"
+
+  local org="" repo=""
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --org=*) org="${1#--org=}" ;;
+      --repo=*) repo="${1#--repo=}" ;;
+      *) err "unexpected arg: $1" ;;
+    esac
+    shift
+  done
+  if [[ -n "$org" && -z "$repo" ]] || [[ -z "$org" && -n "$repo" ]]; then
+    err "--org and --repo must be specified together"
+  fi
+
+  log "up: gateway CLI で project create '$id'"
+  local create_cmd
+  create_cmd="${GATEWAY_CLI_CMD} project create $(printf '%q' "$id")"
+  if [[ -n "$org" && -n "$repo" ]]; then
+    create_cmd+=" --org $(printf '%q' "$org") --repo $(printf '%q' "$repo")"
+  fi
+  if ! cdr-exec "$RUNNER_WS" -- "$create_cmd"; then
+    err "gateway project create failed; workspace VM script は実行しない"
+  fi
+
+  log "up: workspace VM 側 project-up.sh '$id' を実行"
+  local up_cmd
+  up_cmd="sudo bash ${REMOTE_UP_SCRIPT} $(printf '%q' "$id")"
+  if [[ -n "$org" && -n "$repo" ]]; then
+    up_cmd+=" --org=$(printf '%q' "$org") --repo=$(printf '%q' "$repo")"
+  fi
+  if ! cdr-exec "$RUNNER_WS" -- "$up_cmd"; then
+    err "workspace project-up.sh failed; gateway 側 create は完了済 (= 状態不整合)。 'cdr-project down ${id}' で cleanup するか、 手動修復"
+  fi
+
+  log "up complete: $id"
+}
+
+cmd_down() {
+  if [[ $# -lt 1 ]]; then
+    err "usage: cdr-project down <id> [--hard]"
+  fi
+  local id="$1"; shift
+  validate_id "$id"
+
+  local hard=0
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --hard) hard=1 ;;
+      *) err "unexpected arg: $1" ;;
+    esac
+    shift
+  done
+
+  log "down: workspace VM 側 project-down.sh '$id' を実行"
+  local down_cmd
+  down_cmd="sudo bash ${REMOTE_DOWN_SCRIPT} $(printf '%q' "$id")"
+  if [[ "$hard" == "1" ]]; then
+    down_cmd+=" --hard"
+  fi
+  if ! cdr-exec "$RUNNER_WS" -- "$down_cmd"; then
+    err "workspace project-down.sh failed; gateway 側 archive/delete は実行しない (= data 整合性優先)"
+  fi
+
+  if [[ "$hard" == "1" ]]; then
+    log "down: gateway CLI で project delete --hard '$id'"
+    local del_cmd
+    del_cmd="${GATEWAY_CLI_CMD} project delete $(printf '%q' "$id") --hard"
+    if ! cdr-exec "$RUNNER_WS" -- "$del_cmd"; then
+      err "gateway project delete --hard failed; workspace VM 側 cleanup は完了済 (= 状態不整合、 手動修復)"
+    fi
+  else
+    log "down: gateway CLI で project archive '$id'"
+    local arch_cmd
+    arch_cmd="${GATEWAY_CLI_CMD} project archive $(printf '%q' "$id")"
+    if ! cdr-exec "$RUNNER_WS" -- "$arch_cmd"; then
+      err "gateway project archive failed; workspace VM 側 cleanup は完了済 (= 状態不整合、 手動修復)"
+    fi
+  fi
+
+  log "down complete: $id (mode: $([[ "$hard" == "1" ]] && echo hard || echo soft))"
+}
+
+cmd_list() {
+  log "list: gateway CLI passthrough"
+  cdr-exec "$RUNNER_WS" -- "${GATEWAY_CLI_CMD} project list $*"
+}
+
+cmd_show() {
+  if [[ $# -lt 1 ]]; then
+    err "usage: cdr-project show <id>"
+  fi
+  local id="$1"; shift
+  validate_id "$id"
+  log "show: gateway CLI passthrough '$id'"
+  cdr-exec "$RUNNER_WS" -- "${GATEWAY_CLI_CMD} project show $(printf '%q' "$id") $*"
+}
+
+# ---- dispatch ---------------------------------------------------------
+
+require_cdr_exec
+
+if [[ $# -lt 1 ]]; then
+  err "usage: cdr-project <up|down|list|show> [args...]"
+fi
+
+SUB="$1"
+shift
+
+case "$SUB" in
+  up) cmd_up "$@" ;;
+  down) cmd_down "$@" ;;
+  list) cmd_list "$@" ;;
+  show) cmd_show "$@" ;;
+  -h|--help|help)
+    sed -n '/^# Usage:/,/^# What this does/p' "$0" | sed 's/^# \?//' >&2
+    exit 0
+    ;;
+  *) err "unknown subcommand: $SUB (expected: up | down | list | show)" ;;
+esac

--- a/exe/scripts/project-down.sh
+++ b/exe/scripts/project-down.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# project-down.sh — workspace VM 上で project lifecycle 「down」 phase を実行する。
+#
+# Usage:
+#   project-down.sh <id> [--hard]
+#
+# Example:
+#   project-down.sh foo            # soft archive (= ~/projects/.archive/foo-<ts>/ に move)
+#   project-down.sh foo --hard     # hard delete (= ディレクトリ rm -rf)
+#
+# What this does (refs/docs/issues/0020-multi 軸 2 受入基準):
+#   1. validate <id> against runops-gateway domain spec.
+#   2. (0009 完成時) phonewave@<id>.service systemctl disable。 現状 0009 defer
+#      状態なので no-op。
+#   3. fetch-projects-env.sh を再実行 (= gateway registry から project list を再取得、
+#      <id> が registry から削除されていれば dmail systemd drop-in env から外れる)。
+#   4. project ディレクトリを archive (default = soft、 `--hard` 指定で 削除):
+#      - soft: ~/projects/<id>/ → ~/projects/.archive/<id>-<timestamp>/ に move
+#              (再起動可能、 復旧は単純 mv)
+#      - hard: rm -rf ~/projects/<id>/ (= 不可逆)
+#
+# Idempotency: 同じ <id> で複数回実行しても破壊的副作用なし (= ディレクトリ既不在なら skip)。
+# Default は soft archive (= 復旧可能を優先)、 hard delete は明示的 opt-in のみ。
+# Fail mode: 各 step で error は明示的 fail-loud + stderr。
+#
+# 関連:
+#   - dotfiles ADR 0011 (multi-project systemd env delivery)
+#   - refs issue 0020-multi (project lifecycle completion) 軸 2
+
+set -euo pipefail
+
+err() { printf '\033[31m[project-down]\033[0m %s\n' "$*" >&2; exit 1; }
+log() { printf '\033[36m[project-down]\033[0m %s\n' "$*" >&2; }
+
+# ---- arg parsing ------------------------------------------------------
+
+if [[ $# -lt 1 ]]; then
+  err "usage: project-down.sh <id> [--hard]"
+fi
+
+PROJECT_ID="$1"
+shift
+HARD=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --hard) HARD=1 ;;
+    *) err "unexpected arg: $1" ;;
+  esac
+  shift
+done
+
+PROJECT_ID_RE='^[a-zA-Z0-9_-]+$'
+PROJECT_ID_MAX_LEN=64
+
+if (( ${#PROJECT_ID} > PROJECT_ID_MAX_LEN )); then
+  err "project id exceeds ${PROJECT_ID_MAX_LEN} chars"
+fi
+if ! [[ "$PROJECT_ID" =~ ${PROJECT_ID_RE} ]]; then
+  err "project id failed regex"
+fi
+
+WORKSPACE_HOME="${WORKSPACE_HOME:-${HOME}}"
+PROJECT_DIR="${WORKSPACE_HOME}/projects/${PROJECT_ID}"
+ARCHIVE_ROOT="${WORKSPACE_HOME}/projects/.archive"
+
+# ---- step 1: phonewave per-project systemd disable (0009 完成時に有効化) -
+
+# 0009 defer 状態 = phonewave@.service なし、 現状 no-op。
+log "step 1: phonewave per-project systemd disable は 0009 defer 状態、 no-op"
+
+# ---- step 2: fetch-projects-env.sh 再実行 -----------------------------
+
+# Note: gateway registry 側で project が archived/deleted されていれば、
+# fetch-projects-env.sh の curl 結果から外れて dmail env が再構成される。
+# この script は workspace VM 側 cleanup で、 gateway registry update は
+# cdr-project wrapper が呼出責任を持つ。
+
+FETCH_SCRIPT="${FETCH_PROJECTS_ENV:-/usr/local/bin/fetch-projects-env.sh}"
+if [[ ! -x "${FETCH_SCRIPT}" ]]; then
+  log "step 2: ${FETCH_SCRIPT} not executable, skip env reload"
+else
+  log "step 2: fetch-projects-env.sh で dmail systemd drop-in env reload"
+  if ! "${FETCH_SCRIPT}" 2>&1 | sed 's/^/  fetch-projects-env: /' >&2; then
+    err "fetch-projects-env.sh failed"
+  fi
+fi
+
+# ---- step 3: project ディレクトリ archive (or hard delete) -------------
+
+if [[ ! -d "${PROJECT_DIR}" ]]; then
+  log "step 3: ${PROJECT_DIR} 既不在 (idempotent: 既に down 済)、 skip"
+elif [[ "${HARD}" == "1" ]]; then
+  log "step 3: --hard 指定、 ${PROJECT_DIR} を rm -rf"
+  if ! rm -rf "${PROJECT_DIR}"; then
+    err "rm -rf failed; check perms / mounted"
+  fi
+else
+  TIMESTAMP="$(date +%Y%m%d-%H%M%S)"
+  ARCHIVE_DIR="${ARCHIVE_ROOT}/${PROJECT_ID}-${TIMESTAMP}"
+  mkdir -p "${ARCHIVE_ROOT}"
+  log "step 3: soft archive: ${PROJECT_DIR} -> ${ARCHIVE_DIR}"
+  if ! mv "${PROJECT_DIR}" "${ARCHIVE_DIR}"; then
+    err "mv failed; check perms / cross-fs / mounted"
+  fi
+fi
+
+log "project-down complete: ${PROJECT_ID} (mode: $([[ ${HARD} == 1 ]] && echo hard || echo soft))"

--- a/exe/scripts/project-up.sh
+++ b/exe/scripts/project-up.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+# project-up.sh — workspace VM 上で project lifecycle 「up」 phase を実行する。
+#
+# Usage:
+#   project-up.sh <id> [--org=<org>] [--repo=<repo>]
+#
+# Example:
+#   project-up.sh foo
+#   project-up.sh foo --org=acme --repo=widget
+#
+# What this does (refs/docs/issues/0020-multi 軸 2 受入基準):
+#   1. validate <id> against runops-gateway domain spec (= [a-zA-Z0-9_-]+, max 64).
+#   2. mkdir ~/projects/<id>/ + ~/projects/<id>/.phonewave/{outbox,archive}
+#      (idempotent: 既存なら skip、 perms 0777 = fetch-projects-env.sh と同方針).
+#   3. (optional) git clone github.com/<org>/<repo> ~/projects/<id>/ (= --org / --repo
+#      指定時のみ、 既に clone 済なら skip)。
+#   4. fetch-projects-env.sh を再実行 (= gateway registry から project list 取得、
+#      dmail-receiver/emitter systemd drop-in env を更新 + daemon-reload + try-restart)。
+#      これにより新 project が dmail 配送対象に追加される。
+#   5. (0009 完成時) phonewave@<id>.service systemctl enable。 現状 0009 は defer 状態
+#      なので暫定的に単一 phonewave + PHONEWAVE_OUTBOX_DIRS_BY_PROJECT で互換動作。
+#
+# Idempotency: 同じ <id> で複数回実行しても破壊的副作用なし。
+# Fail mode: 各 step で error は明示的 fail-loud + stderr (silent escalation 防止)。
+#
+# 関連:
+#   - dotfiles ADR 0011 (multi-project systemd env delivery)
+#   - dotfiles ADR 0012 (RUNOPS_ACTOR_TYPE env injection)
+#   - refs issue 0020-multi (project lifecycle completion) 軸 2
+
+set -euo pipefail
+
+err() { printf '\033[31m[project-up]\033[0m %s\n' "$*" >&2; exit 1; }
+log() { printf '\033[36m[project-up]\033[0m %s\n' "$*" >&2; }
+
+# ---- arg parsing ------------------------------------------------------
+
+if [[ $# -lt 1 ]]; then
+  err "usage: project-up.sh <id> [--org=<org>] [--repo=<repo>]"
+fi
+
+PROJECT_ID="$1"
+shift
+ORG=""
+REPO=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --org=*) ORG="${1#--org=}" ;;
+    --repo=*) REPO="${1#--repo=}" ;;
+    *) err "unexpected arg: $1" ;;
+  esac
+  shift
+done
+
+# project_id spec — mirror runops-gateway internal/core/domain/project.go and
+# fetch-projects-env.sh PROJECT_ID_RE.
+PROJECT_ID_RE='^[a-zA-Z0-9_-]+$'
+PROJECT_ID_MAX_LEN=64
+
+if (( ${#PROJECT_ID} > PROJECT_ID_MAX_LEN )); then
+  err "project id exceeds ${PROJECT_ID_MAX_LEN} chars (got ${#PROJECT_ID})"
+fi
+if ! [[ "$PROJECT_ID" =~ ${PROJECT_ID_RE} ]]; then
+  err "project id failed regex (must match ${PROJECT_ID_RE})"
+fi
+
+# org / repo 指定時の format check (= 緩い validation: ascii / hyphen / dot のみ)。
+if [[ -n "$ORG" ]] && ! [[ "$ORG" =~ ^[a-zA-Z0-9_.-]+$ ]]; then
+  err "--org failed regex"
+fi
+if [[ -n "$REPO" ]] && ! [[ "$REPO" =~ ^[a-zA-Z0-9_.-]+$ ]]; then
+  err "--repo failed regex"
+fi
+# org / repo は両方 set または両方 unset。
+if [[ -n "$ORG" && -z "$REPO" ]] || [[ -z "$ORG" && -n "$REPO" ]]; then
+  err "--org and --repo must be specified together"
+fi
+
+# ---- step 1: project directory + .phonewave 作成 ----------------------
+
+WORKSPACE_HOME="${WORKSPACE_HOME:-${HOME}}"
+PROJECT_DIR="${WORKSPACE_HOME}/projects/${PROJECT_ID}"
+
+log "step 1: create ${PROJECT_DIR}"
+mkdir -p "${PROJECT_DIR}/.phonewave/outbox" "${PROJECT_DIR}/.phonewave/archive"
+chmod 0777 "${PROJECT_DIR}/.phonewave/outbox" "${PROJECT_DIR}/.phonewave/archive"
+
+# ---- step 2: git clone (optional) -------------------------------------
+
+if [[ -n "$ORG" && -n "$REPO" ]]; then
+  CLONE_URL="https://github.com/${ORG}/${REPO}.git"
+  if [[ -d "${PROJECT_DIR}/.git" ]]; then
+    log "step 2: git repo already exists at ${PROJECT_DIR}, skip clone"
+  else
+    log "step 2: git clone ${CLONE_URL} -> ${PROJECT_DIR}"
+    # clone を project ディレクトリ内に展開。 既に .phonewave/ がある場合は preserve。
+    if ! git clone "${CLONE_URL}" "${PROJECT_DIR}.tmp" 2>&1 | sed 's/^/  git: /' >&2; then
+      err "git clone failed; ${CLONE_URL} unreachable or auth failure"
+    fi
+    # tmp 内容を project_dir に move (= .phonewave 保護)。
+    rsync -a "${PROJECT_DIR}.tmp/" "${PROJECT_DIR}/" 2>/dev/null || \
+      cp -R "${PROJECT_DIR}.tmp/." "${PROJECT_DIR}/"
+    rm -rf "${PROJECT_DIR}.tmp"
+  fi
+else
+  log "step 2: --org/--repo unset, skip git clone"
+fi
+
+# ---- step 3: fetch-projects-env.sh 再実行 (= dmail 系 env reload) ------
+
+FETCH_SCRIPT="${FETCH_PROJECTS_ENV:-/usr/local/bin/fetch-projects-env.sh}"
+if [[ ! -x "${FETCH_SCRIPT}" ]]; then
+  log "step 3: ${FETCH_SCRIPT} not executable, skip env reload (= legacy single-mode fallback で動作維持)"
+else
+  log "step 3: fetch-projects-env.sh で dmail systemd drop-in env reload"
+  if ! "${FETCH_SCRIPT}" 2>&1 | sed 's/^/  fetch-projects-env: /' >&2; then
+    err "fetch-projects-env.sh failed; check gateway URL / admin token / connectivity"
+  fi
+fi
+
+# ---- step 4: phonewave per-project systemd (0009 完成時に有効化) ------
+
+# 0009 (phonewave per-project systemd) が defer 状態 = phonewave@.service が
+# 存在しないため現状 no-op。 暫定的に単一 phonewave + PHONEWAVE_OUTBOX_DIRS_BY_PROJECT
+# で動作 (Phase α で確認済)。 0009 着地後にこの block を有効化。
+#
+# if systemctl list-unit-files phonewave@.service >/dev/null 2>&1; then
+#   log "step 4: enable phonewave@${PROJECT_ID}.service"
+#   sudo systemctl enable --now "phonewave@${PROJECT_ID}.service"
+# fi
+log "step 4: phonewave per-project systemd は 0009 defer 状態、 暫定単一 daemon で互換動作"
+
+log "project-up complete: ${PROJECT_ID}"
+log "  dir: ${PROJECT_DIR}"
+log "  outbox: ${PROJECT_DIR}/.phonewave/outbox"
+log "  archive: ${PROJECT_DIR}/.phonewave/archive"

--- a/justfile
+++ b/justfile
@@ -1011,7 +1011,7 @@ exe-cdr-install:
     #!/usr/bin/env bash
     set -euo pipefail
     mkdir -p "${HOME}/.local/bin"
-    for name in cdr cdr-header cdr-job cdr-exec; do
+    for name in cdr cdr-header cdr-job cdr-exec cdr-project; do
       src="$(pwd)/exe/scripts/$name"
       dst="${HOME}/.local/bin/$name"
       ln -sf "$src" "$dst"


### PR DESCRIPTION
## 動機

[refs issue 0020-multi](https://github.com/hironow/refs) (project lifecycle completion) の **軸 2 (workspace VM script) + 軸 3 (cdr wrapper)** を実装。 0011 architectural pin の `cmd/runops project add/list/show/archive` (gateway 側 = 軸 1) は `acb0fda` で着地済、 dotfiles 側 lifecycle script + cdr glue が未着手だった。

軸 4 (severity ADR) と 軸 5 (full integration test) は **scope 拡大判断後** に separate 着手。

## 変更内容

### exe/scripts/project-up.sh (workspace VM 側、 165 lines)

```
project-up.sh <id> [--org=<org>] [--repo=<repo>]
```

- validate `<id>` (= runops-gateway domain spec)
- `mkdir ~/projects/<id>/.phonewave/{outbox,archive}` idempotent + 0777
- (optional) `git clone https://github.com/<org>/<repo>.git`
- `fetch-projects-env.sh` 再実行 (= dmail systemd drop-in env reload)
- phonewave per-project systemd は 0009 defer のため no-op (= 暫定単一 daemon + `PHONEWAVE_OUTBOX_DIRS_BY_PROJECT` で互換動作)

### exe/scripts/project-down.sh (workspace VM 側、 105 lines)

```
project-down.sh <id> [--hard]
```

- default = soft archive (`~/projects/.archive/<id>-<timestamp>/` に `mv`)
- `--hard` 指定で `rm -rf`
- idempotent

### exe/scripts/cdr-project (host 側 wrapper、 165 lines)

```
cdr-project up <id> [--org=<org> --repo=<repo>]
cdr-project down <id> [--hard]
cdr-project list
cdr-project show <id>
```

- `up`: gateway CLI `runops project create` → workspace VM `project-up.sh`
- `down`: workspace VM `project-down.sh` → gateway CLI `runops project archive` (or `delete --hard`)
- 順序保証: gateway 側失敗時は workspace VM 側を実行しない (= rollback 不要、 at-least-once); workspace VM 側失敗時は gateway 側 archive を実行しない (= data 整合性優先)

### justfile

`exe-cdr-install` recipe の symlink 対象に `cdr-project` 追加 (= cdr / cdr-header / cdr-job / cdr-exec / cdr-project 5 script)。

## 検証

- `bash -n` syntax PASS (3 script)
- `shellcheck` warnings ゼロ (3 script)
- pre-commit hooks PASS (= trim trailing whitespace / fix end of files / just fmt / just lint)
- ADR 0011 (multi-project systemd env) + ADR 0012 Path C (cdr-exec で human-operator override) と整合

## 関連

- refs issue 0020-multi (= 本 PR が反映する spec)
- runops-gateway `cmd/runops project` subcommand (= 軸 1、 `acb0fda` 着地済)
- dotfiles ADR 0011 (multi-project systemd env delivery)
- dotfiles ADR 0012 (RUNOPS_ACTOR_TYPE env injection、 cdr-exec Path C)

## out-of-scope (= 別 PR)

- 軸 4: AI agent シナリオ severity 判定 ADR (HIGH/LOW どちらで扱うか)
- 軸 5: 2 project full cycle integration test (= 実 VM/container 必要、 CI 統合)