### PR TITLE
chore(gitignore): ignore dated intent/handover backups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,8 +68,12 @@ continent-config.yaml
 
 # Per-session intent + handover for AI agents (CLAUDE.md exempts these
 # from "current state only" but they are intentionally not committed).
+# The `-*` globs also cover dated/archived backups (e.g. when a new work
+# unit displaces the live handover) so they can't be committed by accident.
 docs/intent.md
+docs/intent-*.md
 docs/handover.md
+docs/handover-*.md
 docs/setup.md
 node_modules
 


### PR DESCRIPTION
## 概要

新しい作業ユニットが live な `docs/handover.md` を上書きすると、旧 handover は dated ファイル（例: `docs/handover-exe-dmail-2026-05-06.md`）に退避される。だが `.gitignore` は完全パス `docs/handover.md` / `docs/intent.md` のみを ignore していたため、退避ファイルは **untracked だが commit 可能**な状態で、`git add docs/` 等で誤コミットされ得た。

## 変更

`.gitignore` に glob を追加:
- `docs/handover-*.md`
- `docs/intent-*.md`

これで dated/archived な per-session AI doc も ignore 対象に。

## 検証

`git check-ignore`:
- `docs/handover-exe-dmail-2026-05-06.md` → IGNORED（新 glob）✓
- `docs/handover.md` / `docs/intent.md` → IGNORED（従来どおり）✓
- tracked な `docs/changelogs.md` → 対象外 ✓

※ exe.hironow.dev の handover backup は intent.md（主作業ユニット）に対応する未push作業の記録なので、**削除せず保全**してこの ignore で誤コミットを防ぐ方針。