### PR TITLE
fix(workspace): run claude-code postinstall via mise npm_args

### DIFF
--- a/.devcontainer/features/dotfiles-tools/install.sh
+++ b/.devcontainer/features/dotfiles-tools/install.sh
@@ -249,7 +249,9 @@ vp = "0.1.20"
 node = "24.15.0"
 "npm:@openai/codex" = "0.128.0"
 "npm:@google/gemini-cli" = "0.40.1"
-"npm:@anthropic-ai/claude-code" = "2.1.126"
+# npm_args re-enables postinstall (mise defaults to --ignore-scripts=true)
+# so claude-code's native binary is linked, not left as a stub. See mise.toml.
+"npm:@anthropic-ai/claude-code" = { version = "2.1.126", npm_args = "--ignore-scripts=false" }
 "npm:@github/copilot" = "1.0.40"
 "npm:@earendil-works/pi-coding-agent" = "0.74.0"
 EOF

--- a/mise.toml
+++ b/mise.toml
@@ -30,7 +30,14 @@ node = "24.15.0"
 # `copilot auth`, `pi auth`). Source: 2026-05 latest stable.
 "npm:@openai/codex" = "0.128.0"
 "npm:@google/gemini-cli" = "0.40.1"
-"npm:@anthropic-ai/claude-code" = "2.1.126"
+# claude-code ships its ~248MB native binary as per-platform npm
+# optionalDependencies that a postinstall (install.cjs) hardlinks over a
+# stub. mise's npm backend installs with --ignore-scripts=true by default,
+# so the optional dep downloads but the postinstall never runs, leaving the
+# stub — `claude` then errors at runtime with "native binary not installed".
+# npm_args re-enables scripts for this one tool (npm honors the last
+# --ignore-scripts flag, so this overrides mise's default).
+"npm:@anthropic-ai/claude-code" = { version = "2.1.126", npm_args = "--ignore-scripts=false" }
 "npm:@github/copilot" = "1.0.40"
 "npm:@earendil-works/pi-coding-agent" = "0.74.0"
 

--- a/tests/test_mise_pin_consistency.py
+++ b/tests/test_mise_pin_consistency.py
@@ -57,6 +57,30 @@ FEATURE_INSTALL_SH = (
 )
 
 
