### PR TITLE
feat(emulator): add emu-api-stop to stop the host emulate API

### DIFF
--- a/justfile
+++ b/justfile
@@ -1176,7 +1176,8 @@ emu-lint:
     echo '🔍 markdownlint (git-tracked only; excludes .venv etc.)...'
     git ls-files -z '*.md' | xargs -0 -r mise x -- markdownlint-cli2
 
-# Start emulate API emulators (vercel-labs/emulate) via npx on host (base 4100, Ctrl+C to stop)
+# Start emulate API emulators (vercel-labs/emulate) via npx on host (base 4100; Ctrl+C, or
+# `just emu-api-stop` if backgrounded)
 # Override `services=` to drop any rejected by the published CLI (see emulator/emulate/README.md)
 [group('Emulator')]
 emu-api services='github,google,slack,apple,microsoft,stripe,clerk,okta,resend':
@@ -1186,6 +1187,22 @@ emu-api services='github,google,slack,apple,microsoft,stripe,clerk,okta,resend':
     cd emulator/emulate
     echo "▶ emulate@0.6.0 services={{services}} base=4100 (Ctrl+C to stop)"
     npx -y emulate@0.6.0 --service '{{services}}' --port 4100 --seed emulate.config.yaml
+
+# Stop the emulate API emulators started by `just emu-api` (the host npx/emulate process; no
+# Docker container is involved, unlike emu-stop / tel-down)
+[group('Emulator')]
+emu-api-stop:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    pids="$(pgrep -f 'emulate.* --service' 2>/dev/null || true)"
+    if [ -z "$pids" ]; then
+      echo 'ℹ️  emulate API is not running.'
+      exit 0
+    fi
+    echo "▶ stopping emulate API (PIDs: $(echo "$pids" | tr '\n' ' '))"
+    # shellcheck disable=SC2086
+    kill $pids 2>/dev/null || true
+    echo '✅ emulate API stopped.'
 
 # ------------------------------
 # Telemetry (telemetry/) — OTel + Grafana + Loki + Prometheus + Tempo


### PR DESCRIPTION
## 概要

3つ目のスタック `just emu-api`（vercel-labs/emulate を host の foreground npx で起動）には停止 recipe が無く、`emu-stop` / `tel-down` と違って手動で PID を kill するしかなかった。`just emu-api-stop` を追加して対にする。

## 追加

`just emu-api-stop`:
- `pgrep -f 'emulate.* --service'` で emulate プロセス（npm exec + node）を捕捉して kill
- ポート 4100-4108 を解放
- **冪等**: 停止済みなら `ℹ️ not running` で exit 0
- emu-api の comment にも `just emu-api-stop` を追記

## 検証（実証済み）

- 稼働中の emu-api を停止 → PIDs 停止・ポート 4100-4108 全解放・プロセス消滅を確認
- 停止済みでの再実行 → no-op (exit 0)
- shebang recipe なので pattern は temp ファイル内 = pgrep 自己マッチ無し
- root `just ci` green