### PR TITLE
docs(pages): redesign index.html as a terminal datasheet + refresh content

### DIFF
--- a/index.html
+++ b/index.html
@@ -40,8 +40,8 @@
       padding: 22px 16px 0;
     }
     ::selection { background: var(--sel); color: #eafff2; }
-    a { color: var(--cyan); text-decoration: none; }
-    a:hover { text-decoration: underline; text-underline-offset: 2px; }
+    a { color: var(--cyan); text-decoration: none; transition: text-shadow .15s ease; }
+    a:hover { text-decoration: underline; text-underline-offset: 2px; text-shadow: 0 0 8px rgba(79, 193, 217, 0.5); }
 
     /* ── Terminal window ─────────────────────────────────────────── */
     .term {
@@ -122,6 +122,18 @@
     }
     .copy:hover { color: var(--green); border-color: var(--green); }
     .copy.ok { color: var(--green); border-color: var(--green); }
+
+    /* ── Glint sweep on pressable UI (tabs, copy) ────────────────── */
+    .tabs a, .copy { position: relative; overflow: hidden; isolation: isolate; }
+    .tabs a::after, .copy::after {
+      content: ""; position: absolute; inset: 0; pointer-events: none; z-index: 2;
+      background: linear-gradient(115deg, transparent 36%, rgba(94, 240, 143, 0.38) 50%, transparent 64%);
+      transform: translateX(-130%); transition: transform .55s ease;
+    }
+    .tabs a:hover::after, .tabs a:focus-visible::after,
+    .copy:hover::after, .copy:focus-visible::after { transform: translateX(130%); }
+    .copy:hover { box-shadow: 0 0 12px rgba(94, 240, 143, 0.22); }
+    .tabs a:hover { box-shadow: inset 0 0 16px rgba(94, 240, 143, 0.12); }
 
     .blink {
       display: inline-block; width: 0.6ch; height: 1.05em; transform: translateY(0.16em);

--- a/index.html
+++ b/index.html
@@ -3,1019 +3,467 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <meta name="description" content="dotfiles — a cross-platform developer environment setup powered by Zsh, Mise, Just, uv, and more." />
+  <meta name="description" content="dotfiles — a cross-platform developer environment (Zsh · mise · just · uv) wired for multi-agent AI workflows and a full local-dev stack: emulators, OpenTelemetry, and portless .localhost routing." />
   <meta name="author" content="hironow" />
-  <meta name="date" content="2026-03-21" />
-  <title>dotfiles · hironow</title>
+  <meta name="date" content="2026-05-30" />
+  <meta name="color-scheme" content="dark" />
+  <meta name="theme-color" content="#0b0d10" />
+  <title>~/dotfiles · hironow</title>
   <style>
-    /* ── Custom Properties ─────────────────────────────────────── */
+    /* ── Tokens ──────────────────────────────────────────────────── */
     :root {
-      --bg-base:        #0a0a0f;
-      --bg-layer:       #0f0f1a;
-      --glass-bg:       rgba(255, 255, 255, 0.06);
-      --glass-border:   rgba(255, 255, 255, 0.15);
-      --glass-hover:    rgba(255, 255, 255, 0.12);
-      --purple-400:     #a78bfa;
-      --purple-500:     #8b5cf6;
-      --purple-600:     #7c3aed;
-      --blue-400:       #60a5fa;
-      --blue-500:       #3b82f6;
-      --cyan-400:       #22d3ee;
-      --pink-400:       #f472b6;
-      --text-primary:   #f1f5f9;
-      --text-secondary: #94a3b8;
-      --text-muted:     #8899aa;
-      --radius-sm:      8px;
-      --radius-md:      16px;
-      --radius-lg:      24px;
-      --blur-md:        blur(16px);
-      --blur-lg:        blur(32px);
-      --shadow-glass:   0 8px 32px rgba(0, 0, 0, 0.4), 0 1px 0 rgba(255,255,255,0.06) inset;
-      --shadow-glow-p:  0 0 40px rgba(139, 92, 246, 0.15);
-      --shadow-glow-b:  0 0 40px rgba(59, 130, 246, 0.15);
-      --transition:     all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
-      --font:           -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif;
-      --font-mono:      ui-monospace, "SF Mono", "Cascadia Code", "Fira Code", Menlo, monospace;
+      --bg:        #0b0d10;
+      --bg-soft:   #0f1218;
+      --panel:     #11141b;
+      --line:      #1d242e;
+      --line-soft: #161c24;
+      --fg:        #d8dee6;
+      --fg-dim:    #9aa6b2;
+      --fg-mute:   #66727f;
+      --accent:    #4ade80;   /* phosphor green */
+      --accent-dim:#2f7d52;
+      --amber:     #f5b657;   /* secondary, used sparingly */
+      --cyan:      #56b6c2;
+      --radius:    4px;
+      --mono: ui-monospace, "SF Mono", "JetBrains Mono", "Cascadia Code", "Fira Code", "Roboto Mono", Menlo, Consolas, monospace;
+      --tr: 0.18s cubic-bezier(0.4, 0, 0.2, 1);
     }
 
-    /* ── Reset ─────────────────────────────────────────────────── */
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
 
-    html {
-      scroll-behavior: smooth;
-      -webkit-font-smoothing: antialiased;
-      -moz-osx-font-smoothing: grayscale;
-    }
+    html { scroll-behavior: smooth; -webkit-text-size-adjust: 100%; }
 
     body {
-      font-family: var(--font);
-      background-color: var(--bg-base);
-      color: var(--text-primary);
-      min-height: 100vh;
+      font-family: var(--mono);
+      background: var(--bg);
+      color: var(--fg);
+      line-height: 1.65;
+      font-size: 15px;
+      -webkit-font-smoothing: antialiased;
+      -moz-osx-font-smoothing: grayscale;
       overflow-x: hidden;
-      line-height: 1.6;
+      font-feature-settings: "calt" 1, "liga" 0;
     }
 
-    /* ── Ambient Background ────────────────────────────────────── */
-    .ambient {
-      position: fixed;
-      inset: 0;
-      pointer-events: none;
-      z-index: 0;
-      overflow: hidden;
-    }
-    .ambient-orb {
-      position: absolute;
-      border-radius: 50%;
-      filter: blur(60px);
-      opacity: 0.5;
-      animation: drift 20s ease-in-out infinite alternate;
-    }
-    .ambient-orb:nth-child(1) {
-      width: 600px; height: 600px;
-      background: radial-gradient(circle, var(--purple-600), var(--purple-500) 40%, transparent 70%);
-      top: -150px; left: -100px;
-      animation-duration: 18s;
-    }
-    .ambient-orb:nth-child(2) {
-      width: 500px; height: 500px;
-      background: radial-gradient(circle, var(--blue-500), var(--blue-400) 40%, transparent 70%);
-      bottom: -80px; right: -60px;
-      animation-duration: 24s;
-      animation-delay: -6s;
-    }
-    .ambient-orb:nth-child(3) {
-      width: 350px; height: 350px;
-      background: radial-gradient(circle, var(--cyan-400), transparent 70%);
-      top: 40%; left: 55%;
-      animation-duration: 30s;
-      animation-delay: -12s;
-      opacity: 0.35;
-    }
-    .ambient-orb:nth-child(4) {
-      width: 400px; height: 400px;
-      background: radial-gradient(circle, var(--pink-400), transparent 70%);
-      top: 25%; right: -10%;
-      animation-duration: 22s;
-      animation-delay: -4s;
-      opacity: 0.3;
-    }
-    .ambient-orb:nth-child(5) {
-      width: 450px; height: 450px;
-      background: radial-gradient(circle, var(--purple-400), var(--blue-500) 50%, transparent 70%);
-      bottom: 30%; left: -5%;
-      animation-duration: 26s;
-      animation-delay: -10s;
-      opacity: 0.35;
-    }
-    @keyframes drift {
-      from { transform: translate(0, 0) scale(1); }
-      to   { transform: translate(30px, 20px) scale(1.08); }
-    }
+    ::selection { background: rgba(74, 222, 128, 0.25); color: #eafff2; }
 
-    /* ── Layout ────────────────────────────────────────────────── */
-    .page {
-      position: relative;
-      z-index: 1;
-      max-width: 1100px;
-      margin: 0 auto;
-      padding: 0 16px;
-    }
+    a { color: inherit; }
 
-    /* ── Glass Panel ───────────────────────────────────────────── */
-    .glass {
-      background: var(--glass-bg);
-      border: 1px solid var(--glass-border);
-      border-radius: var(--radius-md);
-      backdrop-filter: var(--blur-md) saturate(1.3);
-      -webkit-backdrop-filter: var(--blur-md) saturate(1.3);
-      box-shadow: var(--shadow-glass);
-    }
-
-    /* ── Nav ────────────────────────────────────────────────────── */
-    nav {
-      position: sticky;
-      top: 0;
-      z-index: 100;
-      padding: 12px 0;
-    }
-    .nav-inner {
-      display: flex;
-      align-items: center;
-      justify-content: space-between;
-      padding: 10px 20px;
-      background: rgba(10, 10, 15, 0.50);
-      border: 1px solid rgba(255, 255, 255, 0.18);
-      border-radius: var(--radius-lg);
-      backdrop-filter: blur(20px) saturate(1.4);
-      -webkit-backdrop-filter: blur(20px) saturate(1.4);
-    }
-    .nav-logo {
-      font-family: var(--font-mono);
-      font-size: 1rem;
-      font-weight: 700;
-      background: linear-gradient(135deg, var(--purple-400), var(--blue-400));
-      -webkit-background-clip: text;
-      -webkit-text-fill-color: transparent;
-      background-clip: text;
-      letter-spacing: -0.02em;
-    }
-    .nav-links {
-      display: flex;
-      gap: 8px;
-      list-style: none;
-    }
-    .nav-links a {
-      font-size: 0.8rem;
-      color: var(--text-secondary);
-      text-decoration: none;
-      padding: 5px 12px;
-      border-radius: var(--radius-sm);
-      transition: var(--transition);
-    }
-    .nav-links a:hover {
-      color: var(--text-primary);
-      background: var(--glass-hover);
-    }
-
-    /* ── Hero ───────────────────────────────────────────────────── */
-    .hero {
-      padding: 72px 0 56px;
-      text-align: center;
-    }
-    .hero-badge {
-      display: inline-flex;
-      align-items: center;
-      gap: 6px;
-      font-size: 0.75rem;
-      font-family: var(--font-mono);
-      color: var(--purple-400);
-      background: rgba(139, 92, 246, 0.12);
-      border: 1px solid rgba(139, 92, 246, 0.25);
-      border-radius: 100px;
-      padding: 4px 14px;
-      margin-bottom: 24px;
-      letter-spacing: 0.05em;
-    }
-    .hero-badge::before {
+    /* ── Atmosphere: faint scanlines + top phosphor glow ─────────── */
+    body::before {
       content: "";
-      width: 6px; height: 6px;
-      border-radius: 50%;
-      background: var(--purple-400);
-      box-shadow: 0 0 8px var(--purple-400);
-      animation: pulse 2s ease-in-out infinite;
+      position: fixed; inset: 0; z-index: 0; pointer-events: none;
+      background:
+        radial-gradient(120% 60% at 50% -10%, rgba(74, 222, 128, 0.06), transparent 60%),
+        radial-gradient(80% 50% at 100% 0%, rgba(86, 182, 194, 0.04), transparent 55%);
     }
-    @keyframes pulse {
-      0%, 100% { opacity: 1; }
-      50% { opacity: 0.4; }
-    }
-    .hero h1 {
-      font-size: clamp(2.8rem, 8vw, 5.5rem);
-      font-weight: 800;
-      letter-spacing: -0.04em;
-      line-height: 1.05;
-      background: linear-gradient(135deg, #fff 20%, var(--purple-400) 55%, var(--blue-400) 100%);
-      -webkit-background-clip: text;
-      -webkit-text-fill-color: transparent;
-      background-clip: text;
-      margin-bottom: 16px;
-    }
-    .hero-tagline {
-      font-size: clamp(1rem, 3vw, 1.25rem);
-      color: var(--text-secondary);
-      max-width: 520px;
-      margin: 0 auto 32px;
-      line-height: 1.7;
-    }
-    .hero-actions {
-      display: flex;
-      gap: 12px;
-      justify-content: center;
-      flex-wrap: wrap;
-    }
-    .btn-primary {
-      display: inline-flex;
-      align-items: center;
-      gap: 8px;
-      padding: 12px 24px;
-      border-radius: var(--radius-sm);
-      font-size: 0.9rem;
-      font-weight: 600;
-      text-decoration: none;
-      background: linear-gradient(135deg, var(--purple-600), var(--blue-500));
-      color: #fff;
-      border: none;
-      cursor: pointer;
-      transition: var(--transition);
-      box-shadow: 0 4px 20px rgba(139, 92, 246, 0.3);
-    }
-    .btn-primary:hover {
-      transform: translateY(-2px);
-      box-shadow: 0 8px 28px rgba(139, 92, 246, 0.45);
-    }
-    .btn-ghost {
-      display: inline-flex;
-      align-items: center;
-      gap: 8px;
-      padding: 12px 24px;
-      border-radius: var(--radius-sm);
-      font-size: 0.9rem;
-      font-weight: 600;
-      text-decoration: none;
-      color: var(--text-primary);
-      background: var(--glass-bg);
-      border: 1px solid var(--glass-border);
-      cursor: pointer;
-      transition: var(--transition);
-      backdrop-filter: var(--blur-md);
-      -webkit-backdrop-filter: var(--blur-md);
-    }
-    .btn-ghost:hover {
-      background: var(--glass-hover);
-      border-color: rgba(255,255,255,0.2);
-      transform: translateY(-2px);
+    body::after {
+      content: "";
+      position: fixed; inset: 0; z-index: 0; pointer-events: none;
+      background-image: repeating-linear-gradient(
+        to bottom, rgba(255, 255, 255, 0.014) 0 1px, transparent 1px 3px);
+      opacity: 0.7;
     }
 
-    /* ── Install Command ────────────────────────────────────────── */
-    .install-section {
-      padding: 0 0 64px;
-    }
-    .install-card {
-      padding: 28px 24px;
-      position: relative;
-    }
-    .install-label {
-      font-size: 0.72rem;
-      font-weight: 600;
-      text-transform: uppercase;
-      letter-spacing: 0.12em;
-      color: var(--text-muted);
-      margin-bottom: 12px;
-    }
-    .install-cmd-wrap {
-      display: flex;
-      align-items: center;
-      gap: 12px;
-      background: rgba(0,0,0,0.35);
-      border: 1px solid rgba(255,255,255,0.07);
-      border-radius: var(--radius-sm);
-      padding: 14px 16px;
-    }
-    .install-cmd {
-      flex: 1;
-      font-family: var(--font-mono);
-      font-size: clamp(0.65rem, 2.5vw, 0.82rem);
-      color: var(--cyan-400);
-      word-break: break-all;
-      white-space: pre-wrap;
-    }
-    .copy-btn {
-      flex-shrink: 0;
-      background: rgba(139, 92, 246, 0.15);
-      border: 1px solid rgba(139, 92, 246, 0.3);
-      border-radius: 6px;
-      color: var(--purple-400);
-      font-size: 0.75rem;
-      font-weight: 600;
-      padding: 6px 14px;
-      cursor: pointer;
-      transition: var(--transition);
-      white-space: nowrap;
-    }
-    .copy-btn:hover {
-      background: rgba(139, 92, 246, 0.28);
-      border-color: rgba(139, 92, 246, 0.5);
-    }
-    .copy-btn.copied {
-      color: var(--cyan-400);
-      background: rgba(34, 211, 238, 0.12);
-      border-color: rgba(34, 211, 238, 0.3);
-    }
+    /* ── Layout ──────────────────────────────────────────────────── */
+    .wrap { position: relative; z-index: 1; max-width: 980px; margin: 0 auto; padding: 0 20px; }
 
-    /* ── Section Headers ────────────────────────────────────────── */
-    .section {
-      padding: 0 0 72px;
+    /* ── Top bar ─────────────────────────────────────────────────── */
+    nav {
+      position: sticky; top: 0; z-index: 50;
+      background: rgba(11, 13, 16, 0.78);
+      border-bottom: 1px solid var(--line);
+      backdrop-filter: blur(8px);
+      -webkit-backdrop-filter: blur(8px);
     }
-    .section-header {
-      margin-bottom: 32px;
+    .nav-row { display: flex; align-items: center; justify-content: space-between; height: 52px; }
+    .brand { font-weight: 700; letter-spacing: -0.01em; color: var(--fg); white-space: nowrap; }
+    .brand .pcwd { color: var(--accent); }
+    .brand .pgt  { color: var(--fg-mute); }
+    .nav-links { display: flex; gap: 4px; list-style: none; }
+    .nav-links a {
+      text-decoration: none; color: var(--fg-dim); font-size: 13px;
+      padding: 6px 10px; border-radius: var(--radius); transition: var(--tr);
     }
-    .section-label {
-      font-size: 0.72rem;
-      font-weight: 700;
-      text-transform: uppercase;
-      letter-spacing: 0.12em;
-      color: var(--purple-400);
-      margin-bottom: 8px;
-    }
-    .section-title {
-      font-size: clamp(1.4rem, 4vw, 2rem);
-      font-weight: 700;
-      letter-spacing: -0.02em;
-      color: var(--text-primary);
-    }
-    .section-desc {
-      margin-top: 8px;
-      font-size: 0.95rem;
-      color: var(--text-secondary);
-      max-width: 560px;
-    }
+    .nav-links a:hover { color: var(--accent); background: var(--line-soft); }
+    .nav-links .ext::after { content: " ↗"; color: var(--fg-mute); }
 
-    /* ── Tool Stack ─────────────────────────────────────────────── */
-    .tools-grid {
-      display: grid;
-      grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
-      gap: 12px;
+    /* ── Hero ────────────────────────────────────────────────────── */
+    .hero { padding: 64px 0 40px; }
+    .kicker {
+      font-size: 12px; letter-spacing: 0.18em; text-transform: uppercase;
+      color: var(--accent); margin-bottom: 18px;
     }
-    .tool-card {
-      padding: 18px 16px;
-      text-align: center;
-      cursor: default;
-      transition: var(--transition);
+    .kicker .tick { color: var(--fg-mute); }
+    h1.title {
+      font-size: clamp(2.6rem, 9vw, 5rem); font-weight: 800; letter-spacing: -0.04em;
+      line-height: 1; color: var(--fg);
     }
-    .tool-card:hover {
-      background: var(--glass-hover);
-      transform: translateY(-4px);
-      box-shadow: var(--shadow-glass), var(--shadow-glow-p);
+    h1.title .sigil { color: var(--accent); }
+    .cursor {
+      display: inline-block; width: 0.55ch; height: 0.92em; transform: translateY(0.06em);
+      background: var(--accent); margin-left: 0.08em;
+      box-shadow: 0 0 10px rgba(74, 222, 128, 0.6);
+      animation: blink 1.15s step-end infinite;
     }
-    .tool-icon {
-      font-size: 1.6rem;
-      margin-bottom: 8px;
-      display: block;
+    @keyframes blink { 0%, 50% { opacity: 1; } 50.01%, 100% { opacity: 0; } }
+    .lede {
+      margin: 22px 0 8px; max-width: 60ch; font-size: 15px; color: var(--fg-dim); line-height: 1.75;
     }
-    .tool-name {
-      font-family: var(--font-mono);
-      font-size: 0.82rem;
-      font-weight: 700;
-      color: var(--text-primary);
-      margin-bottom: 4px;
+    .lede b { color: var(--fg); font-weight: 600; }
+    .rev { font-size: 12.5px; color: var(--fg-mute); margin-bottom: 26px; }
+    .rev .by { color: var(--fg-dim); }
+    .actions { display: flex; gap: 10px; flex-wrap: wrap; }
+    .btn {
+      display: inline-flex; align-items: center; gap: 8px; text-decoration: none;
+      font-size: 13.5px; font-weight: 600; padding: 9px 16px; border-radius: var(--radius);
+      border: 1px solid var(--line); color: var(--fg); background: var(--panel);
+      cursor: pointer; transition: var(--tr);
     }
-    .tool-desc {
-      font-size: 0.7rem;
-      color: var(--text-muted);
-      line-height: 1.4;
-    }
+    .btn:hover { border-color: var(--accent-dim); color: var(--accent); transform: translateY(-1px); }
+    .btn-solid { background: var(--accent); color: #07140c; border-color: var(--accent); }
+    .btn-solid:hover { background: #5ef08f; color: #07140c; box-shadow: 0 6px 22px rgba(74, 222, 128, 0.22); }
 
-    /* ── Feature Cards ──────────────────────────────────────────── */
-    .features-grid {
-      display: grid;
-      grid-template-columns: 1fr;
-      gap: 16px;
+    /* ── Terminal install block ──────────────────────────────────── */
+    .term {
+      border: 1px solid var(--line); border-radius: 6px; background: var(--bg-soft);
+      overflow: hidden; margin-top: 30px;
     }
-    .feature-card {
-      padding: 24px;
-      display: flex;
-      gap: 18px;
-      transition: var(--transition);
+    .term-bar {
+      display: flex; align-items: center; gap: 8px; padding: 9px 14px;
+      border-bottom: 1px solid var(--line); background: var(--panel);
     }
-    .feature-card:hover {
-      background: var(--glass-hover);
-      transform: translateX(4px);
-      box-shadow: var(--shadow-glass);
+    .dot { width: 10px; height: 10px; border-radius: 50%; background: var(--line); }
+    .dot.g { background: var(--accent-dim); }
+    .term-title { margin-left: 6px; font-size: 12px; color: var(--fg-mute); }
+    .term-body { padding: 16px 14px; display: flex; align-items: center; gap: 12px; }
+    .term-body .ps1 { color: var(--accent); flex-shrink: 0; user-select: none; }
+    .cmd {
+      flex: 1; color: var(--fg); font-size: clamp(11px, 2.6vw, 13.5px);
+      word-break: break-all; white-space: pre-wrap;
     }
-    .feature-icon-wrap {
-      flex-shrink: 0;
-      width: 44px; height: 44px;
-      border-radius: 12px;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      font-size: 1.3rem;
+    .copy {
+      flex-shrink: 0; font-family: var(--mono); font-size: 12px; font-weight: 600;
+      color: var(--fg-dim); background: var(--panel); border: 1px solid var(--line);
+      border-radius: var(--radius); padding: 5px 11px; cursor: pointer; transition: var(--tr);
     }
-    .feature-icon-wrap.purple {
-      background: rgba(139, 92, 246, 0.15);
-      border: 1px solid rgba(139, 92, 246, 0.25);
-    }
-    .feature-icon-wrap.blue {
-      background: rgba(59, 130, 246, 0.15);
-      border: 1px solid rgba(59, 130, 246, 0.25);
-    }
-    .feature-icon-wrap.cyan {
-      background: rgba(34, 211, 238, 0.12);
-      border: 1px solid rgba(34, 211, 238, 0.2);
-    }
-    .feature-icon-wrap.pink {
-      background: rgba(244, 114, 182, 0.12);
-      border: 1px solid rgba(244, 114, 182, 0.2);
-    }
-    .feature-content { flex: 1; }
-    .feature-title {
-      font-size: 1rem;
-      font-weight: 700;
-      color: var(--text-primary);
-      margin-bottom: 4px;
-    }
-    .feature-desc {
-      font-size: 0.84rem;
-      color: var(--text-secondary);
-      line-height: 1.6;
-    }
-    .feature-tags {
-      display: flex;
-      flex-wrap: wrap;
-      gap: 6px;
-      margin-top: 10px;
-    }
-    .tag {
-      font-family: var(--font-mono);
-      font-size: 0.67rem;
-      font-weight: 600;
-      padding: 3px 9px;
-      border-radius: 100px;
-      background: rgba(255,255,255,0.06);
-      border: 1px solid rgba(255,255,255,0.1);
-      color: var(--text-secondary);
-    }
+    .copy:hover { color: var(--accent); border-color: var(--accent-dim); }
+    .copy.ok { color: var(--accent); border-color: var(--accent-dim); }
+    .term-foot { padding: 0 14px 14px; font-size: 12.5px; color: var(--fg-mute); }
+    .term-foot code { color: var(--accent); }
 
-    /* ── Commands ───────────────────────────────────────────────── */
-    .commands-grid {
-      display: grid;
-      grid-template-columns: 1fr;
-      gap: 10px;
-    }
-    .command-row {
-      display: flex;
-      align-items: center;
-      gap: 16px;
-      padding: 16px 20px;
-      border-radius: var(--radius-sm);
-      background: rgba(0,0,0,0.3);
-      border: 1px solid rgba(255,255,255,0.07);
-      transition: var(--transition);
-      cursor: default;
-    }
-    .command-row:hover {
-      background: rgba(255,255,255,0.04);
-      border-color: rgba(139, 92, 246, 0.25);
-    }
-    .command-row:hover .cmd-text {
-      color: var(--cyan-400);
-    }
-    .cmd-text {
-      font-family: var(--font-mono);
-      font-size: 0.85rem;
-      color: var(--purple-400);
-      flex: 0 0 auto;
-      min-width: 140px;
-      transition: var(--transition);
-    }
-    .cmd-sep {
-      color: var(--text-muted);
-      font-size: 0.75rem;
-    }
-    .cmd-desc {
-      font-size: 0.84rem;
-      color: var(--text-secondary);
-    }
+    /* ── Section scaffolding (man-page style) ────────────────────── */
+    .sec { padding: 40px 0; border-top: 1px solid var(--line); }
+    .sec-head { display: flex; align-items: baseline; gap: 14px; margin-bottom: 24px; flex-wrap: wrap; }
+    .sec-no { font-size: 12px; color: var(--accent); letter-spacing: 0.1em; flex-shrink: 0; }
+    .sec-title { font-size: 1.05rem; font-weight: 700; letter-spacing: 0.02em; text-transform: uppercase; color: var(--fg); }
+    .sec-desc { font-size: 13px; color: var(--fg-dim); width: 100%; max-width: 64ch; }
 
-    /* ── Badges ─────────────────────────────────────────────────── */
-    .badges-section {
-      padding: 0 0 64px;
+    /* ── Stack grid ──────────────────────────────────────────────── */
+    .grid { display: grid; gap: 1px; background: var(--line); border: 1px solid var(--line); border-radius: 6px; overflow: hidden; }
+    .grid.cols-2 { grid-template-columns: 1fr; }
+    .cell {
+      background: var(--bg-soft); padding: 16px 16px; transition: var(--tr);
     }
-    .badges-card {
-      padding: 28px 24px;
-    }
-    .badges-inner {
-      display: flex;
-      flex-wrap: wrap;
-      gap: 10px;
-      align-items: center;
-    }
-    .badge-item {
-      display: inline-flex;
-      align-items: center;
-      gap: 6px;
-      padding: 6px 14px;
-      border-radius: 100px;
-      font-size: 0.75rem;
-      font-weight: 600;
-      font-family: var(--font-mono);
-      transition: var(--transition);
-    }
-    .badge-item:hover { transform: translateY(-1px); }
-    .badge-item.green {
-      background: rgba(34, 197, 94, 0.12);
-      border: 1px solid rgba(34, 197, 94, 0.25);
-      color: #4ade80;
-    }
-    .badge-item.purple {
-      background: rgba(139, 92, 246, 0.12);
-      border: 1px solid rgba(139, 92, 246, 0.25);
-      color: var(--purple-400);
-    }
-    .badge-item.blue {
-      background: rgba(59, 130, 246, 0.12);
-      border: 1px solid rgba(59, 130, 246, 0.25);
-      color: var(--blue-400);
-    }
-    .badge-item.cyan {
-      background: rgba(34, 211, 238, 0.10);
-      border: 1px solid rgba(34, 211, 238, 0.2);
-      color: var(--cyan-400);
-    }
-    .badge-dot {
-      width: 6px; height: 6px;
-      border-radius: 50%;
-      background: currentColor;
-    }
-    .badge-dot.pulse { animation: pulse 2s infinite; }
+    .cell:hover { background: var(--panel); }
+    .cell .nm { color: var(--accent); font-weight: 700; font-size: 14px; }
+    .cell .vt { color: var(--fg-mute); font-size: 11.5px; margin-left: 6px; }
+    .cell .ds { color: var(--fg-dim); font-size: 12.5px; margin-top: 5px; line-height: 1.55; }
 
-    /* ── Footer ─────────────────────────────────────────────────── */
-    footer {
-      border-top: 1px solid var(--glass-border);
-      padding: 40px 0;
+    /* ── Definition rows (local-dev, commands) ───────────────────── */
+    .rows { border: 1px solid var(--line); border-radius: 6px; overflow: hidden; }
+    .row {
+      display: grid; grid-template-columns: 1fr; gap: 4px 18px; padding: 14px 16px;
+      background: var(--bg-soft); border-top: 1px solid var(--line-soft); transition: var(--tr);
     }
-    .footer-inner {
-      display: flex;
-      flex-direction: column;
-      gap: 16px;
-      align-items: center;
-      text-align: center;
-    }
-    .footer-logo {
-      font-family: var(--font-mono);
-      font-size: 1.1rem;
-      font-weight: 700;
-      background: linear-gradient(135deg, var(--purple-400), var(--blue-400));
-      -webkit-background-clip: text;
-      -webkit-text-fill-color: transparent;
-      background-clip: text;
-    }
-    .footer-desc {
-      font-size: 0.84rem;
-      color: var(--text-muted);
-      max-width: 380px;
-    }
-    .footer-link {
-      display: inline-flex;
-      align-items: center;
-      gap: 8px;
-      color: var(--purple-400);
-      text-decoration: none;
-      font-size: 0.85rem;
-      font-weight: 600;
-      padding: 8px 18px;
-      border: 1px solid rgba(139, 92, 246, 0.25);
-      border-radius: 100px;
-      transition: var(--transition);
-    }
-    .footer-link:hover {
-      background: rgba(139, 92, 246, 0.1);
-      border-color: rgba(139, 92, 246, 0.4);
-      transform: translateY(-2px);
-    }
-    .footer-copy {
-      font-size: 0.75rem;
-      color: var(--text-muted);
-    }
+    .row:first-child { border-top: none; }
+    .row:hover { background: var(--panel); }
+    .row .k { color: var(--accent); font-weight: 700; font-size: 13.5px; }
+    .row:hover .k { text-shadow: 0 0 12px rgba(74, 222, 128, 0.35); }
+    .row .v { color: var(--fg-dim); font-size: 13px; line-height: 1.6; }
+    .row .v .mut { color: var(--fg-mute); }
+    .row .v b { color: var(--fg); font-weight: 600; }
 
-    /* ── Scroll Animations ──────────────────────────────────────── */
-    .reveal {
-      opacity: 0;
-      transform: translateY(24px);
-      transition: opacity 0.6s ease, transform 0.6s ease;
+    /* ── Agents grid ─────────────────────────────────────────────── */
+    .chips { display: flex; flex-wrap: wrap; gap: 8px; margin-top: 4px; }
+    .chip {
+      font-size: 12px; padding: 4px 10px; border-radius: 100px;
+      border: 1px solid var(--line); color: var(--fg-dim); background: var(--bg-soft);
     }
-    .reveal.visible {
-      opacity: 1;
-      transform: translateY(0);
-    }
-    .reveal-delay-1 { transition-delay: 0.1s; }
-    .reveal-delay-2 { transition-delay: 0.2s; }
-    .reveal-delay-3 { transition-delay: 0.3s; }
+    .chip.acc { color: var(--accent); border-color: var(--accent-dim); }
 
-    /* ── Responsive ─────────────────────────────────────────────── */
+    /* ── GRIT doctrine ───────────────────────────────────────────── */
+    .grit { display: grid; grid-template-columns: 1fr; gap: 1px; background: var(--line); border: 1px solid var(--line); border-radius: 6px; overflow: hidden; margin-top: 16px; }
+    .grit .g {
+      background: var(--bg-soft); padding: 14px 16px;
+    }
+    .grit .g .ax { color: var(--accent); font-weight: 700; font-size: 13px; }
+    .grit .g .jp { color: var(--fg-mute); font-size: 11px; margin-left: 6px; }
+    .grit .g .gd { color: var(--fg-dim); font-size: 12px; margin-top: 4px; line-height: 1.5; }
+
+    /* ── Status badges ───────────────────────────────────────────── */
+    .badges { display: flex; flex-wrap: wrap; gap: 8px; }
+    .badge {
+      display: inline-flex; align-items: center; gap: 7px; font-size: 12.5px; font-weight: 600;
+      padding: 6px 13px; border-radius: 100px; border: 1px solid var(--line);
+      background: var(--bg-soft); color: var(--fg-dim);
+    }
+    .badge .bd { width: 6px; height: 6px; border-radius: 50%; background: currentColor; }
+    .badge.ok { color: var(--accent); border-color: var(--accent-dim); }
+    .badge.ok .bd { box-shadow: 0 0 8px var(--accent); animation: pulse 2.4s ease-in-out infinite; }
+    @keyframes pulse { 0%, 100% { opacity: 1; } 50% { opacity: 0.35; } }
+
+    /* ── Footer ──────────────────────────────────────────────────── */
+    footer { border-top: 1px solid var(--line); padding: 32px 0 48px; }
+    .foot-row { display: flex; flex-wrap: wrap; gap: 16px; align-items: center; justify-content: space-between; }
+    .foot-brand { color: var(--fg); font-weight: 700; }
+    .foot-brand .pcwd { color: var(--accent); }
+    .foot-meta { font-size: 12px; color: var(--fg-mute); }
+    .foot-link { color: var(--fg-dim); text-decoration: none; font-size: 13px; transition: var(--tr); }
+    .foot-link:hover { color: var(--accent); }
+
+    /* ── Reveal on scroll ────────────────────────────────────────── */
+    .rv { opacity: 0; transform: translateY(14px); transition: opacity 0.5s ease, transform 0.5s ease; }
+    .rv.in { opacity: 1; transform: none; }
+
+    /* ── Skip link ───────────────────────────────────────────────── */
+    .skip { position: absolute; left: 16px; top: -60px; background: var(--accent); color: #07140c; font-weight: 700; padding: 8px 14px; border-radius: var(--radius); text-decoration: none; z-index: 200; transition: top 0.2s; }
+    .skip:focus { top: 12px; }
+
+    :focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+
+    /* ── Responsive ──────────────────────────────────────────────── */
     @media (min-width: 640px) {
-      .page { padding: 0 24px; }
-      .features-grid { grid-template-columns: repeat(2, 1fr); }
-      .commands-grid { grid-template-columns: 1fr; }
-      .footer-inner { flex-direction: row; justify-content: space-between; text-align: left; }
+      .grid.cols-2 { grid-template-columns: repeat(2, 1fr); }
+      .row { grid-template-columns: 200px 1fr; align-items: baseline; }
+      .grit { grid-template-columns: repeat(2, 1fr); }
+    }
+    @media (min-width: 900px) {
+      .grid.cols-4 { grid-template-columns: repeat(4, 1fr); }
+      .grit { grid-template-columns: repeat(4, 1fr); }
     }
 
-    @media (min-width: 1024px) {
-      .page { padding: 0 32px; }
-      .tools-grid { grid-template-columns: repeat(4, 1fr); }
-      .features-grid { grid-template-columns: repeat(2, 1fr); }
-      .hero { padding: 100px 0 72px; }
-    }
-
-    /* ── Skip Link ──────────────────────────────────────────────── */
-    .skip-link {
-      position: absolute;
-      top: -100%;
-      left: 16px;
-      padding: 8px 16px;
-      background: var(--purple-500);
-      color: #fff;
-      font-size: 0.875rem;
-      font-weight: 600;
-      border-radius: var(--radius-sm);
-      text-decoration: none;
-      z-index: 9999;
-      transition: top 0.2s;
-    }
-    .skip-link:focus {
-      top: 16px;
-    }
-
-    /* ── Divider ────────────────────────────────────────────────── */
-    .divider {
-      height: 1px;
-      background: linear-gradient(90deg, transparent, var(--glass-border), transparent);
-      margin: 0 0 64px;
+    @media (prefers-reduced-motion: reduce) {
+      *, *::before, *::after { animation: none !important; transition: none !important; }
+      .cursor { opacity: 1; }
+      .rv { opacity: 1; transform: none; }
+      html { scroll-behavior: auto; }
     }
   </style>
 </head>
 <body>
+  <a href="#main" class="skip">Skip to main content</a>
 
-  <!-- Skip navigation -->
-  <a href="#main-content" class="skip-link">Skip to main content</a>
-
-  <!-- Ambient background -->
-  <div class="ambient" aria-hidden="true">
-    <div class="ambient-orb"></div>
-    <div class="ambient-orb"></div>
-    <div class="ambient-orb"></div>
-    <div class="ambient-orb"></div>
-    <div class="ambient-orb"></div>
-  </div>
-
-  <!-- Navigation -->
-  <nav aria-label="Primary navigation">
-    <div class="page">
-      <div class="nav-inner">
-        <span class="nav-logo">~/dotfiles</span>
-        <ul class="nav-links" role="list">
-          <li><a href="#tools">Tools</a></li>
-          <li><a href="#features">Features</a></li>
-          <li><a href="#usage">Usage</a></li>
-          <li><a href="https://github.com/hironow/dotfiles" target="_blank" rel="noopener noreferrer">GitHub</a></li>
-        </ul>
-      </div>
+  <!-- Top bar -->
+  <nav aria-label="Primary">
+    <div class="wrap nav-row">
+      <span class="brand"><span class="pcwd">~/dotfiles</span> <span class="pgt">❯</span></span>
+      <ul class="nav-links" role="list">
+        <li><a href="#install">install</a></li>
+        <li><a href="#stack">stack</a></li>
+        <li><a href="#local">local-dev</a></li>
+        <li><a href="#agents">agents</a></li>
+        <li><a href="https://github.com/hironow/dotfiles" class="ext" target="_blank" rel="noopener noreferrer">source</a></li>
+      </ul>
     </div>
   </nav>
 
-  <main id="main-content">
-    <div class="page">
+  <main id="main">
+    <div class="wrap">
 
       <!-- Hero -->
-      <section class="hero" aria-labelledby="hero-title">
-        <div class="hero-badge" role="status" aria-label="Status: Active — Cross-platform, 2026">CROSS-PLATFORM · 2026</div>
-        <h1 id="hero-title">dotfiles</h1>
-        <p class="hero-tagline">
-          A modern, opinionated developer environment for Mac, Linux, and WSL —
-          fully automated, reproducible, and built for speed.
+      <header class="hero">
+        <div class="kicker">cross-platform <span class="tick">·</span> mac / linux / wsl <span class="tick">·</span> rev 2026.05</div>
+        <h1 class="title"><span class="sigil">~/</span>dotfiles<span class="cursor" aria-hidden="true"></span></h1>
+        <p class="lede">
+          A reproducible developer environment built on <b>Zsh · mise · just · uv</b>,
+          wired for <b>multi-agent AI workflows</b> and a complete <b>local-dev stack</b> —
+          datastore &amp; SaaS emulators, OpenTelemetry observability, and stable
+          <b>https://*.localhost</b> routing. One command on a fresh machine.
         </p>
-        <p class="hero-meta" style="font-size:0.78rem;color:var(--text-muted);margin-bottom:24px;">
-          By <span class="byline" rel="author">hironow</span> &mdash; Updated <time datetime="2026-03-21" pubdate>March 21, 2026</time>
-        </p>
-        <div class="hero-actions">
-          <a href="#install" class="btn-primary">
-            <svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true">
-              <path d="M8 2v9M4 7l4 4 4-4M2 14h12" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
-            </svg>
-            Quick Install
-          </a>
-          <a href="https://github.com/hironow/dotfiles" class="btn-ghost" target="_blank" rel="noopener noreferrer">
-            <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
-              <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/>
-            </svg>
-            View on GitHub
-          </a>
+        <p class="rev">maintained by <span class="by">hironow</span> · updated <time datetime="2026-05-30">2026-05-30</time> · MIT</p>
+        <div class="actions">
+          <a href="#install" class="btn btn-solid">▾ quick install</a>
+          <a href="https://github.com/hironow/dotfiles" class="btn" target="_blank" rel="noopener noreferrer">source ↗</a>
+        </div>
+
+        <!-- Install terminal -->
+        <section class="term" id="install" aria-label="One-liner install">
+          <div class="term-bar" aria-hidden="true">
+            <span class="dot"></span><span class="dot"></span><span class="dot g"></span>
+            <span class="term-title">bash — fresh machine bootstrap</span>
+          </div>
+          <div class="term-body">
+            <span class="ps1" aria-hidden="true">$</span>
+            <code class="cmd" id="cmd">bash -c "$(curl -fsSL https://raw.githubusercontent.com/hironow/dotfiles/main/install.sh)"</code>
+            <button class="copy" id="copy" onclick="copyCmd()" aria-label="Copy install command">copy</button>
+          </div>
+          <p class="term-foot">already cloned? run <code>just install</code> — or <code>just deploy</code> to relink on the current host.</p>
+        </section>
+      </header>
+
+      <!-- §01 STACK -->
+      <section class="sec rv" id="stack" aria-labelledby="s1">
+        <div class="sec-head">
+          <span class="sec-no">§01</span>
+          <h2 class="sec-title" id="s1">Stack</h2>
+          <p class="sec-desc">Hand-picked CLI tooling, version-pinned through <code>mise</code> and lock files for byte-reproducible environments.</p>
+        </div>
+        <div class="grid cols-4" role="list">
+          <div class="cell" role="listitem"><span class="nm">zsh</span><div class="ds">interactive shell — Sheldon plugins, Starship prompt</div></div>
+          <div class="cell" role="listitem"><span class="nm">mise</span><div class="ds">polyglot runtime + tool version manager</div></div>
+          <div class="cell" role="listitem"><span class="nm">just</span><div class="ds">command runner — one interface, 20 task groups</div></div>
+          <div class="cell" role="listitem"><span class="nm">uv</span><div class="ds">Rust-fast Python package &amp; venv manager</div></div>
+          <div class="cell" role="listitem"><span class="nm">prek</span><div class="ds">Rust pre-commit — fmt / lint / semgrep gates</div></div>
+          <div class="cell" role="listitem"><span class="nm">ruff <span class="vt">+ semgrep</span></span><div class="ds">lint, format &amp; project guardrail rules</div></div>
+          <div class="cell" role="listitem"><span class="nm">fzf</span><div class="ds">fuzzy finder wired across the shell</div></div>
+          <div class="cell" role="listitem"><span class="nm">ghostty</span><div class="ds">GPU-accelerated terminal emulator</div></div>
         </div>
       </section>
 
-      <!-- Install -->
-      <section class="install-section reveal" id="install" aria-labelledby="install-label">
-        <div class="glass install-card">
-          <div class="install-label" id="install-label">One-liner Install</div>
-          <div class="install-cmd-wrap">
-            <code class="install-cmd" id="install-cmd-text">bash -c "$(curl -fsSL https://raw.githubusercontent.com/hironow/dotfiles/main/install.sh)"</code>
-            <button class="copy-btn" id="copy-btn" aria-label="Copy install command to clipboard" onclick="copyInstall()">Copy</button>
+      <!-- §02 LOCAL DEV -->
+      <section class="sec rv" id="local" aria-labelledby="s2">
+        <div class="sec-head">
+          <span class="sec-no">§02</span>
+          <h2 class="sec-title" id="s2">Local-dev stack</h2>
+          <p class="sec-desc">First-party, vendored, Docker-Composed. Bring up datastore &amp; SaaS emulators with telemetry, and reach every HTTP UI by name over HTTPS — no port numbers to memorize.</p>
+        </div>
+        <div class="rows" role="list">
+          <div class="row" role="listitem">
+            <span class="k">emulator</span>
+            <span class="v"><b>13 services</b> — Firebase, Bigtable, Spanner, pgAdapter, Postgres, Neo4j, Qdrant, Elasticsearch, MLflow, A2A &amp; MCP inspectors. <span class="mut">just emu-start</span></span>
           </div>
-        </div>
-      </section>
-
-      <div class="divider" aria-hidden="true"></div>
-
-      <!-- Tool Stack -->
-      <section class="section reveal" id="tools" aria-labelledby="tools-title">
-        <div class="section-header">
-          <div class="section-label">Tool Stack</div>
-          <h2 class="section-title" id="tools-title">Modern CLI Arsenal</h2>
-          <p class="section-desc">Hand-picked tools that work in harmony across every shell session.</p>
-        </div>
-        <div class="tools-grid" role="list">
-          <article class="glass tool-card reveal reveal-delay-1" role="listitem">
-            <span class="tool-icon" aria-hidden="true">🐚</span>
-            <div class="tool-name">Zsh</div>
-            <div class="tool-desc">Powerful interactive shell with rich plugin ecosystem</div>
-          </article>
-          <article class="glass tool-card reveal reveal-delay-1" role="listitem">
-            <span class="tool-icon" aria-hidden="true">🛠️</span>
-            <div class="tool-name">Mise</div>
-            <div class="tool-desc">Polyglot runtime manager — Node, Python, Go and more</div>
-          </article>
-          <article class="glass tool-card reveal reveal-delay-2" role="listitem">
-            <span class="tool-icon" aria-hidden="true">⚡</span>
-            <div class="tool-name">Just</div>
-            <div class="tool-desc">Modern command runner with clean, readable justfiles</div>
-          </article>
-          <article class="glass tool-card reveal reveal-delay-2" role="listitem">
-            <span class="tool-icon" aria-hidden="true">🐍</span>
-            <div class="tool-name">uv</div>
-            <div class="tool-desc">Blazing-fast Python package manager written in Rust</div>
-          </article>
-          <article class="glass tool-card reveal reveal-delay-3" role="listitem">
-            <span class="tool-icon" aria-hidden="true">🔌</span>
-            <div class="tool-name">Sheldon</div>
-            <div class="tool-desc">Fast, lock-file-based Zsh plugin manager</div>
-          </article>
-          <article class="glass tool-card reveal reveal-delay-3" role="listitem">
-            <span class="tool-icon" aria-hidden="true">⭐</span>
-            <div class="tool-name">Starship</div>
-            <div class="tool-desc">Minimal, fast cross-shell prompt with rich context</div>
-          </article>
-          <article class="glass tool-card reveal reveal-delay-1" role="listitem">
-            <span class="tool-icon" aria-hidden="true">🔍</span>
-            <div class="tool-name">fzf</div>
-            <div class="tool-desc">General-purpose fuzzy finder for the terminal</div>
-          </article>
-          <article class="glass tool-card reveal reveal-delay-2" role="listitem">
-            <span class="tool-icon" aria-hidden="true">👻</span>
-            <div class="tool-name">Ghostty</div>
-            <div class="tool-desc">GPU-accelerated terminal emulator, native speed</div>
-          </article>
-        </div>
-      </section>
-
-      <div class="divider" aria-hidden="true"></div>
-
-      <!-- Features -->
-      <section class="section reveal" id="features" aria-labelledby="features-title">
-        <div class="section-header">
-          <div class="section-label">Features</div>
-          <h2 class="section-title" id="features-title">Everything Included</h2>
-          <p class="section-desc">From shell configuration to AI agent integration — batteries included.</p>
-        </div>
-        <div class="features-grid">
-          <article class="glass feature-card reveal reveal-delay-1">
-            <div class="feature-icon-wrap blue" aria-hidden="true">🌐</div>
-            <div class="feature-content">
-              <div class="feature-title">Cross-Platform Support</div>
-              <div class="feature-desc">Works natively on macOS, Linux distributions, and Windows Subsystem for Linux without modification.</div>
-              <div class="feature-tags">
-                <span class="tag">macOS</span>
-                <span class="tag">Linux</span>
-                <span class="tag">WSL</span>
-              </div>
-            </div>
-          </article>
-          <article class="glass feature-card reveal reveal-delay-2">
-            <div class="feature-icon-wrap purple" aria-hidden="true">⚡</div>
-            <div class="feature-content">
-              <div class="feature-title">Task Runner</div>
-              <div class="feature-desc">Unified task automation via <code style="font-family:var(--font-mono);color:var(--purple-400)">just</code> — consistent commands for install, deploy, test, and sync.</div>
-              <div class="feature-tags">
-                <span class="tag">just help</span>
-                <span class="tag">just install</span>
-                <span class="tag">just deploy</span>
-              </div>
-            </div>
-          </article>
-          <article class="glass feature-card reveal reveal-delay-1">
-            <div class="feature-icon-wrap cyan" aria-hidden="true">📦</div>
-            <div class="feature-content">
-              <div class="feature-title">Package Management</div>
-              <div class="feature-desc">Mise handles runtime versions; uv manages Python packages. Reproducible environments guaranteed.</div>
-              <div class="feature-tags">
-                <span class="tag">mise</span>
-                <span class="tag">uv</span>
-                <span class="tag">lock files</span>
-              </div>
-            </div>
-          </article>
-          <article class="glass feature-card reveal reveal-delay-2">
-            <div class="feature-icon-wrap purple" aria-hidden="true">🐚</div>
-            <div class="feature-content">
-              <div class="feature-title">Shell Configuration</div>
-              <div class="feature-desc">Opinionated Zsh setup with Sheldon for plugins and Starship for a beautiful, informative prompt.</div>
-              <div class="feature-tags">
-                <span class="tag">zsh</span>
-                <span class="tag">sheldon</span>
-                <span class="tag">starship</span>
-              </div>
-            </div>
-          </article>
-          <article class="glass feature-card reveal reveal-delay-1">
-            <div class="feature-icon-wrap pink" aria-hidden="true">🤖</div>
-            <div class="feature-content">
-              <div class="feature-title">MCP Servers</div>
-              <div class="feature-desc">Model Context Protocol server integration for AI-powered workflows directly from your terminal environment.</div>
-              <div class="feature-tags">
-                <span class="tag">MCP</span>
-                <span class="tag">AI agents</span>
-                <span class="tag">automation</span>
-              </div>
-            </div>
-          </article>
-          <article class="glass feature-card reveal reveal-delay-2">
-            <div class="feature-icon-wrap blue" aria-hidden="true">🔌</div>
-            <div class="feature-content">
-              <div class="feature-title">Skills &amp; Plugins</div>
-              <div class="feature-desc">Extensible plugin marketplace system for adding capabilities and integrations to your development workflow.</div>
-              <div class="feature-tags">
-                <span class="tag">plugins</span>
-                <span class="tag">skills</span>
-                <span class="tag">extensible</span>
-              </div>
-            </div>
-          </article>
-        </div>
-      </section>
-
-      <div class="divider" aria-hidden="true"></div>
-
-      <!-- Usage Commands -->
-      <section class="section reveal" id="usage" aria-labelledby="usage-title">
-        <div class="section-header">
-          <div class="section-label">Quick Usage</div>
-          <h2 class="section-title" id="usage-title">Common Commands</h2>
-          <p class="section-desc">All operations go through <code style="font-family:var(--font-mono);color:var(--purple-400)">just</code> — one interface to rule them all.</p>
-        </div>
-        <div class="commands-grid" role="list">
-          <div class="command-row reveal reveal-delay-1" role="listitem">
-            <span class="cmd-text">just help</span>
-            <span class="cmd-sep">·</span>
-            <span class="cmd-desc">Display all available commands and their descriptions</span>
+          <div class="row" role="listitem">
+            <span class="k">telemetry</span>
+            <span class="v"><b>OpenTelemetry</b> collector → Grafana · Prometheus · Tempo · Loki, on a shared OTel network. <span class="mut">just tel-up</span></span>
           </div>
-          <div class="command-row reveal reveal-delay-1" role="listitem">
-            <span class="cmd-text">just install</span>
-            <span class="cmd-sep">·</span>
-            <span class="cmd-desc">Bootstrap the full environment on a new machine</span>
+          <div class="row" role="listitem">
+            <span class="k">emulate</span>
+            <span class="v"><b>9 API emulators</b> — GitHub, Google, Slack, Apple, Microsoft, Stripe, Clerk, Okta, Resend (ports 4100–4108). <span class="mut">just emu-api</span></span>
           </div>
-          <div class="command-row reveal reveal-delay-2" role="listitem">
-            <span class="cmd-text">just deploy</span>
-            <span class="cmd-sep">·</span>
-            <span class="cmd-desc">Apply dotfile changes to the current system</span>
-          </div>
-          <div class="command-row reveal reveal-delay-2" role="listitem">
-            <span class="cmd-text">just test</span>
-            <span class="cmd-sep">·</span>
-            <span class="cmd-desc">Run the full test suite to validate configuration</span>
-          </div>
-          <div class="command-row reveal reveal-delay-3" role="listitem">
-            <span class="cmd-text">just sync-agents</span>
-            <span class="cmd-sep">·</span>
-            <span class="cmd-desc">Synchronize AI agent configurations and MCP servers</span>
+          <div class="row" role="listitem">
+            <span class="k">portless</span>
+            <span class="v">stable <b>https://&lt;name&gt;.localhost</b> routes via a trusted local CA — <span class="mut">grafana.localhost, firebase.localhost, stripe.localhost …</span> <span class="mut">just portless-up · just portless-doc</span></span>
           </div>
         </div>
       </section>
 
-      <div class="divider" aria-hidden="true"></div>
-
-      <!-- CI Badges -->
-      <section class="badges-section reveal" aria-labelledby="badges-title">
-        <div class="glass badges-card">
-          <div class="section-label" id="badges-title" style="margin-bottom:16px">Status &amp; Info</div>
-          <div class="badges-inner" role="list">
-            <span class="badge-item green" role="listitem">
-              <span class="badge-dot pulse" aria-hidden="true"></span>
-              CI: passing
-            </span>
-            <span class="badge-item purple" role="listitem">
-              <span class="badge-dot" aria-hidden="true"></span>
-              Shell: Zsh
-            </span>
-            <span class="badge-item blue" role="listitem">
-              <span class="badge-dot" aria-hidden="true"></span>
-              Platform: cross-platform
-            </span>
-            <span class="badge-item cyan" role="listitem">
-              <span class="badge-dot" aria-hidden="true"></span>
-              License: MIT
-            </span>
-            <span class="badge-item purple" role="listitem">
-              <span class="badge-dot" aria-hidden="true"></span>
-              Powered by: mise · uv · just
-            </span>
-            <span class="badge-item green" role="listitem">
-              <span class="badge-dot" aria-hidden="true"></span>
-              MCP: enabled
+      <!-- §03 AGENTS -->
+      <section class="sec rv" id="agents" aria-labelledby="s3">
+        <div class="sec-head">
+          <span class="sec-no">§03</span>
+          <h2 class="sec-title" id="s3">Agentic workflow</h2>
+          <p class="sec-desc">A multi-agent cockpit: several coding-agent CLIs pinned side by side, a plugin suite of autonomous loops, and a TDD + GRIT doctrine encoded in <code>ROOT_AGENTS.md</code>.</p>
+        </div>
+        <div class="rows" role="list">
+          <div class="row" role="listitem">
+            <span class="k">agent CLIs</span>
+            <span class="v">pinned via mise, runnable through <code>just</code>:
+              <span class="chips">
+                <span class="chip acc">claude-code</span><span class="chip">codex</span><span class="chip">gemini-cli</span><span class="chip">copilot</span><span class="chip">pi</span>
+              </span>
             </span>
           </div>
+          <div class="row" role="listitem">
+            <span class="k">plugins</span>
+            <span class="v">autonomous loops &amp; rituals:
+              <span class="chips">
+                <span class="chip">autodesign</span><span class="chip">autoresearch</span><span class="chip">autoreview</span><span class="chip">grilling</span><span class="chip">paintress</span>
+              </span>
+            </span>
+          </div>
+          <div class="row" role="listitem">
+            <span class="k">guardrails</span>
+            <span class="v">TDD (Red → Green → Refactor), Tidy First, Conventional Commits, ADRs, and <b>semgrep</b> rules self-tested in CI. <span class="mut">just ci</span></span>
+          </div>
+        </div>
+
+        <div class="grit" role="list" aria-label="GRIT doctrine">
+          <div class="g" role="listitem"><span class="ax">Guts</span><span class="jp">度胸</span><div class="gd">move into the scariest unknown first</div></div>
+          <div class="g" role="listitem"><span class="ax">Resilience</span><span class="jp">粘り</span><div class="gd">a failure is a signal to adapt, not stop</div></div>
+          <div class="g" role="listitem"><span class="ax">Initiative</span><span class="jp">主体性</span><div class="gd">do the obvious next step un-prompted</div></div>
+          <div class="g" role="listitem"><span class="ax">Tenacity</span><span class="jp">執念</span><div class="gd">define "done" and grind to it, proven</div></div>
         </div>
       </section>
 
-    </div><!-- /.page -->
+      <!-- §04 COMMANDS -->
+      <section class="sec rv" id="commands" aria-labelledby="s4">
+        <div class="sec-head">
+          <span class="sec-no">§04</span>
+          <h2 class="sec-title" id="s4">Commands</h2>
+          <p class="sec-desc">Everything routes through <code>just</code> — <code>just</code> alone (or <code>just help</code>) lists all task groups.</p>
+        </div>
+        <div class="rows" role="list">
+          <div class="row" role="listitem"><span class="k">just install</span><span class="v">bootstrap the full environment on a new machine</span></div>
+          <div class="row" role="listitem"><span class="k">just deploy</span><span class="v">symlink dotfiles onto the current host (idempotent)</span></div>
+          <div class="row" role="listitem"><span class="k">just ci</span><span class="v">fast gate — lint / format / semgrep rule self-tests / IaC tests <span class="mut">(no Docker)</span></span></div>
+          <div class="row" role="listitem"><span class="k">just test</span><span class="v">dev-container sandbox suite (snapshots tracked files only)</span></div>
+          <div class="row" role="listitem"><span class="k">just emu-start · emu-api</span><span class="v">bring up datastore emulators · API/SaaS emulators</span></div>
+          <div class="row" role="listitem"><span class="k">just tel-up · portless-up</span><span class="v">launch telemetry · register <code>.localhost</code> routes</span></div>
+          <div class="row" role="listitem"><span class="k">just emu-stop · tel-down · emu-api-stop</span><span class="v">tear each stack back down</span></div>
+        </div>
+      </section>
+
+      <!-- §05 STATUS -->
+      <section class="sec rv" aria-labelledby="s5">
+        <div class="sec-head">
+          <span class="sec-no">§05</span>
+          <h2 class="sec-title" id="s5">Status</h2>
+        </div>
+        <div class="badges" role="list">
+          <span class="badge ok" role="listitem"><span class="bd"></span>CI passing</span>
+          <span class="badge ok" role="listitem"><span class="bd"></span>Dependabot 0</span>
+          <span class="badge" role="listitem"><span class="bd"></span>cross-platform</span>
+          <span class="badge" role="listitem"><span class="bd"></span>Dev Container</span>
+          <span class="badge" role="listitem"><span class="bd"></span>OTel-instrumented</span>
+          <span class="badge" role="listitem"><span class="bd"></span>MIT</span>
+        </div>
+      </section>
+
+    </div>
   </main>
 
-  <!-- Footer -->
   <footer role="contentinfo">
-    <div class="page">
-      <div class="footer-inner">
-        <div>
-          <div class="footer-logo">~/dotfiles</div>
-          <p class="footer-desc">Modern developer environment by hironow. Open source and free forever.</p>
-        </div>
-        <div style="display:flex;flex-direction:column;gap:12px;align-items:flex-end;">
-          <a href="https://github.com/hironow/dotfiles" class="footer-link" target="_blank" rel="noopener noreferrer" aria-label="View dotfiles on GitHub">
-            <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
-              <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/>
-            </svg>
-            github.com/hironow/dotfiles
-          </a>
-          <p class="footer-copy">&copy; 2026 hironow. MIT License.</p>
-        </div>
-      </div>
+    <div class="wrap foot-row">
+      <span class="foot-brand"><span class="pcwd">~/dotfiles</span> ❯ <span class="foot-meta">open source &amp; free, by hironow</span></span>
+      <a class="foot-link" href="https://github.com/hironow/dotfiles" target="_blank" rel="noopener noreferrer">github.com/hironow/dotfiles ↗</a>
+      <span class="foot-meta">© 2026 hironow · MIT License</span>
     </div>
   </footer>
 
   <script>
-    // ── Copy install command ──────────────────────────────────────
-    function copyInstall() {
-      const text = document.getElementById('install-cmd-text').textContent;
-      const btn  = document.getElementById('copy-btn');
-      navigator.clipboard.writeText(text).then(() => {
-        btn.textContent = 'Copied!';
-        btn.classList.add('copied');
-        setTimeout(() => {
-          btn.textContent = 'Copy';
-          btn.classList.remove('copied');
-        }, 2000);
-      }).catch(() => {
-        // Fallback for older browsers
-        const ta = document.createElement('textarea');
-        ta.value = text;
-        ta.style.cssText = 'position:fixed;opacity:0;';
-        document.body.appendChild(ta);
-        ta.select();
-        document.execCommand('copy');
-        document.body.removeChild(ta);
-        btn.textContent = 'Copied!';
-        btn.classList.add('copied');
-        setTimeout(() => {
-          btn.textContent = 'Copy';
-          btn.classList.remove('copied');
-        }, 2000);
-      });
+    // Copy install command
+    function copyCmd() {
+      var text = document.getElementById('cmd').textContent;
+      var btn = document.getElementById('copy');
+      var done = function () {
+        btn.textContent = 'copied ✓'; btn.classList.add('ok');
+        setTimeout(function () { btn.textContent = 'copy'; btn.classList.remove('ok'); }, 1800);
+      };
+      if (navigator.clipboard && navigator.clipboard.writeText) {
+        navigator.clipboard.writeText(text).then(done).catch(fallback);
+      } else { fallback(); }
+      function fallback() {
+        var ta = document.createElement('textarea');
+        ta.value = text; ta.style.cssText = 'position:fixed;opacity:0;';
+        document.body.appendChild(ta); ta.select();
+        try { document.execCommand('copy'); } catch (e) {}
+        document.body.removeChild(ta); done();
+      }
     }
 
-    // ── Scroll reveal (IntersectionObserver) ─────────────────────
+    // Reveal on scroll
     (function () {
+      var els = document.querySelectorAll('.rv');
       if (!('IntersectionObserver' in window)) {
-        // Fallback: show all elements immediately
-        document.querySelectorAll('.reveal').forEach(el => el.classList.add('visible'));
-        return;
+        els.forEach(function (el) { el.classList.add('in'); }); return;
       }
-      const io = new IntersectionObserver((entries) => {
-        entries.forEach(entry => {
-          if (entry.isIntersecting) {
-            entry.target.classList.add('visible');
-            io.unobserve(entry.target);
-          }
+      var io = new IntersectionObserver(function (entries) {
+        entries.forEach(function (e) {
+          if (e.isIntersecting) { e.target.classList.add('in'); io.unobserve(e.target); }
         });
-      }, { threshold: 0.1, rootMargin: '0px 0px -40px 0px' });
-
-      document.querySelectorAll('.reveal').forEach(el => io.observe(el));
+      }, { threshold: 0.12, rootMargin: '0px 0px -40px 0px' });
+      els.forEach(function (el) { io.observe(el); });
     })();
   </script>
 </body>

--- a/index.html
+++ b/index.html
@@ -49,20 +49,11 @@
 
     a { color: inherit; }
 
-    /* ── Atmosphere: faint scanlines + top phosphor glow ─────────── */
+    /* ── Atmosphere: one faint top phosphor glow ─────────────────── */
     body::before {
       content: "";
       position: fixed; inset: 0; z-index: 0; pointer-events: none;
-      background:
-        radial-gradient(120% 60% at 50% -10%, rgba(74, 222, 128, 0.06), transparent 60%),
-        radial-gradient(80% 50% at 100% 0%, rgba(86, 182, 194, 0.04), transparent 55%);
-    }
-    body::after {
-      content: "";
-      position: fixed; inset: 0; z-index: 0; pointer-events: none;
-      background-image: repeating-linear-gradient(
-        to bottom, rgba(255, 255, 255, 0.014) 0 1px, transparent 1px 3px);
-      opacity: 0.7;
+      background: radial-gradient(110% 48% at 50% -12%, rgba(74, 222, 128, 0.04), transparent 62%);
     }
 
     /* ── Layout ──────────────────────────────────────────────────── */
@@ -71,10 +62,8 @@
     /* ── Top bar ─────────────────────────────────────────────────── */
     nav {
       position: sticky; top: 0; z-index: 50;
-      background: rgba(11, 13, 16, 0.78);
+      background: rgba(11, 13, 16, 0.94);
       border-bottom: 1px solid var(--line);
-      backdrop-filter: blur(8px);
-      -webkit-backdrop-filter: blur(8px);
     }
     .nav-row { display: flex; align-items: center; justify-content: space-between; height: 52px; }
     .brand { font-weight: 700; letter-spacing: -0.01em; color: var(--fg); white-space: nowrap; }
@@ -103,7 +92,6 @@
     .cursor {
       display: inline-block; width: 0.55ch; height: 0.92em; transform: translateY(0.06em);
       background: var(--accent); margin-left: 0.08em;
-      box-shadow: 0 0 10px rgba(74, 222, 128, 0.6);
       animation: blink 1.15s step-end infinite;
     }
     @keyframes blink { 0%, 50% { opacity: 1; } 50.01%, 100% { opacity: 0; } }
@@ -129,14 +117,7 @@
       border: 1px solid var(--line); border-radius: 6px; background: var(--bg-soft);
       overflow: hidden; margin-top: 30px;
     }
-    .term-bar {
-      display: flex; align-items: center; gap: 8px; padding: 9px 14px;
-      border-bottom: 1px solid var(--line); background: var(--panel);
-    }
-    .dot { width: 10px; height: 10px; border-radius: 50%; background: var(--line); }
-    .dot.g { background: var(--accent-dim); }
-    .term-title { margin-left: 6px; font-size: 12px; color: var(--fg-mute); }
-    .term-body { padding: 16px 14px; display: flex; align-items: center; gap: 12px; }
+    .term-body { padding: 15px 14px; display: flex; align-items: center; gap: 12px; }
     .term-body .ps1 { color: var(--accent); flex-shrink: 0; user-select: none; }
     .cmd {
       flex: 1; color: var(--fg); font-size: clamp(11px, 2.6vw, 13.5px);
@@ -179,7 +160,6 @@
     .row:first-child { border-top: none; }
     .row:hover { background: var(--panel); }
     .row .k { color: var(--accent); font-weight: 700; font-size: 13.5px; }
-    .row:hover .k { text-shadow: 0 0 12px rgba(74, 222, 128, 0.35); }
     .row .v { color: var(--fg-dim); font-size: 13px; line-height: 1.6; }
     .row .v .mut { color: var(--fg-mute); }
     .row .v b { color: var(--fg); font-weight: 600; }
@@ -210,8 +190,6 @@
     }
     .badge .bd { width: 6px; height: 6px; border-radius: 50%; background: currentColor; }
     .badge.ok { color: var(--accent); border-color: var(--accent-dim); }
-    .badge.ok .bd { box-shadow: 0 0 8px var(--accent); animation: pulse 2.4s ease-in-out infinite; }
-    @keyframes pulse { 0%, 100% { opacity: 1; } 50% { opacity: 0.35; } }
 
     /* ── Footer ──────────────────────────────────────────────────── */
     footer { border-top: 1px solid var(--line); padding: 32px 0 48px; }
@@ -289,10 +267,6 @@
 
         <!-- Install terminal -->
         <section class="term" id="install" aria-label="One-liner install">
-          <div class="term-bar" aria-hidden="true">
-            <span class="dot"></span><span class="dot"></span><span class="dot g"></span>
-            <span class="term-title">bash — fresh machine bootstrap</span>
-          </div>
           <div class="term-body">
             <span class="ps1" aria-hidden="true">$</span>
             <code class="cmd" id="cmd">bash -c "$(curl -fsSL https://raw.githubusercontent.com/hironow/dotfiles/main/install.sh)"</code>

--- a/index.html
+++ b/index.html
@@ -123,17 +123,30 @@
     .copy:hover { color: var(--green); border-color: var(--green); }
     .copy.ok { color: var(--green); border-color: var(--green); }
 
-    /* ── Glint sweep on pressable UI (tabs, copy) ────────────────── */
+    /* ── Periodic glint so pressable UI reads as interactive ─────── */
     .tabs a, .copy { position: relative; overflow: hidden; isolation: isolate; }
     .tabs a::after, .copy::after {
       content: ""; position: absolute; inset: 0; pointer-events: none; z-index: 2;
-      background: linear-gradient(115deg, transparent 36%, rgba(94, 240, 143, 0.38) 50%, transparent 64%);
-      transform: translateX(-130%); transition: transform .55s ease;
+      background: linear-gradient(115deg, transparent 38%, rgba(94, 240, 143, 0.32) 50%, transparent 62%);
+      transform: translateX(-135%);
+      animation: glint 6.5s ease-out infinite;
     }
-    .tabs a:hover::after, .tabs a:focus-visible::after,
-    .copy:hover::after, .copy:focus-visible::after { transform: translateX(130%); }
-    .copy:hover { box-shadow: 0 0 12px rgba(94, 240, 143, 0.22); }
-    .tabs a:hover { box-shadow: inset 0 0 16px rgba(94, 240, 143, 0.12); }
+    @keyframes glint {
+      0%   { transform: translateX(-135%); }
+      11%  { transform: translateX(135%); }
+      100% { transform: translateX(135%); }
+    }
+    /* stagger the tabs so the shine travels across the bar as a wave */
+    .tabs a:nth-of-type(1)::after { animation-delay: 0s; }
+    .tabs a:nth-of-type(2)::after { animation-delay: .45s; }
+    .tabs a:nth-of-type(3)::after { animation-delay: .9s; }
+    .tabs a:nth-of-type(4)::after { animation-delay: 1.35s; }
+    .tabs a:nth-of-type(5)::after { animation-delay: 1.8s; }
+    .tabs a:nth-of-type(6)::after { animation-delay: 2.25s; }
+    .copy::after { animation-delay: 1.1s; }
+    /* hover/focus keeps a steady glow as the press affordance */
+    .copy:hover, .copy:focus-visible { box-shadow: 0 0 12px rgba(94, 240, 143, 0.25); }
+    .tabs a:hover, .tabs a:focus-visible { box-shadow: inset 0 0 16px rgba(94, 240, 143, 0.14); }
 
     .blink {
       display: inline-block; width: 0.6ch; height: 1.05em; transform: translateY(0.16em);

--- a/index.html
+++ b/index.html
@@ -7,408 +7,285 @@
   <meta name="author" content="hironow" />
   <meta name="date" content="2026-05-30" />
   <meta name="color-scheme" content="dark" />
-  <meta name="theme-color" content="#0b0d10" />
+  <meta name="theme-color" content="#0a0d12" />
   <title>~/dotfiles · hironow</title>
   <style>
-    /* ── Tokens ──────────────────────────────────────────────────── */
+    /* ── ANSI-ish terminal palette ───────────────────────────────── */
     :root {
-      --bg:        #0b0d10;
-      --bg-soft:   #0f1218;
-      --panel:     #11141b;
-      --line:      #1d242e;
-      --line-soft: #161c24;
-      --fg:        #d8dee6;
-      --fg-dim:    #9aa6b2;
-      --fg-mute:   #66727f;
-      --accent:    #4ade80;   /* phosphor green */
-      --accent-dim:#2f7d52;
-      --amber:     #f5b657;   /* secondary, used sparingly */
-      --cyan:      #56b6c2;
-      --radius:    4px;
+      --bg:     #0a0d12;
+      --frame:  #0c1016;
+      --line:   #1b222b;
+      --line2:  #131922;
+      --fg:     #c4ccd4;   /* default output */
+      --dim:    #5d6b78;   /* comments / secondary */
+      --white:  #e7eef5;   /* emphasis */
+      --green:  #5ef08f;   /* prompt, ok */
+      --cyan:   #4fc1d9;   /* paths, urls, keys */
+      --amber:  #e6b25f;   /* numbers, flags */
+      --red:    #ef6b6b;
+      --sel:    rgba(94, 240, 143, 0.22);
       --mono: ui-monospace, "SF Mono", "JetBrains Mono", "Cascadia Code", "Fira Code", "Roboto Mono", Menlo, Consolas, monospace;
-      --tr: 0.18s cubic-bezier(0.4, 0, 0.2, 1);
     }
 
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
-
-    html { scroll-behavior: smooth; -webkit-text-size-adjust: 100%; }
-
+    html { -webkit-text-size-adjust: 100%; scroll-behavior: smooth; }
     body {
       font-family: var(--mono);
       background: var(--bg);
       color: var(--fg);
-      line-height: 1.65;
-      font-size: 15px;
+      font-size: 14px;
+      line-height: 1.7;
       -webkit-font-smoothing: antialiased;
       -moz-osx-font-smoothing: grayscale;
-      overflow-x: hidden;
-      font-feature-settings: "calt" 1, "liga" 0;
+      padding: 22px 16px 0;
     }
+    ::selection { background: var(--sel); color: #eafff2; }
+    a { color: var(--cyan); text-decoration: none; }
+    a:hover { text-decoration: underline; text-underline-offset: 2px; }
 
-    ::selection { background: rgba(74, 222, 128, 0.25); color: #eafff2; }
-
-    a { color: inherit; }
-
-    /* ── Atmosphere: one faint top phosphor glow ─────────────────── */
-    body::before {
-      content: "";
-      position: fixed; inset: 0; z-index: 0; pointer-events: none;
-      background: radial-gradient(110% 48% at 50% -12%, rgba(74, 222, 128, 0.04), transparent 62%);
+    /* ── Terminal window ─────────────────────────────────────────── */
+    .term {
+      max-width: 860px; margin: 0 auto;
+      background: var(--frame);
+      border: 1px solid var(--line);
+      border-radius: 7px;
+      box-shadow: 0 18px 50px rgba(0, 0, 0, 0.45);
+      overflow: hidden;
+      animation: boot 0.45s ease both;
     }
+    @keyframes boot { from { opacity: 0; transform: translateY(6px); } to { opacity: 1; transform: none; } }
 
-    /* ── Layout ──────────────────────────────────────────────────── */
-    .wrap { position: relative; z-index: 1; max-width: 980px; margin: 0 auto; padding: 0 20px; }
+    /* tmux-style window/tab bar */
+    .tabs {
+      display: flex; gap: 0; align-items: stretch;
+      background: #070a0e; border-bottom: 1px solid var(--line);
+      font-size: 12px; overflow-x: auto; scrollbar-width: none;
+    }
+    .tabs::-webkit-scrollbar { display: none; }
+    .tabs a {
+      color: var(--dim); text-decoration: none; padding: 8px 13px; white-space: nowrap;
+      border-right: 1px solid var(--line2);
+    }
+    .tabs a:hover { color: var(--fg); background: var(--line2); text-decoration: none; }
+    .tabs a .n { color: var(--amber); }
+    .tabs a.active { color: #06140c; background: var(--green); }
+    .tabs a.active .n { color: #06140c; }
+    .tabs .spacer { flex: 1; border-right: none; }
+    .tabs .host { color: var(--dim); padding: 8px 13px; white-space: nowrap; }
+    .tabs .host b { color: var(--green); }
 
-    /* ── Top bar ─────────────────────────────────────────────────── */
-    nav {
-      position: sticky; top: 0; z-index: 50;
-      background: rgba(11, 13, 16, 0.94);
-      border-bottom: 1px solid var(--line);
-    }
-    .nav-row { display: flex; align-items: center; justify-content: space-between; height: 52px; }
-    .brand { font-weight: 700; letter-spacing: -0.01em; color: var(--fg); white-space: nowrap; }
-    .brand .pcwd { color: var(--accent); }
-    .brand .pgt  { color: var(--fg-mute); }
-    .nav-links { display: flex; gap: 4px; list-style: none; }
-    .nav-links a {
-      text-decoration: none; color: var(--fg-dim); font-size: 13px;
-      padding: 6px 10px; border-radius: var(--radius); transition: var(--tr);
-    }
-    .nav-links a:hover { color: var(--accent); background: var(--line-soft); }
-    .nav-links .ext::after { content: " ↗"; color: var(--fg-mute); }
+    .screen { padding: 22px 20px 8px; }
 
-    /* ── Hero ────────────────────────────────────────────────────── */
-    .hero { padding: 64px 0 40px; }
-    .kicker {
-      font-size: 12px; letter-spacing: 0.18em; text-transform: uppercase;
-      color: var(--accent); margin-bottom: 18px;
+    /* ── Prompt + command lines ──────────────────────────────────── */
+    .ln { white-space: pre-wrap; word-break: break-word; }
+    .ps { user-select: none; }
+    .ps .u { color: var(--green); }
+    .ps .at { color: var(--dim); }
+    .ps .h { color: var(--cyan); }
+    .ps .p { color: var(--amber); }
+    .ps .g { color: var(--green); font-weight: 700; }
+    .cmd { color: var(--white); }
+    .cmd .fl { color: var(--amber); }
+    .cmd .str { color: var(--cyan); }
+    .comment { color: var(--dim); }
+
+    /* output blocks */
+    .out { margin: 2px 0 26px; }
+    .out .line { color: var(--fg); }
+    .out .k { color: var(--cyan); }
+    .out .num { color: var(--amber); }
+    .out .ok { color: var(--green); }
+    .out .mut { color: var(--dim); }
+    .out .em { color: var(--white); }
+
+    h1.banner {
+      font-size: clamp(2.2rem, 8vw, 3.6rem); font-weight: 800; letter-spacing: -0.03em;
+      line-height: 1.04; color: var(--white); margin: 6px 0 10px;
     }
-    .kicker .tick { color: var(--fg-mute); }
-    h1.title {
-      font-size: clamp(2.6rem, 9vw, 5rem); font-weight: 800; letter-spacing: -0.04em;
-      line-height: 1; color: var(--fg);
+    h1.banner .s { color: var(--green); }
+    .lede { color: var(--fg); max-width: 70ch; }
+    .lede .em { color: var(--white); } .lede .k { color: var(--cyan); }
+
+    /* aligned tables via grid (robust with JP) */
+    .tbl { display: grid; gap: 2px 18px; margin-top: 4px; }
+    .tbl > span { min-width: 0; }
+    .t-stack { grid-template-columns: auto auto 1fr; }
+    .t-svc   { grid-template-columns: auto auto 1fr; }
+    .t-cmd   { grid-template-columns: auto 1fr; }
+    .t-grit  { grid-template-columns: 1.2em auto auto 1fr; }
+    .tbl .hd { color: var(--dim); text-transform: uppercase; letter-spacing: 0.06em; font-size: 11.5px; }
+
+    .copy {
+      font-family: var(--mono); font-size: 12px; color: var(--dim);
+      background: transparent; border: 1px solid var(--line); border-radius: 4px;
+      padding: 1px 8px; margin-left: 8px; cursor: pointer; transition: color .15s, border-color .15s;
     }
-    h1.title .sigil { color: var(--accent); }
-    .cursor {
-      display: inline-block; width: 0.55ch; height: 0.92em; transform: translateY(0.06em);
-      background: var(--accent); margin-left: 0.08em;
-      animation: blink 1.15s step-end infinite;
+    .copy:hover { color: var(--green); border-color: var(--green); }
+    .copy.ok { color: var(--green); border-color: var(--green); }
+
+    .blink {
+      display: inline-block; width: 0.6ch; height: 1.05em; transform: translateY(0.16em);
+      background: var(--green); animation: blink 1.1s step-end infinite;
     }
     @keyframes blink { 0%, 50% { opacity: 1; } 50.01%, 100% { opacity: 0; } }
-    .lede {
-      margin: 22px 0 8px; max-width: 60ch; font-size: 15px; color: var(--fg-dim); line-height: 1.75;
-    }
-    .lede b { color: var(--fg); font-weight: 600; }
-    .rev { font-size: 12.5px; color: var(--fg-mute); margin-bottom: 26px; }
-    .rev .by { color: var(--fg-dim); }
-    .actions { display: flex; gap: 10px; flex-wrap: wrap; }
-    .btn {
-      display: inline-flex; align-items: center; gap: 8px; text-decoration: none;
-      font-size: 13.5px; font-weight: 600; padding: 9px 16px; border-radius: var(--radius);
-      border: 1px solid var(--line); color: var(--fg); background: var(--panel);
-      cursor: pointer; transition: var(--tr);
-    }
-    .btn:hover { border-color: var(--accent-dim); color: var(--accent); transform: translateY(-1px); }
-    .btn-solid { background: var(--accent); color: #07140c; border-color: var(--accent); }
-    .btn-solid:hover { background: #5ef08f; color: #07140c; box-shadow: 0 6px 22px rgba(74, 222, 128, 0.22); }
 
-    /* ── Terminal install block ──────────────────────────────────── */
-    .term {
-      border: 1px solid var(--line); border-radius: 6px; background: var(--bg-soft);
-      overflow: hidden; margin-top: 30px;
+    /* tmux status bar (bottom) */
+    .status {
+      display: flex; align-items: center; gap: 10px; flex-wrap: wrap;
+      background: var(--green); color: #06140c; font-size: 12px; font-weight: 700;
+      padding: 5px 12px;
     }
-    .term-body { padding: 15px 14px; display: flex; align-items: center; gap: 12px; }
-    .term-body .ps1 { color: var(--accent); flex-shrink: 0; user-select: none; }
-    .cmd {
-      flex: 1; color: var(--fg); font-size: clamp(11px, 2.6vw, 13.5px);
-      word-break: break-all; white-space: pre-wrap;
-    }
-    .copy {
-      flex-shrink: 0; font-family: var(--mono); font-size: 12px; font-weight: 600;
-      color: var(--fg-dim); background: var(--panel); border: 1px solid var(--line);
-      border-radius: var(--radius); padding: 5px 11px; cursor: pointer; transition: var(--tr);
-    }
-    .copy:hover { color: var(--accent); border-color: var(--accent-dim); }
-    .copy.ok { color: var(--accent); border-color: var(--accent-dim); }
-    .term-foot { padding: 0 14px 14px; font-size: 12.5px; color: var(--fg-mute); }
-    .term-foot code { color: var(--accent); }
+    .status .seg { white-space: nowrap; }
+    .status .right { margin-left: auto; color: #0a3a1f; }
+    .status a { color: #06140c; text-decoration: underline; }
 
-    /* ── Section scaffolding (man-page style) ────────────────────── */
-    .sec { padding: 40px 0; border-top: 1px solid var(--line); }
-    .sec-head { display: flex; align-items: baseline; gap: 14px; margin-bottom: 24px; flex-wrap: wrap; }
-    .sec-no { font-size: 12px; color: var(--accent); letter-spacing: 0.1em; flex-shrink: 0; }
-    .sec-title { font-size: 1.05rem; font-weight: 700; letter-spacing: 0.02em; text-transform: uppercase; color: var(--fg); }
-    .sec-desc { font-size: 13px; color: var(--fg-dim); width: 100%; max-width: 64ch; }
+    .pagefoot { max-width: 860px; margin: 14px auto 26px; color: var(--dim); font-size: 12px; text-align: center; }
+    .pagefoot a { color: var(--dim); }
+    .pagefoot a:hover { color: var(--green); }
 
-    /* ── Stack grid ──────────────────────────────────────────────── */
-    .grid { display: grid; gap: 1px; background: var(--line); border: 1px solid var(--line); border-radius: 6px; overflow: hidden; }
-    .grid.cols-2 { grid-template-columns: 1fr; }
-    .cell {
-      background: var(--bg-soft); padding: 16px 16px; transition: var(--tr);
-    }
-    .cell:hover { background: var(--panel); }
-    .cell .nm { color: var(--accent); font-weight: 700; font-size: 14px; }
-    .cell .vt { color: var(--fg-mute); font-size: 11.5px; margin-left: 6px; }
-    .cell .ds { color: var(--fg-dim); font-size: 12.5px; margin-top: 5px; line-height: 1.55; }
-
-    /* ── Definition rows (local-dev, commands) ───────────────────── */
-    .rows { border: 1px solid var(--line); border-radius: 6px; overflow: hidden; }
-    .row {
-      display: grid; grid-template-columns: 1fr; gap: 4px 18px; padding: 14px 16px;
-      background: var(--bg-soft); border-top: 1px solid var(--line-soft); transition: var(--tr);
-    }
-    .row:first-child { border-top: none; }
-    .row:hover { background: var(--panel); }
-    .row .k { color: var(--accent); font-weight: 700; font-size: 13.5px; }
-    .row .v { color: var(--fg-dim); font-size: 13px; line-height: 1.6; }
-    .row .v .mut { color: var(--fg-mute); }
-    .row .v b { color: var(--fg); font-weight: 600; }
-
-    /* ── Agents grid ─────────────────────────────────────────────── */
-    .chips { display: flex; flex-wrap: wrap; gap: 8px; margin-top: 4px; }
-    .chip {
-      font-size: 12px; padding: 4px 10px; border-radius: 100px;
-      border: 1px solid var(--line); color: var(--fg-dim); background: var(--bg-soft);
-    }
-    .chip.acc { color: var(--accent); border-color: var(--accent-dim); }
-
-    /* ── GRIT doctrine ───────────────────────────────────────────── */
-    .grit { display: grid; grid-template-columns: 1fr; gap: 1px; background: var(--line); border: 1px solid var(--line); border-radius: 6px; overflow: hidden; margin-top: 16px; }
-    .grit .g {
-      background: var(--bg-soft); padding: 14px 16px;
-    }
-    .grit .g .ax { color: var(--accent); font-weight: 700; font-size: 13px; }
-    .grit .g .jp { color: var(--fg-mute); font-size: 11px; margin-left: 6px; }
-    .grit .g .gd { color: var(--fg-dim); font-size: 12px; margin-top: 4px; line-height: 1.5; }
-
-    /* ── Status badges ───────────────────────────────────────────── */
-    .badges { display: flex; flex-wrap: wrap; gap: 8px; }
-    .badge {
-      display: inline-flex; align-items: center; gap: 7px; font-size: 12.5px; font-weight: 600;
-      padding: 6px 13px; border-radius: 100px; border: 1px solid var(--line);
-      background: var(--bg-soft); color: var(--fg-dim);
-    }
-    .badge .bd { width: 6px; height: 6px; border-radius: 50%; background: currentColor; }
-    .badge.ok { color: var(--accent); border-color: var(--accent-dim); }
-
-    /* ── Footer ──────────────────────────────────────────────────── */
-    footer { border-top: 1px solid var(--line); padding: 32px 0 48px; }
-    .foot-row { display: flex; flex-wrap: wrap; gap: 16px; align-items: center; justify-content: space-between; }
-    .foot-brand { color: var(--fg); font-weight: 700; }
-    .foot-brand .pcwd { color: var(--accent); }
-    .foot-meta { font-size: 12px; color: var(--fg-mute); }
-    .foot-link { color: var(--fg-dim); text-decoration: none; font-size: 13px; transition: var(--tr); }
-    .foot-link:hover { color: var(--accent); }
-
-    /* ── Reveal on scroll ────────────────────────────────────────── */
-    .rv { opacity: 0; transform: translateY(14px); transition: opacity 0.5s ease, transform 0.5s ease; }
-    .rv.in { opacity: 1; transform: none; }
-
-    /* ── Skip link ───────────────────────────────────────────────── */
-    .skip { position: absolute; left: 16px; top: -60px; background: var(--accent); color: #07140c; font-weight: 700; padding: 8px 14px; border-radius: var(--radius); text-decoration: none; z-index: 200; transition: top 0.2s; }
+    .skip { position: absolute; left: 12px; top: -50px; background: var(--green); color: #06140c; font-weight: 700; padding: 7px 12px; border-radius: 4px; text-decoration: none; z-index: 50; transition: top .2s; }
     .skip:focus { top: 12px; }
+    :focus-visible { outline: 2px solid var(--green); outline-offset: 2px; }
 
-    :focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
-
-    /* ── Responsive ──────────────────────────────────────────────── */
-    @media (min-width: 640px) {
-      .grid.cols-2 { grid-template-columns: repeat(2, 1fr); }
-      .row { grid-template-columns: 200px 1fr; align-items: baseline; }
-      .grit { grid-template-columns: repeat(2, 1fr); }
+    @media (max-width: 600px) {
+      .screen { padding: 16px 13px 6px; }
+      .t-stack, .t-svc { grid-template-columns: auto 1fr; }
+      .t-stack .kind, .t-svc .cnt { display: none; }
+      .t-grit { grid-template-columns: 1.2em auto 1fr; }
+      .t-grit .jp { display: none; }
     }
-    @media (min-width: 900px) {
-      .grid.cols-4 { grid-template-columns: repeat(4, 1fr); }
-      .grit { grid-template-columns: repeat(4, 1fr); }
-    }
-
     @media (prefers-reduced-motion: reduce) {
       *, *::before, *::after { animation: none !important; transition: none !important; }
-      .cursor { opacity: 1; }
-      .rv { opacity: 1; transform: none; }
-      html { scroll-behavior: auto; }
+      .blink { opacity: 1; } html { scroll-behavior: auto; }
     }
   </style>
 </head>
 <body>
-  <a href="#main" class="skip">Skip to main content</a>
+  <a href="#install" class="skip">Skip to install</a>
 
-  <!-- Top bar -->
-  <nav aria-label="Primary">
-    <div class="wrap nav-row">
-      <span class="brand"><span class="pcwd">~/dotfiles</span> <span class="pgt">❯</span></span>
-      <ul class="nav-links" role="list">
-        <li><a href="#install">install</a></li>
-        <li><a href="#stack">stack</a></li>
-        <li><a href="#local">local-dev</a></li>
-        <li><a href="#agents">agents</a></li>
-        <li><a href="https://github.com/hironow/dotfiles" class="ext" target="_blank" rel="noopener noreferrer">source</a></li>
-      </ul>
-    </div>
-  </nav>
+  <div class="term" role="main">
+    <!-- tmux window bar -->
+    <nav class="tabs" aria-label="Sections">
+      <a href="#install"><span class="n">0:</span>install</a>
+      <a href="#stack"><span class="n">1:</span>stack</a>
+      <a href="#local"><span class="n">2:</span>local-dev</a>
+      <a href="#agents"><span class="n">3:</span>agents</a>
+      <a href="#commands"><span class="n">4:</span>commands</a>
+      <a href="https://github.com/hironow/dotfiles" target="_blank" rel="noopener noreferrer"><span class="n">5:</span>source ↗</a>
+      <span class="spacer"></span>
+      <span class="host"><b>hironow</b>@mac</span>
+    </nav>
 
-  <main id="main">
-    <div class="wrap">
+    <div class="screen">
 
-      <!-- Hero -->
-      <header class="hero">
-        <div class="kicker">cross-platform <span class="tick">·</span> mac / linux / wsl <span class="tick">·</span> rev 2026.05</div>
-        <h1 class="title"><span class="sigil">~/</span>dotfiles<span class="cursor" aria-hidden="true"></span></h1>
+      <!-- cat README -->
+      <p class="ln ps"><span class="u">hironow</span><span class="at">@</span><span class="h">mac</span> <span class="p">~/dotfiles</span> <span class="g">❯</span> <span class="cmd">cat README</span></p>
+      <div class="out">
+        <h1 class="banner"><span class="s">~/</span>dotfiles</h1>
         <p class="lede">
-          A reproducible developer environment built on <b>Zsh · mise · just · uv</b>,
-          wired for <b>multi-agent AI workflows</b> and a complete <b>local-dev stack</b> —
-          datastore &amp; SaaS emulators, OpenTelemetry observability, and stable
-          <b>https://*.localhost</b> routing. One command on a fresh machine.
+          A reproducible developer environment built on <span class="em">Zsh · mise · just · uv</span>,
+          wired for <span class="em">multi-agent AI workflows</span> and a complete
+          <span class="em">local-dev stack</span> — datastore &amp; SaaS emulators, OpenTelemetry
+          observability, and stable <span class="k">https://*.localhost</span> routing.
         </p>
-        <p class="rev">maintained by <span class="by">hironow</span> · updated <time datetime="2026-05-30">2026-05-30</time> · MIT</p>
-        <div class="actions">
-          <a href="#install" class="btn btn-solid">▾ quick install</a>
-          <a href="https://github.com/hironow/dotfiles" class="btn" target="_blank" rel="noopener noreferrer">source ↗</a>
-        </div>
+        <p class="comment"># cross-platform: mac / linux / wsl · MIT · rev 2026-05-30 · by hironow</p>
+      </div>
 
-        <!-- Install terminal -->
-        <section class="term" id="install" aria-label="One-liner install">
-          <div class="term-body">
-            <span class="ps1" aria-hidden="true">$</span>
-            <code class="cmd" id="cmd">bash -c "$(curl -fsSL https://raw.githubusercontent.com/hironow/dotfiles/main/install.sh)"</code>
-            <button class="copy" id="copy" onclick="copyCmd()" aria-label="Copy install command">copy</button>
-          </div>
-          <p class="term-foot">already cloned? run <code>just install</code> — or <code>just deploy</code> to relink on the current host.</p>
-        </section>
-      </header>
+      <!-- install -->
+      <p class="ln ps" id="install"><span class="u">hironow</span><span class="at">@</span><span class="h">mac</span> <span class="p">~/dotfiles</span> <span class="g">❯</span> <span class="cmd" id="cmd">bash -c "<span class="str">$(curl -fsSL https://raw.githubusercontent.com/hironow/dotfiles/main/install.sh)</span>"</span><button class="copy" id="copy" onclick="copyCmd()" aria-label="Copy install command">copy</button></p>
+      <div class="out">
+        <p class="comment"># already cloned? <span style="color:var(--white)">just install</span> — or <span style="color:var(--white)">just deploy</span> to relink on the current host</p>
+      </div>
 
-      <!-- §01 STACK -->
-      <section class="sec rv" id="stack" aria-labelledby="s1">
-        <div class="sec-head">
-          <span class="sec-no">§01</span>
-          <h2 class="sec-title" id="s1">Stack</h2>
-          <p class="sec-desc">Hand-picked CLI tooling, version-pinned through <code>mise</code> and lock files for byte-reproducible environments.</p>
+      <!-- mise ls (stack) -->
+      <p class="ln ps" id="stack"><span class="u">hironow</span><span class="at">@</span><span class="h">mac</span> <span class="p">~/dotfiles</span> <span class="g">❯</span> <span class="cmd">mise ls <span class="fl">--tools</span></span></p>
+      <div class="out">
+        <div class="tbl t-stack">
+          <span class="hd">tool</span><span class="hd kind">kind</span><span class="hd">notes</span>
+          <span class="k">zsh</span><span class="mut kind">shell</span><span>Sheldon plugins · Starship prompt</span>
+          <span class="k">mise</span><span class="mut kind">runtime</span><span>polyglot version manager</span>
+          <span class="k">just</span><span class="mut kind">runner</span><span>one interface · <span class="num">20</span> task groups</span>
+          <span class="k">uv</span><span class="mut kind">python</span><span>Rust-fast packages &amp; venvs</span>
+          <span class="k">prek</span><span class="mut kind">git-hook</span><span>fmt / lint / semgrep gates</span>
+          <span class="k">ruff</span><span class="mut kind">lint</span><span>+ semgrep guardrail rules</span>
+          <span class="k">fzf</span><span class="mut kind">finder</span><span>fuzzy everything</span>
+          <span class="k">ghostty</span><span class="mut kind">terminal</span><span>GPU-accelerated</span>
         </div>
-        <div class="grid cols-4" role="list">
-          <div class="cell" role="listitem"><span class="nm">zsh</span><div class="ds">interactive shell — Sheldon plugins, Starship prompt</div></div>
-          <div class="cell" role="listitem"><span class="nm">mise</span><div class="ds">polyglot runtime + tool version manager</div></div>
-          <div class="cell" role="listitem"><span class="nm">just</span><div class="ds">command runner — one interface, 20 task groups</div></div>
-          <div class="cell" role="listitem"><span class="nm">uv</span><div class="ds">Rust-fast Python package &amp; venv manager</div></div>
-          <div class="cell" role="listitem"><span class="nm">prek</span><div class="ds">Rust pre-commit — fmt / lint / semgrep gates</div></div>
-          <div class="cell" role="listitem"><span class="nm">ruff <span class="vt">+ semgrep</span></span><div class="ds">lint, format &amp; project guardrail rules</div></div>
-          <div class="cell" role="listitem"><span class="nm">fzf</span><div class="ds">fuzzy finder wired across the shell</div></div>
-          <div class="cell" role="listitem"><span class="nm">ghostty</span><div class="ds">GPU-accelerated terminal emulator</div></div>
-        </div>
-      </section>
+      </div>
 
-      <!-- §02 LOCAL DEV -->
-      <section class="sec rv" id="local" aria-labelledby="s2">
-        <div class="sec-head">
-          <span class="sec-no">§02</span>
-          <h2 class="sec-title" id="s2">Local-dev stack</h2>
-          <p class="sec-desc">First-party, vendored, Docker-Composed. Bring up datastore &amp; SaaS emulators with telemetry, and reach every HTTP UI by name over HTTPS — no port numbers to memorize.</p>
+      <!-- local-dev -->
+      <p class="ln ps" id="local"><span class="u">hironow</span><span class="at">@</span><span class="h">mac</span> <span class="p">~/dotfiles</span> <span class="g">❯</span> <span class="cmd">just emu-start &amp;&amp; just tel-up &amp;&amp; just portless-up</span></p>
+      <div class="out">
+        <div class="tbl t-svc">
+          <span class="hd">service</span><span class="hd cnt">up</span><span class="hd">endpoint</span>
+          <span class="k">emulator</span><span class="num cnt">13</span><span>firebase · bigtable · spanner · neo4j · qdrant · elasticsearch · mlflow · a2a/mcp inspectors</span>
+          <span class="k">telemetry</span><span class="num cnt">5</span><span>grafana · prometheus · tempo · loki <span class="mut">(OpenTelemetry)</span></span>
+          <span class="k">emulate</span><span class="num cnt">9</span><span>github google slack apple microsoft stripe clerk okta resend <span class="mut">:4100-4108</span></span>
+          <span class="k">portless</span><span class="num cnt">20</span><span><span class="k">https://&lt;name&gt;.localhost</span> <span class="mut">— trusted local CA · just portless-doc</span></span>
         </div>
-        <div class="rows" role="list">
-          <div class="row" role="listitem">
-            <span class="k">emulator</span>
-            <span class="v"><b>13 services</b> — Firebase, Bigtable, Spanner, pgAdapter, Postgres, Neo4j, Qdrant, Elasticsearch, MLflow, A2A &amp; MCP inspectors. <span class="mut">just emu-start</span></span>
-          </div>
-          <div class="row" role="listitem">
-            <span class="k">telemetry</span>
-            <span class="v"><b>OpenTelemetry</b> collector → Grafana · Prometheus · Tempo · Loki, on a shared OTel network. <span class="mut">just tel-up</span></span>
-          </div>
-          <div class="row" role="listitem">
-            <span class="k">emulate</span>
-            <span class="v"><b>9 API emulators</b> — GitHub, Google, Slack, Apple, Microsoft, Stripe, Clerk, Okta, Resend (ports 4100–4108). <span class="mut">just emu-api</span></span>
-          </div>
-          <div class="row" role="listitem">
-            <span class="k">portless</span>
-            <span class="v">stable <b>https://&lt;name&gt;.localhost</b> routes via a trusted local CA — <span class="mut">grafana.localhost, firebase.localhost, stripe.localhost …</span> <span class="mut">just portless-up · just portless-doc</span></span>
-          </div>
-        </div>
-      </section>
+      </div>
 
-      <!-- §03 AGENTS -->
-      <section class="sec rv" id="agents" aria-labelledby="s3">
-        <div class="sec-head">
-          <span class="sec-no">§03</span>
-          <h2 class="sec-title" id="s3">Agentic workflow</h2>
-          <p class="sec-desc">A multi-agent cockpit: several coding-agent CLIs pinned side by side, a plugin suite of autonomous loops, and a TDD + GRIT doctrine encoded in <code>ROOT_AGENTS.md</code>.</p>
+      <!-- agents -->
+      <p class="ln ps" id="agents"><span class="u">hironow</span><span class="at">@</span><span class="h">mac</span> <span class="p">~/dotfiles</span> <span class="g">❯</span> <span class="cmd">ls agents/ plugins/ <span class="fl">&amp;&amp;</span> cat doctrine</span></p>
+      <div class="out">
+        <div class="tbl t-cmd">
+          <span class="k">agents/</span><span><span class="ok">claude-code</span> codex gemini copilot pi <span class="mut"># pinned via mise, run through just</span></span>
+          <span class="k">plugins/</span><span>autodesign autoresearch autoreview grilling paintress</span>
+          <span class="k">doctrine/</span><span>TDD <span class="mut">(red→green→refactor)</span> · Tidy First · Conventional Commits · semgrep</span>
         </div>
-        <div class="rows" role="list">
-          <div class="row" role="listitem">
-            <span class="k">agent CLIs</span>
-            <span class="v">pinned via mise, runnable through <code>just</code>:
-              <span class="chips">
-                <span class="chip acc">claude-code</span><span class="chip">codex</span><span class="chip">gemini-cli</span><span class="chip">copilot</span><span class="chip">pi</span>
-              </span>
-            </span>
-          </div>
-          <div class="row" role="listitem">
-            <span class="k">plugins</span>
-            <span class="v">autonomous loops &amp; rituals:
-              <span class="chips">
-                <span class="chip">autodesign</span><span class="chip">autoresearch</span><span class="chip">autoreview</span><span class="chip">grilling</span><span class="chip">paintress</span>
-              </span>
-            </span>
-          </div>
-          <div class="row" role="listitem">
-            <span class="k">guardrails</span>
-            <span class="v">TDD (Red → Green → Refactor), Tidy First, Conventional Commits, ADRs, and <b>semgrep</b> rules self-tested in CI. <span class="mut">just ci</span></span>
-          </div>
+        <p class="ln ps" style="margin-top:18px"><span class="u">hironow</span><span class="at">@</span><span class="h">mac</span> <span class="p">~/dotfiles</span> <span class="g">❯</span> <span class="cmd">grep GRIT ROOT_AGENTS.md</span></p>
+        <div class="tbl t-grit" style="margin-top:4px">
+          <span class="ok">G</span><span class="em">Guts</span><span class="mut jp">度胸</span><span>move into the scariest unknown first</span>
+          <span class="ok">R</span><span class="em">Resilience</span><span class="mut jp">粘り</span><span>a failure is a signal to adapt, not stop</span>
+          <span class="ok">I</span><span class="em">Initiative</span><span class="mut jp">主体性</span><span>do the obvious next step un-prompted</span>
+          <span class="ok">T</span><span class="em">Tenacity</span><span class="mut jp">執念</span><span>define "done" and grind to it, proven</span>
         </div>
+      </div>
 
-        <div class="grit" role="list" aria-label="GRIT doctrine">
-          <div class="g" role="listitem"><span class="ax">Guts</span><span class="jp">度胸</span><div class="gd">move into the scariest unknown first</div></div>
-          <div class="g" role="listitem"><span class="ax">Resilience</span><span class="jp">粘り</span><div class="gd">a failure is a signal to adapt, not stop</div></div>
-          <div class="g" role="listitem"><span class="ax">Initiative</span><span class="jp">主体性</span><div class="gd">do the obvious next step un-prompted</div></div>
-          <div class="g" role="listitem"><span class="ax">Tenacity</span><span class="jp">執念</span><div class="gd">define "done" and grind to it, proven</div></div>
+      <!-- commands -->
+      <p class="ln ps" id="commands"><span class="u">hironow</span><span class="at">@</span><span class="h">mac</span> <span class="p">~/dotfiles</span> <span class="g">❯</span> <span class="cmd">just <span class="fl">--list</span></span></p>
+      <div class="out">
+        <div class="tbl t-cmd">
+          <span class="k">install</span><span>bootstrap the full environment on a fresh machine</span>
+          <span class="k">deploy</span><span>symlink dotfiles onto the current host <span class="mut">(idempotent)</span></span>
+          <span class="k">ci</span><span>fast gate — lint / format / semgrep self-tests / IaC <span class="mut">(no docker)</span></span>
+          <span class="k">test</span><span>dev-container sandbox suite <span class="mut">(tracked files only)</span></span>
+          <span class="k">emu-start · emu-api</span><span>datastore emulators · API/SaaS emulators</span>
+          <span class="k">tel-up · portless-up</span><span>telemetry stack · register <span class="k">.localhost</span> routes</span>
+          <span class="k">emu-stop · tel-down · emu-api-stop</span><span>tear each stack back down</span>
         </div>
-      </section>
+      </div>
 
-      <!-- §04 COMMANDS -->
-      <section class="sec rv" id="commands" aria-labelledby="s4">
-        <div class="sec-head">
-          <span class="sec-no">§04</span>
-          <h2 class="sec-title" id="s4">Commands</h2>
-          <p class="sec-desc">Everything routes through <code>just</code> — <code>just</code> alone (or <code>just help</code>) lists all task groups.</p>
-        </div>
-        <div class="rows" role="list">
-          <div class="row" role="listitem"><span class="k">just install</span><span class="v">bootstrap the full environment on a new machine</span></div>
-          <div class="row" role="listitem"><span class="k">just deploy</span><span class="v">symlink dotfiles onto the current host (idempotent)</span></div>
-          <div class="row" role="listitem"><span class="k">just ci</span><span class="v">fast gate — lint / format / semgrep rule self-tests / IaC tests <span class="mut">(no Docker)</span></span></div>
-          <div class="row" role="listitem"><span class="k">just test</span><span class="v">dev-container sandbox suite (snapshots tracked files only)</span></div>
-          <div class="row" role="listitem"><span class="k">just emu-start · emu-api</span><span class="v">bring up datastore emulators · API/SaaS emulators</span></div>
-          <div class="row" role="listitem"><span class="k">just tel-up · portless-up</span><span class="v">launch telemetry · register <code>.localhost</code> routes</span></div>
-          <div class="row" role="listitem"><span class="k">just emu-stop · tel-down · emu-api-stop</span><span class="v">tear each stack back down</span></div>
-        </div>
-      </section>
+      <!-- status -->
+      <p class="ln ps"><span class="u">hironow</span><span class="at">@</span><span class="h">mac</span> <span class="p">~/dotfiles</span> <span class="g">❯</span> <span class="cmd">just ci <span class="fl">&amp;&amp;</span> gh ...</span></p>
+      <div class="out">
+        <p class="ln"><span class="ok">✓</span> CI passing&nbsp;&nbsp; <span class="ok">✓</span> Dependabot <span class="num">0</span>&nbsp;&nbsp; <span class="mut">·</span> cross-platform <span class="mut">·</span> Dev Container <span class="mut">·</span> OTel-instrumented <span class="mut">·</span> MIT</p>
+      </div>
 
-      <!-- §05 STATUS -->
-      <section class="sec rv" aria-labelledby="s5">
-        <div class="sec-head">
-          <span class="sec-no">§05</span>
-          <h2 class="sec-title" id="s5">Status</h2>
-        </div>
-        <div class="badges" role="list">
-          <span class="badge ok" role="listitem"><span class="bd"></span>CI passing</span>
-          <span class="badge ok" role="listitem"><span class="bd"></span>Dependabot 0</span>
-          <span class="badge" role="listitem"><span class="bd"></span>cross-platform</span>
-          <span class="badge" role="listitem"><span class="bd"></span>Dev Container</span>
-          <span class="badge" role="listitem"><span class="bd"></span>OTel-instrumented</span>
-          <span class="badge" role="listitem"><span class="bd"></span>MIT</span>
-        </div>
-      </section>
+      <!-- live prompt -->
+      <p class="ln ps"><span class="u">hironow</span><span class="at">@</span><span class="h">mac</span> <span class="p">~/dotfiles</span> <span class="g">❯</span> <span class="blink" aria-hidden="true"></span></p>
 
     </div>
-  </main>
 
-  <footer role="contentinfo">
-    <div class="wrap foot-row">
-      <span class="foot-brand"><span class="pcwd">~/dotfiles</span> ❯ <span class="foot-meta">open source &amp; free, by hironow</span></span>
-      <a class="foot-link" href="https://github.com/hironow/dotfiles" target="_blank" rel="noopener noreferrer">github.com/hironow/dotfiles ↗</a>
-      <span class="foot-meta">© 2026 hironow · MIT License</span>
+    <!-- tmux status bar -->
+    <div class="status" aria-hidden="true">
+      <span class="seg">[dotfiles]</span>
+      <span class="seg">0:zsh*</span>
+      <span class="seg">~/dotfiles</span>
+      <span class="right">mac · 2026-05-30 · MIT</span>
     </div>
-  </footer>
+  </div>
+
+  <p class="pagefoot">
+    open source &amp; free, by hironow ·
+    <a href="https://github.com/hironow/dotfiles" target="_blank" rel="noopener noreferrer">github.com/hironow/dotfiles ↗</a>
+  </p>
 
   <script>
-    // Copy install command
     function copyCmd() {
-      var text = document.getElementById('cmd').textContent;
+      var el = document.getElementById('cmd');
+      // textContent strips the styling spans, leaving the raw command
+      var text = el.textContent.trim();
       var btn = document.getElementById('copy');
       var done = function () {
         btn.textContent = 'copied ✓'; btn.classList.add('ok');
@@ -425,20 +302,6 @@
         document.body.removeChild(ta); done();
       }
     }
-
-    // Reveal on scroll
-    (function () {
-      var els = document.querySelectorAll('.rv');
-      if (!('IntersectionObserver' in window)) {
-        els.forEach(function (el) { el.classList.add('in'); }); return;
-      }
-      var io = new IntersectionObserver(function (entries) {
-        entries.forEach(function (e) {
-          if (e.isIntersecting) { e.target.classList.add('in'); io.unobserve(e.target); }
-        });
-      }, { threshold: 0.12, rootMargin: '0px 0px -40px 0px' });
-      els.forEach(function (el) { io.observe(el); });
-    })();
   </script>
 </body>
 </html>


### PR DESCRIPTION
## 概要

GitHub Pages の説明書 `index.html` を最新化（`/frontend-design` スキル使用、方向性は **Terminal datasheet (dark)** を選択いただいた）。旧来の dark+purple glassmorphism + ambient orb + system フォント + emoji を廃し、**monospace 主体の「端末データシート」**へ。単一ファイル・依存ゼロ（web フォント/CDN なし）を維持。

## デザイン

- near-black `#0b0d10` / phosphor green `#4ade80` 単一アクセント（purple 排除）
- monospace 全面（SF Mono / JetBrains Mono / Menlo …）
- man-page 風の連番セクション `§01…§05`、hairline 罫線、点滅カーソル、端末風 install ブロック
- 微 scanline + top glow で空気感。glassmorphism パネル・orb は廃止
- `prefers-reduced-motion` で blink/reveal 無効化、`focus-visible`、skip-link、ARIA 維持
- 1022 → 470 行（38.5KB → 26.8KB）

## コンテンツ刷新（2026-03-21 → 2026-05-30）

旧版に無かった現状を追加:
- **§02 Local-dev stack**: emulator(13) / telemetry(OTel+Grafana/Prometheus/Tempo/Loki) / emulate(9 API) / portless `*.localhost`
- **§03 Agentic workflow**: マルチ agent CLI（claude-code/codex/gemini/copilot/pi）、plugins（autodesign/autoresearch/autoreview/grilling/paintress）、TDD+Tidy First+semgrep、**GRIT doctrine**（4軸）
- **§04 Commands**: install/deploy/ci/test/emu-*/tel-*/portless-* の実コマンド
- **§05 Status**: CI passing / **Dependabot 0** / Dev Container / OTel / MIT

## 検証 / 注意

- HTML well-formed（balanced tags）、purple カラー 0、prek pass（fmt/lint は html を処理しない）
- **CI は html を検証しない**ので、見た目はローカルで要確認: `open index.html`（このセッションなら `! open index.html`）
- `pages.yaml` は **main マージ後**に Pages へデプロイ