### PR TITLE
chore(deps): bump pinned tool versions to latest (>=7d old)

### DIFF
--- a/.devcontainer/features/dotfiles-tools/install.sh
+++ b/.devcontainer/features/dotfiles-tools/install.sh
@@ -89,7 +89,7 @@ apt-get update -y
 apt-get install -y --no-install-recommends mise
 
 # ---- uv (Python package manager) ------------------------------------
-UV_VERSION="0.11.8"
+UV_VERSION="0.11.14"
 case "$ARCH" in
   x86_64)  UV_TARGET="x86_64-unknown-linux-gnu" ;;
   aarch64) UV_TARGET="aarch64-unknown-linux-gnu" ;;
@@ -127,7 +127,7 @@ install -m 0755 /tmp/uvx /usr/local/bin/uvx
 rm -f "/tmp/${UV_FILE}" "/tmp/${UV_FILE}.sha256" /tmp/uv /tmp/uvx
 
 # ---- just (command runner) ------------------------------------------
-JUST_VERSION="1.40.0"
+JUST_VERSION="1.51.0"
 case "$ARCH" in
   x86_64)  JUST_TARGET="x86_64-unknown-linux-musl" ;;
   aarch64) JUST_TARGET="aarch64-unknown-linux-musl" ;;
@@ -143,14 +143,14 @@ tar -xz -f "/tmp/${JUST_FILE}" -C /usr/local/bin just
 rm -f "/tmp/${JUST_FILE}" /tmp/just.SHA256SUMS
 
 # ---- sheldon (zsh plugin manager) -----------------------------------
-SHELDON_VERSION="0.8.4"
+SHELDON_VERSION="0.8.5"
 case "$ARCH" in
   x86_64)
     SHELDON_TARGET="x86_64-unknown-linux-musl"
-    SHELDON_SHA256="604ebaeccb485da58f5c3c3353d18f2f7ccc8fd9de0d65ee0b424f5b1a0324ce" ;;
+    SHELDON_SHA256="80aa0be617072c278d67fd6c5fbce4903d3801d78b6abf8f058f0648d2242c78" ;;
   aarch64)
     SHELDON_TARGET="aarch64-unknown-linux-musl"
-    SHELDON_SHA256="7fe1007c52ebb2777edfd66f4a4119b1e2b175269150a334467cf8708621fcf6" ;;
+    SHELDON_SHA256="1f6b792e49e259f7c313e9921c8d4ad638d827abc2c023efe0588a55678f9a3e" ;;
   *) echo "[dotfiles-tools] unsupported arch: $ARCH" >&2; exit 1 ;;
 esac
 SHELDON_URL="https://github.com/rossmacarthur/sheldon/releases/download/${SHELDON_VERSION}/sheldon-${SHELDON_VERSION}-${SHELDON_TARGET}.tar.gz"
@@ -241,19 +241,19 @@ install -d -m 0755 /etc/mise
 export MISE_DATA_DIR=/opt/mise
 cat > /etc/mise/config.toml <<'EOF'
 [tools]
-just = "1.40.0"
+just = "1.51.0"
 markdownlint-cli2 = "0.22.1"
-prek = "0.3.11"
-uv = "0.11.8"
-vp = "0.1.20"
+prek = "0.4.0"
+uv = "0.11.14"
+vp = "0.1.21"
 node = "24.15.0"
-"npm:@openai/codex" = "0.128.0"
-"npm:@google/gemini-cli" = "0.40.1"
+"npm:@openai/codex" = "0.131.0"
+"npm:@google/gemini-cli" = "0.42.0"
 # npm_args re-enables postinstall (mise defaults to --ignore-scripts=true)
 # so claude-code's native binary is linked, not left as a stub. See mise.toml.
