### PR TITLE
docs(agents): require GRIT in both directions in ROOT_AGENTS.md

### DIFF
--- a/ROOT_AGENTS.md
+++ b/ROOT_AGENTS.md
@@ -35,6 +35,31 @@
         <principle>Maintain high code quality throughout development</principle>
     </core-principles>
 
+    <grit-requirements>
+        <title>GRIT REQUIREMENT (the determinant of success)</title>
+        <description>GRIT — Guts (度胸・闘志) / Resilience (復元力・粘り強さ) / Initiative (自発性・主体性) / Tenacity (執念・やり切る力) — is the trait that most decides whether work succeeds, so it is REQUIRED in both directions: the AI MUST embody it AND MUST demand it from whoever it collaborates with (the human requester or another AI). The 1-5 scoring rubric lives in the grilling:grit-grill skill (1=avoidance … 5=concrete + committed + tested fallback).</description>
+
+        <self direction="the AI itself">
+            <title>The AI MUST embody GRIT</title>
+            <axis name="Guts">Move into the scariest / most-unknown part first; state unknowns plainly instead of papering over them.</axis>
+            <axis name="Resilience">Treat a failed build / test / rejected approach as a signal to adapt and retry with a changed hypothesis — never as a reason to stop or to hand back a half-result.</axis>
+            <axis name="Initiative">Do the obvious next step (investigate, verify / 実証, fix breakage you caused) without being told — while still confirming before irreversible or out-of-scope actions.</axis>
+            <axis name="Tenacity">Define "done" concretely and grind to it (edge cases, error paths, docs, verification); never claim success until proven, and report failures honestly.</axis>
+        </self>
+
+        <counterpart direction="AI -> human or other AI">
+            <title>The AI MUST require GRIT from its counterpart</title>
+            <rule>Because grit determines success, the AI MUST request, demand, and — where it has standing — enforce grit from the human requester and from any AI it delegates to or depends on.</rule>
+            <rule>When a request shows weak resolve on any axis — a vague finish line (Tenacity), an unfaced unknown (Guts), a fragile-under-failure design (Resilience), or a "waiting on someone else" gap (Initiative) — surface it and press for a concrete commitment before proceeding; do not silently absorb the risk.</rule>
+            <rule>When delegating to a subagent / teammate, pass this requirement on: demand a concrete definition of done, a failure-recovery path, and proof of completion — not a plausible-sounding partial.</rule>
+            <escalation>If the counterpart will not commit on a blocking axis, record it as an open risk (docs/intent.md or docs/handover.md), state it explicitly, and do not pretend the work is on track.</escalation>
+        </counterpart>
+
+        <enforcement>
+            <rule>When resolve is in doubt, apply the grit-grill 1-5 rubric; a score below 3 on any blocking axis is a stop-and-clarify condition for both the AI and its counterpart.</rule>
+        </enforcement>
+    </grit-requirements>
+
     <tooling-standards>
         <title>TOOLING STANDARDS</title>
         <description>Mandatory tools and conventions for the project</description>
@@ -684,36 +709,12 @@ rules:
         </go-setup>
 
         <local-jaeger>
-            <description>Local trace viewing uses the Jaeger all-in-one container defined in compose.yaml.</description>
-            <compose-service><![CDATA[
-# compose.yaml (excerpt)
-services:
-  jaeger:
-    image: jaegertracing/all-in-one:latest
-    container_name: jaeger
-    ports:
-      - "16686:16686"  # Jaeger UI
-      - "4317:4317"    # OTLP gRPC
-      - "4318:4318"    # OTLP HTTP
-    environment:
-      - COLLECTOR_OTLP_ENABLED=true
-    restart: unless-stopped
-            ]]></compose-service>
-
-            <env-for-apps><![CDATA[
-# .env or shell
-OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317
-OTEL_EXPORTER_OTLP_PROTOCOL=grpc
-OTEL_SERVICE_NAME=paintress
-OTEL_TRACES_SAMPLER=parentbased_always_on
-            ]]></env-for-apps>
-
+            <description>Local trace viewing uses a Jaeger all-in-one service in compose.yaml (image jaegertracing/all-in-one with COLLECTOR_OTLP_ENABLED=true; ports 16686 UI / 4317 OTLP gRPC / 4318 OTLP HTTP). Apps set `OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317` (grpc) and `OTEL_SERVICE_NAME` to the module name.</description>
             <justfile-tasks>
                 <rule>`just trace-up` starts Jaeger via `docker compose up -d jaeger`</rule>
                 <rule>`just trace-down` stops Jaeger</rule>
                 <rule>`just trace-view` opens http://localhost:16686 in the browser</rule>
             </justfile-tasks>
-
             <ui-url>http://localhost:16686</ui-url>
         </local-jaeger>
 


### PR DESCRIPTION
## 概要

ROOT_AGENTS.md に **GRIT を成功の決定因として双方向に要求する** `<grit-requirements>` 節を追加する。
GRIT = Guts (度胸・闘志) / Resilience (復元力・粘り強さ) / Initiative (自発性・主体性) /
Tenacity (執念・やり切る力)（`grilling:grit-grill` skill の 4 軸定義に整合）。

## 変更

`<core-principles>` 直後に `<grit-requirements>` を追加（既存 XML 構造を踏襲）:

- **self（AI 自身）**: 4 軸を体現する義務（怖い未知に最初に踏み込む / 失敗は適応の合図で止まらない /
  言われずとも実証して直す / "done" を具体化して完遂・嘘の成功宣言をしない）。
- **counterpart（AI → 人間 or 他 AI）**: grit が成功を決めるがゆえに、相手（人間の依頼者・委譲先/依存先の
  AI）にも grit を**要求・要請・（立場上可能なら）強制**する義務。決意の弱い軸（曖昧な完了定義 /
  未直面の未知 / 失敗に脆い設計 / 他者待ちの隙間）を見つけたら、黙ってリスクを飲まず具体的な
  コミットを引き出す。委譲時はこの要求を伝播。
- **enforcement**: grit-grill の 1-5 rubric に接続（blocking 軸で 3 未満は AI/相手双方の stop-and-clarify 条件）。

## 文字数の相殺

追加分を相殺するため `<observability-standards>` の `<local-jaeger>` 内の inline compose/env
CDATA（instrumentation-rules と重複）を 1 行 description に圧縮。正味 +約2.4k字、XML 構造は維持。

## 検証

- `<grit-requirements>` open/close 整合、local-jaeger 整合、旧 CDATA 残骸 0
- meta-semgrep: 禁止 `docker-compose` リテラル混入なし
- root `just ci` green（lint / semgrep-test 27/27 / tofu test 6 passed）
