### PR TITLE
feat(exe): cdr-project hard-delete 3 種 guard (typed + dry-run) (0024 軸 C)

### DIFF
--- a/exe/scripts/cdr-project
+++ b/exe/scripts/cdr-project
@@ -4,7 +4,7 @@
 #
 # Usage:
 #   cdr-project up <id> [--org=<org> --repo=<repo>]
-#   cdr-project down <id> [--hard]
+#   cdr-project down <id> [--hard] [--dry-run]
 #   cdr-project list
 #   cdr-project show <id>
 #
@@ -113,42 +113,77 @@ cmd_up() {
 
 cmd_down() {
   if [[ $# -lt 1 ]]; then
-    err "usage: cdr-project down <id> [--hard]"
+    err "usage: cdr-project down <id> [--hard] [--dry-run]"
   fi
   local id="$1"; shift
   validate_id "$id"
 
   local hard=0
+  local dry_run=0
   while [[ $# -gt 0 ]]; do
     case "$1" in
       --hard) hard=1 ;;
+      --dry-run) dry_run=1 ;;
       *) err "unexpected arg: $1" ;;
     esac
     shift
   done
 
-  log "down: workspace VM 側 project-down.sh '$id' を実行"
+  # ADR 0013 Bypass #4 mitigation: hard-delete 3 種 guard
+  #   (1) explicit --hard flag                (= 既存)
+  #   (2) typed project_id confirmation prompt (= 本 ADR で追加)
+  #   (3) --dry-run preview                    (= 本 ADR で追加)
+  # escape hatch (= non-TTY / CI): env CDR_PROJECT_NO_TYPED_CONFIRM=1 で typed
+  # confirmation を skip 可能。 ただし server side approval gate (= 0024 軸 B) が
+  # landed すれば server side で reject されるため、 hatch 単独で bypass にはならない。
+  if [[ "$hard" == "1" && "$dry_run" == "0" ]]; then
+    if [[ "${CDR_PROJECT_NO_TYPED_CONFIRM:-0}" != "1" ]]; then
+      log "WARNING: --hard mode は不可逆 (rm -rf + gateway delete --hard)"
+      printf "Type project ID '%s' to confirm hard delete (Ctrl+C to abort): " "$id" >&2
+      local confirmation=""
+      IFS= read -r confirmation
+      if [[ "$confirmation" != "$id" ]]; then
+        err "confirmation mismatch (expected: '$id', got: '$confirmation')"
+      fi
+      log "confirmation matched, proceeding with hard delete"
+    else
+      log "CDR_PROJECT_NO_TYPED_CONFIRM=1 — typed confirmation skipped (= caller responsibility)"
+    fi
+  fi
+
+  # build commands (= dry-run でも実 run でも同じ string、 dry-run で表示用に共通化)
   local down_cmd
   down_cmd="sudo bash ${REMOTE_DOWN_SCRIPT} $(printf '%q' "$id")"
   if [[ "$hard" == "1" ]]; then
     down_cmd+=" --hard"
   fi
+  local gw_cmd
+  if [[ "$hard" == "1" ]]; then
+    gw_cmd="${GATEWAY_CLI_CMD} project delete $(printf '%q' "$id") --hard"
+  else
+    gw_cmd="${GATEWAY_CLI_CMD} project archive $(printf '%q' "$id")"
+  fi
+
+  if [[ "$dry_run" == "1" ]]; then
+    log "DRY-RUN: would invoke cdr-exec ${RUNNER_WS} -- '${down_cmd}'"
+    log "DRY-RUN: would invoke cdr-exec ${RUNNER_WS} -- '${gw_cmd}'"
+    log "DRY-RUN: NO actual side effect, exit 0"
+    return 0
+  fi
+
+  log "down: workspace VM 側 project-down.sh '$id' を実行"
   if ! cdr-exec "$RUNNER_WS" -- "$down_cmd"; then
     err "workspace project-down.sh failed; gateway 側 archive/delete は実行しない (= data 整合性優先)"
   fi
 
   if [[ "$hard" == "1" ]]; then
     log "down: gateway CLI で project delete --hard '$id'"
-    local del_cmd
-    del_cmd="${GATEWAY_CLI_CMD} project delete $(printf '%q' "$id") --hard"
-    if ! cdr-exec "$RUNNER_WS" -- "$del_cmd"; then
+    if ! cdr-exec "$RUNNER_WS" -- "$gw_cmd"; then
       err "gateway project delete --hard failed; workspace VM 側 cleanup は完了済 (= 状態不整合、 手動修復)"
     fi
   else
     log "down: gateway CLI で project archive '$id'"
-    local arch_cmd
-    arch_cmd="${GATEWAY_CLI_CMD} project archive $(printf '%q' "$id")"
-    if ! cdr-exec "$RUNNER_WS" -- "$arch_cmd"; then
+    if ! cdr-exec "$RUNNER_WS" -- "$gw_cmd"; then
       err "gateway project archive failed; workspace VM 側 cleanup は完了済 (= 状態不整合、 手動修復)"
     fi
   fi

--- a/tests/exe/test_project_lifecycle.py
+++ b/tests/exe/test_project_lifecycle.py
@@ -132,11 +132,19 @@ def _run_cdr_project(
     tmp_path: Path,
     args: list[str],
     cdr_exec_body: str,
+    extra_env: dict[str, str] | None = None,
+    stdin_input: str | None = None,
 ) -> tuple[subprocess.CompletedProcess, list[str]]:
     """Execute cdr-project with a stubbed cdr-exec.
 
     Returns (CompletedProcess, list of cdr-exec invocation lines logged
     via the stub to `tmp_path / cdr-exec.log`).
+
+    Args:
+        extra_env: Additional env vars (e.g. CDR_PROJECT_NO_TYPED_CONFIRM=1
+            to skip typed confirmation in --hard tests).
+        stdin_input: Text fed to cdr-project stdin (e.g. typed confirmation
+            input). When None, no stdin is provided.
     """
     stubs = tmp_path / "stubs"
     stubs.mkdir()
@@ -147,10 +155,13 @@ def _run_cdr_project(
         "PATH": f"{stubs}:/usr/bin:/bin",
         "HOME": str(tmp_path),
     }
+    if extra_env:
+        env.update(extra_env)
     result = subprocess.run(
         [BASH, str(CDR_PROJECT), *args],
         text=True,
         env=env,
+        input=stdin_input,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         timeout=10,
@@ -252,7 +263,12 @@ def test_cdr_project_down_invokes_workspace_script_then_gateway_archive(
 
 def test_cdr_project_down_hard_invokes_gateway_delete(tmp_path: Path) -> None:
     """`cdr-project down <id> --hard` calls `runops project delete --hard`
-    (= not `archive`)."""
+    (= not `archive`).
+
+    ADR 0013 Bypass #4 mitigation: hard-delete typed confirmation prompt
+    is skipped here via env so the test exercises the underlying
+    cdr-exec invocations rather than the prompt.
+    """
     cdr_exec_body = """
         #!/usr/bin/env bash
         printf '%s\\n' "$*" >> __LOG__
@@ -262,6 +278,7 @@ def test_cdr_project_down_hard_invokes_gateway_delete(tmp_path: Path) -> None:
         tmp_path,
         ["down", "demo-foo", "--hard"],
         cdr_exec_body,
+        extra_env={"CDR_PROJECT_NO_TYPED_CONFIRM": "1"},
     )
     assert result.returncode == 0
     assert len(logs) == 2
@@ -269,8 +286,82 @@ def test_cdr_project_down_hard_invokes_gateway_delete(tmp_path: Path) -> None:
     assert "--hard" in logs[0]
     # Gateway invoked with delete --hard, NOT archive.
     assert "project delete" in logs[1]
-    assert "--hard" in logs[1]
-    assert "project archive" not in logs[1]
+
+
+def test_cdr_project_hard_requires_typed_confirmation(tmp_path: Path) -> None:
+    """`cdr-project down <id> --hard` (no env hatch) prompts for typed
+    project_id confirmation; matching input proceeds with the destructive
+    chain.
+
+    ADR 0013 Bypass #4 mitigation guard #2.
+    """
+    cdr_exec_body = """
+        #!/usr/bin/env bash
+        printf '%s\\n' "$*" >> __LOG__
+        exit 0
+    """
+    # Provide the matching project_id on stdin (= operator typed it).
+    result, logs = _run_cdr_project(
+        tmp_path,
+        ["down", "demo-foo", "--hard"],
+        cdr_exec_body,
+        stdin_input="demo-foo\n",
+    )
+    assert result.returncode == 0, (
+        f"matching confirmation should proceed; stderr:\n{result.stderr}"
+    )
+    assert "confirmation matched" in result.stderr
+    # Both cdr-exec invocations happened (= prompt did not abort the chain).
+    assert len(logs) == 2
+
+
+def test_cdr_project_hard_typed_mismatch_rejects(tmp_path: Path) -> None:
+    """`cdr-project down <id> --hard` rejects when the typed confirmation
+    does not exactly match the project id; no cdr-exec invocations occur.
+
+    ADR 0013 Bypass #4 mitigation guard #2 (= reject path)."""
+    cdr_exec_body = """
+        #!/usr/bin/env bash
+        printf '%s\\n' "$*" >> __LOG__
+        exit 0
+    """
+    result, logs = _run_cdr_project(
+        tmp_path,
+        ["down", "demo-foo", "--hard"],
+        cdr_exec_body,
+        stdin_input="demo-bar\n",  # mismatch
+    )
+    assert result.returncode != 0, "mismatched confirmation must fail-loud, not proceed"
+    assert "confirmation mismatch" in result.stderr
+    # NO cdr-exec invocations should have happened.
+    assert len(logs) == 0
+
+
+def test_cdr_project_hard_dry_run_no_side_effect(tmp_path: Path) -> None:
+    """`cdr-project down <id> --hard --dry-run` prints the planned
+    invocations and exits 0 without touching cdr-exec or prompting.
+
+    ADR 0013 Bypass #4 mitigation guard #3 (= dry-run preview).
+    """
+    cdr_exec_body = """
+        #!/usr/bin/env bash
+        printf '%s\\n' "$*" >> __LOG__
+        exit 0
+    """
+    result, logs = _run_cdr_project(
+        tmp_path,
+        ["down", "demo-foo", "--hard", "--dry-run"],
+        cdr_exec_body,
+        # No stdin: dry-run path must not prompt.
+    )
+    assert result.returncode == 0
+    # No cdr-exec invocations (= zero side effect).
+    assert len(logs) == 0
+    # DRY-RUN preview lines should appear on stderr (= log channel).
+    assert "DRY-RUN" in result.stderr
+    assert "project-down.sh" in result.stderr
+    assert "project delete" in result.stderr  # --hard branch
+    assert "--hard" in result.stderr
 
 
 def test_cdr_project_down_aborts_gateway_on_workspace_failure(


### PR DESCRIPTION
## Summary

ADR 0013 Bypass #4 mitigation の hard-delete 3 種 guard を cdr-project cmd_down section に追加。 既存 `--hard` flag は keep、 typed project_id confirmation prompt と `--dry-run` preview を追加実装。

## 3 種 guard

| # | guard | 状態 |
|---|---|---|
| 1 | explicit `--hard` flag | 既存実装、 keep |
| 2 | typed project_id confirmation prompt | **本 PR で追加** (= stdin 入力一致 verify) |
| 3 | `--dry-run` preview | **本 PR で追加** (= 副作用ゼロ + 予定 command stderr 表示) |

## escape hatch (= non-TTY / CI)

`CDR_PROJECT_NO_TYPED_CONFIRM=1` で typed confirmation を skip 可能。 ただし server side approval gate (= 0024 軸 B / gateway PR #108 ADR 0039) が landed すれば server side で reject されるため、 hatch 単独では bypass にならない。

## tests

- 既存 `test_cdr_project_down_hard_invokes_gateway_delete` を escape hatch env で update (= behavior 維持)
- `test_cdr_project_hard_requires_typed_confirmation` 新規 (= matching 入力で続行 + zero invocation 不在)
- `test_cdr_project_hard_typed_mismatch_rejects` 新規 (= 不一致で fail-loud + zero invocation)
- `test_cdr_project_hard_dry_run_no_side_effect` 新規 (= dry-run で zero invocation + DRY-RUN 表示)

local pytest: 24 tests all pass.

## Refs

- refs issue 0024 軸 C (= hard-delete 3 種 guard 実装)
- dotfiles ADR 0013 Bypass #4 mitigation
- 関連: gateway PR #108 (= 0024 軸 B ADR 0039 admin endpoint approval gate、 並走中)