-"npm:@anthropic-ai/claude-code" = { version = "2.1.126", npm_args = "--ignore-scripts=false" }
-"npm:@github/copilot" = "1.0.40"
-"npm:@earendil-works/pi-coding-agent" = "0.74.0"
+"npm:@anthropic-ai/claude-code" = { version = "2.1.143", npm_args = "--ignore-scripts=false" }
+"npm:@github/copilot" = "1.0.48"
+"npm:@earendil-works/pi-coding-agent" = "0.75.3"
 EOF
 echo "[dotfiles-tools] pre-installing mise.toml tools at build time (MISE_DATA_DIR=/opt/mise, system config /etc/mise/config.toml)"
 (

--- a/mise.toml
+++ b/mise.toml
@@ -5,13 +5,13 @@
 # build-time consistency check in tests/test_mise_pin_consistency.py
 # fails the image build if these drift from the SHA-verified
 # constants in .devcontainer/features/dotfiles-tools/install.sh.
-just = "1.40.0"
+just = "1.51.0"
 markdownlint-cli2 = "0.22.1"
-prek = "0.3.11"
-uv = "0.11.8"
+prek = "0.4.0"
+uv = "0.11.14"
 # `vp` is the mise registry alias for npm:vite-plus (NOT the
 # unrelated `vp` npm package). Pin to vite-plus's actual version.
-vp = "0.1.20"
+vp = "0.1.21"
 
 # Node runtime. The npm-backed AI CLIs below have a `#!/usr/bin/env
 # node` shebang that needs node on PATH at *runtime*, not just at
@@ -28,8 +28,8 @@ node = "24.15.0"
 # boots with them ready on PATH; operators authenticate them on
 # first use (`codex login`, `claude /login`, `gemini auth`,
 # `copilot auth`, `pi auth`). Source: 2026-05 latest stable.
-"npm:@openai/codex" = "0.128.0"
-"npm:@google/gemini-cli" = "0.40.1"
+"npm:@openai/codex" = "0.131.0"
+"npm:@google/gemini-cli" = "0.42.0"
 # claude-code ships its ~248MB native binary as per-platform npm
 # optionalDependencies that a postinstall (install.cjs) hardlinks over a
 # stub. mise's npm backend installs with --ignore-scripts=true by default,
@@ -37,9 +37,9 @@ node = "24.15.0"
 # stub — `claude` then errors at runtime with "native binary not installed".
 # npm_args re-enables scripts for this one tool (npm honors the last
 # --ignore-scripts flag, so this overrides mise's default).
-"npm:@anthropic-ai/claude-code" = { version = "2.1.126", npm_args = "--ignore-scripts=false" }
-"npm:@github/copilot" = "1.0.40"
-"npm:@earendil-works/pi-coding-agent" = "0.74.0"
+"npm:@anthropic-ai/claude-code" = { version = "2.1.143", npm_args = "--ignore-scripts=false" }
+"npm:@github/copilot" = "1.0.48"
+"npm:@earendil-works/pi-coding-agent" = "0.75.3"
 
 # `~/.npmrc` may set `min-release-age=7` (7-day quarantine, mirrors
 # uv's `exclude-newer = "7 days"`). That blocks `mise install` of


### PR DESCRIPTION
## What

Bump every hand-pinned tool to its newest release that is **at least 7 days old**
(cutoff 2026-05-19), mirroring the `min-release-age=7` quarantine the dotfiles already
apply to mise's npm backend and uv's `exclude-newer`. `mise.toml` and the dev container
feature's `/etc/mise/config.toml` + version constants move together per ADR 0006.

| tool | from | to | published |
|---|---|---|---|
| just | 1.40.0 | **1.51.0** | 2026-05-10 |
| uv | 0.11.8 | **0.11.14** | 2026-05-12 |
| prek | 0.3.11 | **0.4.0** | 2026-05-14 |
| sheldon | 0.8.4 | **0.8.5** | 2025-07-22 |
| vp (vite-plus) | 0.1.20 | **0.1.21** | 2026-05-13 |
| @openai/codex | 0.128.0 | **0.131.0** | 2026-05-18 |
| @google/gemini-cli | 0.40.1 | **0.42.0** | 2026-05-12 |
| @anthropic-ai/claude-code | 2.1.126 | **2.1.143** | 2026-05-15 |
| @github/copilot | 1.0.40 | **1.0.48** | 2026-05-14 |
| @earendil-works/pi-coding-agent | 0.74.0 | **0.75.3** | 2026-05-18 |

**Unchanged**
- `node` stays **24.15.0** — latest 24.x 'Krypton' Active LTS that is ≥7d old (24.16.0 is
  <7d; node 26.x is "Current", not LTS until 2026-10). Pin is deliberate (volume-mount masking).
- `markdownlint-cli2` stays 0.22.1 — no newer ≥7d release.

`sheldon`'s hardcoded SHA256 was recomputed for both arches from the official release tarballs.

## Notes
- Stacked on #109 (the claude-code `npm_args` fix); the claude bump preserves that inline-table form.
  Base retargets to `main` automatically once #109 merges.
- GitHub Actions versions are out of scope (Dependabot-managed).

## Verification
- `uvx pytest tests/test_mise_pin_consistency.py -q` → 8 passed (uv/just cross-check + mise.toml↔heredoc drift NONE)
- shellcheck on `install.sh` → clean
- Full dev container build + tool smoke (`test_image_provides_tool`) left to CI.