+def _parse_tool_line(line: str) -> tuple[str, str] | None:
+    """Parse one mise `[tools]` line into (key, version), or None for
+    blanks/comments/unparseable lines.
+
+    Handles bare keys (`just = "1.40.0"`), quoted keys
+    (`"npm:@openai/codex" = "0.128.0"`), and inline-table values that
+    carry mise tool options alongside the version
+    (`"npm:@anthropic-ai/claude-code" = { version = "2.1.126", npm_args = "..." }`)."""
+    line = line.strip()
+    if not line or line.startswith("#"):
+        return None
+    head = re.match(r'"?([^"=\s]+)"?\s*=\s*(.+)', line)
+    if head is None:
+        return None
+    key, rhs = head.group(1), head.group(2).strip()
+    if rhs.startswith("{"):
+        version = re.search(r'version\s*=\s*"([^"]+)"', rhs)
+    else:
+        version = re.match(r'"([^"]+)"', rhs)
+    if version is None:
+        return None
+    return key, version.group(1)
+
+
 @pytest.fixture(scope="module")
 def mise_pins() -> dict[str, str]:
     """Parse the [tools] section of mise.toml into a dict.
@@ -71,12 +95,9 @@ def mise_pins() -> dict[str, str]:
     assert match is not None, "could not find [tools] section in mise.toml"
     pins: dict[str, str] = {}
     for line in match.group(1).splitlines():
-        line = line.strip()
-        if not line or line.startswith("#"):
-            continue
-        m = re.match(r'"?([^"=\s]+)"?\s*=\s*"([^"]+)"', line)
-        if m:
-            pins[m.group(1)] = m.group(2)
+        parsed = _parse_tool_line(line)
+        if parsed:
+            pins[parsed[0]] = parsed[1]
     return pins
 
 
@@ -89,6 +110,39 @@ def feature_constants() -> dict[str, str]:
         m.group(1): m.group(2)
         for m in re.finditer(r'^([A-Z_]+)_VERSION="([^"]+)"', text, re.MULTILINE)
     }
+
+
+# ---------- tool-line parsing ------------------------------------
+
+
+def test_parse_tool_line_supports_inline_table_pins() -> None:
+    """mise lets a pin carry tool options as an inline table, e.g.
+    `npm_args` to undo the npm backend's default --ignore-scripts.
+    The consistency check must still recover (key, version) from that
+    form, not just the bare `key = "x.y.z"` string form."""
+    # given a pin that carries npm_args alongside the version
+    line = (
+        '"npm:@anthropic-ai/claude-code" = '
+        '{ version = "2.1.126", npm_args = "--ignore-scripts=false" }'
+    )
+
+    # when
+    parsed = _parse_tool_line(line)
+
+    # then key and version are extracted, extra options ignored
+    assert parsed == ("npm:@anthropic-ai/claude-code", "2.1.126")
+
+
+def test_parse_tool_line_supports_bare_string_pins() -> None:
+    """The plain `key = "x.y.z"` form (quoted or bare key) keeps
+    working unchanged."""
+    # given
+    quoted = '"npm:@openai/codex" = "0.128.0"'
+    bare = 'just = "1.40.0"'
+
+    # when / then
+    assert _parse_tool_line(quoted) == ("npm:@openai/codex", "0.128.0")
+    assert _parse_tool_line(bare) == ("just", "1.40.0")
 
 
 # ---------- mise.toml is fully pinned (no "latest") ----------------
@@ -177,7 +231,7 @@ def test_required_tools_are_present(mise_pins: dict[str, str]) -> None:
         "npm:@google/gemini-cli",
         "npm:@anthropic-ai/claude-code",
         "npm:@github/copilot",
-        "npm:@mariozechner/pi-coding-agent",
+        "npm:@earendil-works/pi-coding-agent",
     }
     missing = required - set(mise_pins)
     assert not missing, (
@@ -216,12 +270,9 @@ def test_system_mise_config_matches_workspace_mise_toml(
     )
     system_pins: dict[str, str] = {}
     for line in match.group("body").splitlines():
-        line = line.strip()
-        if not line or line.startswith("#"):
-            continue
-        m = re.match(r'"?([^"=\s]+)"?\s*=\s*"([^"]+)"', line)
-        if m:
-            system_pins[m.group(1)] = m.group(2)
+        parsed = _parse_tool_line(line)
+        if parsed:
+            system_pins[parsed[0]] = parsed[1]
 
     diffs = {
         k: (system_pins.get(k), mise_pins.get(k))


### PR DESCRIPTION
## What

Fix the failing **Just Sandbox Tests** CI job
(`tests/test_devcontainer.py::test_image_provides_tool[claude]`).

## Root cause (reproduced on real amd64 hardware)

mise's npm backend installs npm-backed tools with
`npm install -g ... --ignore-scripts=true` by default. `@anthropic-ai/claude-code` 2.x
ships its ~248MB native binary as per-platform npm `optionalDependencies` and links the
right one over the `bin/claude.exe` stub in a **postinstall** (`install.cjs`). With
scripts ignored, the optional dependency downloads but the postinstall never runs, so
the 500-byte stub remains and `claude --version` errors at runtime:

```
Error: claude native binary not installed.
Either postinstall did not run (--ignore-scripts, some pnpm configs)
or the platform-native optional dependency was not downloaded (--omit=optional).
```

This was masked locally because dev images built before mise adopted the
`--ignore-scripts=true` default still carried a working binary; only a fresh x64 CI
build surfaced it. It is **not** an arch issue — reproduced identically on amd64 and arm64.
The other AI CLIs (codex, gemini, copilot, pi) are pure-JS and need no postinstall, so
only claude was affected.

## Fix

Add `npm_args = "--ignore-scripts=false"` to the claude-code pin in both single-SoT
locations (`mise.toml` and the `/etc/mise/config.toml` heredoc in the dev container
feature). npm honors the last `--ignore-scripts` flag, so the postinstall runs and the
native binary is linked. Scoped to claude-code only.

```text
npm install -g @anthropic-ai/claude-code@2.1.126 ... --ignore-scripts=true --ignore-scripts=false
# last flag wins -> postinstall runs -> bin/claude.exe becomes the 248MB binary
```

## Also (pre-existing latent bug, separate commit)

`tests/test_mise_pin_consistency.py` is not wired into any CI gate and was already red
locally: it still required `npm:@mariozechner/pi-coding-agent` after the package moved to
the `@earendil-works` fork (ece0c12). Corrected the stale pin and taught the line parser
to read inline-table pins (so the npm_args change above doesn't drop the tool).

## Verification

- `uvx pytest tests/test_mise_pin_consistency.py -q` -> 8 passed
- shellcheck on `install.sh` -> clean
- Mechanism proven on `node:24-bookworm-slim --platform linux/amd64`:
  `claude --version` -> `2.1.126 (Claude Code)`
- The full e2e (`test_image_provides_tool[claude]`) requires an x64 devcontainer rebuild,
  left to this PR's CI to confirm.

## Out of scope

Migrating to claude-code's official signed apt repo / Homebrew cask (the upstream-recommended
method) — would amend ADR 0006's single-SoT model; deferred per minimal-fix choice.
