### PR TITLE
feat(emulator): lite default + capability profiles for selective startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,12 @@ emulators via an npx wrapper ([ADR 0016](./docs/adr/0016-integrate-emulate-api-e
 
 ```shell
 # datastore / inspector emulators (emulator/compose.yaml)
-just emu-start            # clean -> prebuild -> up -> wait
+# Lite default = GCP core (firebase+spanner+pgadapter+postgres); heavy/amd64
+# services are opt-in so the OrbStack VM stays under its memory cap.
+just emu-up               # detached, lite (== emu-up-lite); emu-start = clean+prebuild+up+wait
+just emu-up-only firebase-emulator   # only Firebase (e.g. reuse Pub/Sub :9399 from another repo)
+just emu-up-group search  # lite + a capability group (bigtable search graph vector ml inspect exporters full)
+just emu-up-full          # the whole heavy stack (excludes interactive *-cli)
 just emu-check            # status + endpoints
 just emu-stop             # stop (with firebase export)
 
@@ -193,7 +198,7 @@ just portless-ls          # list active routes; just portless-down to tear down
 
 Aliases are static routes, so registering them starts nothing on its own — the
 `https://*.localhost` URLs only respond once the backing stack is up (`just
-emu-start` / `just tel-up` / `just emu-api`). Optionally, `portless service
+emu-up` / `just tel-up` / `just emu-api`). Optionally, `portless service
 install` runs the proxy on login so routes survive reboots.
 
 ## Dev Container

--- a/emulator/README.md
+++ b/emulator/README.md
@@ -35,7 +35,20 @@ Note: The Firebase emulator does not need production credentials, but Google SDK
 Start emulators (recommended)
 
 ```bash
-just emu-start
+# Lite default = the GCP core only: firebase + spanner + pgadapter + postgres.
+# This keeps the OrbStack VM well under its memory cap; heavy/amd64 services
+# (Elasticsearch, Neo4j, Bigtable, inspectors, ...) are opt-in.
+just emu-up                          # detached, lite (== just emu-up-lite)
+just emu-start                       # clean volumes -> prebuild -> up lite -> wait
+
+# Start only specific service(s) — what an external consumer reuses.
+just emu-up-only firebase-emulator   # e.g. reuse Pub/Sub on :9399 from another repo
+
+# Start lite + a capability group: bigtable search graph vector ml inspect exporters full
+just emu-up-group search             # lite + Elasticsearch
+
+# The whole heavy stack (every data service; excludes interactive *-cli)
+just emu-up-full                     # == just emu-start-full for the clean variant
 ```
 
 Stop emulators (recommended)
@@ -47,7 +60,8 @@ just emu-stop
 Or use Docker Compose directly
 
 ```bash
-docker compose up -d
+docker compose up -d                 # lite (default profile only)
+COMPOSE_PROFILES=full docker compose up -d   # the whole heavy stack
 # ... later
 docker compose down
 ```
@@ -108,8 +122,13 @@ These exporters are scraped by the OTEL Collector in the `telemetry` stack via t
 All recipes live in the repo-root `justfile` under the `Emulator` group
 (run `just --list`):
 
-- `just emu-start` / `just emu-stop` — start (clean+prebuild+up+wait) / stop emulators
-- `just emu-up` / `just emu-check` / `just emu-wait` — start detached / status / wait for readiness
+- `just emu-up` / `just emu-up-lite` — start detached, lite (firebase+spanner+pgadapter+postgres = GCP core)
+- `just emu-up-only <service...>` — start exactly the named service(s), bypassing profile gating
+- `just emu-up-group <cap>` — start lite + a capability group (`bigtable search graph vector ml inspect exporters full`)
+- `just emu-up-full` — start the whole heavy stack (every data service; excludes interactive *-cli)
+- `just emu-start` / `just emu-start-full` — clean+prebuild+up+wait, lite / full
+- `just emu-stop` / `just emu-check` / `just emu-wait` — stop / status / wait for readiness
+- `just emu-port-check` — check host port usage (incl. cross-stack collision ports) before starting
 - `just emu-test` / `just emu-test-fast` / `just emu-test-e2e` — pytest (all / non-e2e / e2e)
 - `just emu-lint` / `just emu-fmt` — ruff + semgrep + markdownlint / formatters
 - `just emu-pg-verify` — PostgreSQL 18 verification

--- a/emulator/compose.yaml
+++ b/emulator/compose.yaml
@@ -45,6 +45,9 @@ services:
     image: gcr.io/google.com/cloudsdktool/cloud-sdk:emulators
     pull_policy: always
     container_name: bigtable-emulator
+    profiles:
+      - bigtable
+      - full
     # Apple Silicon (arm64): Bigtable emulator image is amd64-only; run under emulation
     platform: linux/amd64
     command: ["gcloud", "beta", "emulators", "bigtable", "start", "--host-port=0.0.0.0:8086"]
@@ -143,6 +146,9 @@ services:
   neo4j:
     image: neo4j:2025-community
     container_name: neo4j-emulator
+    profiles:
+      - graph
+      - full
     ports:
       - "127.0.0.1:${NEO4J_HTTP_PORT:-7474}:7474"  # HTTP
       - "127.0.0.1:${NEO4J_BOLT_PORT:-7687}:7687"  # Bolt
@@ -191,6 +197,9 @@ services:
         A2A_INSPECTOR_REPO: ${A2A_INSPECTOR_REPO:-https://github.com/a2aproject/a2a-inspector.git}
         A2A_INSPECTOR_REF: ${A2A_INSPECTOR_REF:-main}
     container_name: a2a-inspector
+    profiles:
+      - inspect
+      - full
     platform: linux/amd64
     ports:
       - "127.0.0.1:${A2A_INSPECTOR_PORT:-8081}:8080"
@@ -211,6 +220,9 @@ services:
         MCP_INSPECTOR_REPO: ${MCP_INSPECTOR_REPO:-https://github.com/modelcontextprotocol/inspector.git}
         MCP_INSPECTOR_REF: ${MCP_INSPECTOR_REF:-main}
     container_name: mcp-inspector
+    profiles:
+      - inspect
+      - full
     ports:
       - "127.0.0.1:${MCP_INSPECTOR_PORT:-6274}:6274"  # Client UI
     healthcheck:
@@ -225,6 +237,9 @@ services:
   mlflow:
     image: ghcr.io/mlflow/mlflow:v3.5.1
     container_name: mlflow-server
+    profiles:
+      - ml
+      - full
     ports:
       - "127.0.0.1:${MLFLOW_PORT:-5252}:5000"
     volumes:
@@ -243,6 +258,9 @@ services:
   qdrant:
     image: qdrant/qdrant:latest
     container_name: qdrant-emulator
+    profiles:
+      - vector
+      - full
     ports:
       - "127.0.0.1:${QDRANT_REST_PORT:-6333}:6333"  # REST API
       - "127.0.0.1:${QDRANT_GRPC_PORT:-6334}:6334"  # gRPC API
@@ -323,6 +341,9 @@ services:
   elasticsearch:
     image: elasticsearch:9.3.0
     container_name: elasticsearch-emulator
+    profiles:
+      - search
+      - full
     ports:
       - "127.0.0.1:${ELASTICSEARCH_PORT:-9200}:9200"  # REST API
       - "127.0.0.1:${ELASTICSEARCH_TRANSPORT_PORT:-9300}:9300"  # Transport
@@ -364,6 +385,9 @@ services:
   elasticsearch-exporter:
     image: quay.io/prometheuscommunity/elasticsearch-exporter:latest
     container_name: elasticsearch-exporter
+    profiles:
+      - search
+      - full
     command:
       - '--es.uri=http://elasticsearch:9200'
       - '--es.all'
@@ -383,6 +407,9 @@ services:
   postgres-exporter:
     image: prometheuscommunity/postgres-exporter:latest
     container_name: postgres-exporter
+    profiles:
+      - exporters
+      - full
     environment:
       - DATA_SOURCE_NAME=postgresql://postgres:password@postgres:5432/postgres?sslmode=disable
     ports:

--- a/emulator/scripts/start-services.sh
+++ b/emulator/scripts/start-services.sh
@@ -2,13 +2,28 @@
 set -euo pipefail
 
 # Start compose services. Idempotent.
-# Usage: bash scripts/start-services.sh [--no-build]
+#
+# Usage: bash scripts/start-services.sh [--no-build] [SERVICE...]
+#
+#   (no SERVICE)  -> start the default (lite) profile: only services without a
+#                    compose `profiles:` key (firebase + spanner + pgadapter +
+#                    postgres = the GCP core).
+#   SERVICE...    -> start exactly the named services (+ their depends_on).
+#                    Naming a service activates it even if it sits behind a
+#                    compose profile, so `start-services.sh firebase-emulator`
+#                    brings up just Firebase.
+#   COMPOSE_PROFILES=<a,b>  -> additionally start every service tagged with
+#                    those profiles (compose reads this env natively), e.g.
+#                    `COMPOSE_PROFILES=full` for the whole heavy stack.
 
 NO_BUILD=false
+SERVICES=()
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --no-build) NO_BUILD=true; shift ;;
-    *) echo "Unknown arg: $1" >&2; exit 2 ;;
+    --) shift; SERVICES+=("$@"); break ;;
+    -*) echo "Unknown flag: $1" >&2; exit 2 ;;
+    *) SERVICES+=("$1"); shift ;;
   esac
 done
 
@@ -22,10 +37,16 @@ docker network inspect shared-otel-net >/dev/null 2>&1 || {
   docker network create shared-otel-net
 }
 
+# "${SERVICES[@]+...}" guards against an empty array tripping `set -u` on
+# bash 3.2 (stock macOS); on an empty array it expands to nothing.
 if $NO_BUILD; then
-  docker compose up -d --no-build
+  docker compose up -d --no-build ${SERVICES[@]+"${SERVICES[@]}"}
 else
-  docker compose up -d
+  docker compose up -d ${SERVICES[@]+"${SERVICES[@]}"}
 fi
 
-echo "Services started (detached)."
+if [[ ${#SERVICES[@]} -gt 0 ]]; then
+  echo "Services started (detached): ${SERVICES[*]}"
+else
+  echo "Services started (detached): default profile${COMPOSE_PROFILES:+ + COMPOSE_PROFILES=$COMPOSE_PROFILES}."
+fi

--- a/emulator/scripts/wait-for-services.sh
+++ b/emulator/scripts/wait-for-services.sh
@@ -103,17 +103,39 @@ wait_elasticsearch() {
   return 1
 }
 
-# ─── Wait for each service ───
-wait_http          "Firebase UI"      "http://localhost:${FIREBASE_UI_PORT}"                       "$DEFAULT_WAIT"
-wait_elasticsearch "Elasticsearch"    "http://localhost:${ELASTICSEARCH_PORT}/_cluster/health"     "$DEFAULT_WAIT"
-wait_http          "Qdrant"           "http://localhost:${QDRANT_REST_PORT}/healthz"               "$DEFAULT_WAIT"
-wait_http          "Neo4j HTTP"       "http://localhost:${NEO4J_HTTP_PORT}"                        "$DEFAULT_WAIT"
-wait_http          "A2A Inspector"    "http://localhost:${A2A_INSPECTOR_PORT}"                     "$A2A_WAIT"
-wait_http          "MCP Inspector"    "http://localhost:${MCP_INSPECTOR_PORT}"                     "$MCP_WAIT"
-wait_http          "MLflow"           "http://localhost:${MLFLOW_PORT}/"                           "$DEFAULT_WAIT"
-wait_tcp           "Spanner gRPC"     localhost "$SPANNER_GRPC_PORT"                               "$DEFAULT_WAIT"
-wait_tcp           "pgAdapter"        localhost "$PGADAPTER_PORT"                                  "$DEFAULT_WAIT"
-wait_tcp           "Bigtable"         localhost "$BIGTABLE_PORT"                                   "$DEFAULT_WAIT"
-wait_postgres      "PostgreSQL 18"    localhost "$POSTGRES_PORT"                                   "$POSTGRES_WAIT"
+# ─── Profile-aware gating ───
+# Since `just emu-up` now starts only the lite (default-profile) services and
+# `emu-up-group`/`emu-up-only` start arbitrary subsets, we must NOT block on a
+# service that was never started. is_running checks the container by name and
+# guard runs a wait_* only when its container is up (otherwise it prints a skip
+# line). The is_running call sits inside an `if`, so its non-zero exit is exempt
+# from `set -e`; a genuine wait_* timeout on a RUNNING service still fails loud.
+is_running() {
+  local c="$1" status
+  status=$(docker inspect -f '{{.State.Running}}' "$c" 2>/dev/null || echo false)
+  [[ "$status" == "true" ]]
+}
 
-echo "All targeted services reported ready."
+guard() {  # guard <container_name> <wait_fn> [args...]
+  local c="$1"; shift
+  if is_running "$c"; then
+    "$@"
+  else
+    echo "- skip ${c} (not running)"
+  fi
+}
+
+# ─── Wait for each running service ───
+guard firebase-emulator      wait_http          "Firebase UI"   "http://localhost:${FIREBASE_UI_PORT}"                   "$DEFAULT_WAIT"
+guard elasticsearch-emulator wait_elasticsearch "Elasticsearch" "http://localhost:${ELASTICSEARCH_PORT}/_cluster/health" "$DEFAULT_WAIT"
+guard qdrant-emulator        wait_http          "Qdrant"        "http://localhost:${QDRANT_REST_PORT}/healthz"           "$DEFAULT_WAIT"
+guard neo4j-emulator         wait_http          "Neo4j HTTP"    "http://localhost:${NEO4J_HTTP_PORT}"                    "$DEFAULT_WAIT"
+guard a2a-inspector          wait_http          "A2A Inspector" "http://localhost:${A2A_INSPECTOR_PORT}"                 "$A2A_WAIT"
+guard mcp-inspector          wait_http          "MCP Inspector" "http://localhost:${MCP_INSPECTOR_PORT}"                 "$MCP_WAIT"
+guard mlflow-server          wait_http          "MLflow"        "http://localhost:${MLFLOW_PORT}/"                       "$DEFAULT_WAIT"
+guard spanner-emulator       wait_tcp           "Spanner gRPC"  localhost "$SPANNER_GRPC_PORT"                           "$DEFAULT_WAIT"
+guard pgadapter-emulator     wait_tcp           "pgAdapter"     localhost "$PGADAPTER_PORT"                              "$DEFAULT_WAIT"
+guard bigtable-emulator      wait_tcp           "Bigtable"      localhost "$BIGTABLE_PORT"                               "$DEFAULT_WAIT"
+guard postgres-18            wait_postgres      "PostgreSQL 18" localhost "$POSTGRES_PORT"                               "$POSTGRES_WAIT"
+
+echo "All running services reported ready."

--- a/justfile
+++ b/justfile
@@ -1066,12 +1066,36 @@ exe-cdr-install:
 # scripts use bare `docker compose`; recipes cd into emulator/ for auto-discovery
 # ------------------------------
 
-# Start emulators (detached). nobuild=yes skips image build
+# nobuild=yes skips image build. More: emu-up-group/-only/-full. COMPOSE_PROFILES
+# is cleared so a stray shell env can't drag in heavy services.
+# Start the lite profile: firebase + spanner + pgadapter + postgres (GCP core)
 [group('Emulator')]
 emu-up nobuild='no':
-    cd emulator && if [ '{{nobuild}}' = 'yes' ]; then bash scripts/start-services.sh --no-build; else bash scripts/start-services.sh; fi
+    cd emulator && if [ '{{nobuild}}' = 'yes' ]; then COMPOSE_PROFILES= bash scripts/start-services.sh --no-build; else COMPOSE_PROFILES= bash scripts/start-services.sh; fi
 
-# One-shot: clean volumes -> prebuild -> up -> wait
+# Explicit alias for the lite default above.
+alias emu-up-lite := emu-up
+
+# Bypasses profile gating; consumers reuse this (e.g. runops on :9399).
+# e.g. `just emu-up-only firebase-emulator` brings up only Firebase.
+# Start exactly the named service(s) (+ their depends_on)
+[group('Emulator')]
+emu-up-only +services:
+    cd emulator && COMPOSE_PROFILES= bash scripts/start-services.sh {{services}}
+
+# Groups: bigtable search graph vector ml inspect exporters full.
+# e.g. `just emu-up-group search` = lite + Elasticsearch.
+# Start lite + a capability group
+[group('Emulator')]
+emu-up-group group nobuild='no':
+    cd emulator && if [ '{{nobuild}}' = 'yes' ]; then COMPOSE_PROFILES='{{group}}' bash scripts/start-services.sh --no-build; else COMPOSE_PROFILES='{{group}}' bash scripts/start-services.sh; fi
+
+# Start the whole heavy stack (every data service; excludes interactive *-cli).
+[group('Emulator')]
+emu-up-full nobuild='no':
+    cd emulator && if [ '{{nobuild}}' = 'yes' ]; then COMPOSE_PROFILES=full bash scripts/start-services.sh --no-build; else COMPOSE_PROFILES=full bash scripts/start-services.sh; fi
+
+# One-shot LITE: clean volumes -> prebuild lite images -> up lite -> wait
 [group('Emulator')]
 emu-start:
     #!/usr/bin/env bash
@@ -1079,8 +1103,20 @@ emu-start:
     cd emulator
     echo '🧹 Cleaning old volumes...'
     docker compose down -v || true
+    bash scripts/prebuild-images.sh firebase-emulator postgres
+    COMPOSE_PROFILES= bash scripts/start-services.sh
+    bash scripts/wait-for-services.sh --default 30 --postgres 60
+
+# One-shot FULL: clean volumes -> prebuild heavy images -> up everything -> wait
+[group('Emulator')]
+emu-start-full:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    cd emulator
+    echo '🧹 Cleaning old volumes...'
+    docker compose down -v || true
     bash scripts/prebuild-images.sh a2a-inspector firebase-emulator mcp-inspector postgres
-    bash scripts/start-services.sh
+    COMPOSE_PROFILES=full bash scripts/start-services.sh
     bash scripts/wait-for-services.sh --default 30 --a2a 60 --mcp 60 --postgres 60
 
 # Stop emulators (with Firebase export)
@@ -1114,7 +1150,9 @@ emu-port-check:
     #!/usr/bin/env bash
     set -uo pipefail
     echo '🔍 Checking emulator port usage...'
-    for port in 9099 8080 8086 9010 9020 55432 7474 7687 8081 6274 5252 6333 6334 5433 9200 9300; do
+    # Includes the cross-stack collision ports (9399/4000/4400 firebase, 4317/4318
+    # OTLP) that previously went unchecked and let runops-gateway double-bind.
+    for port in 9099 8080 9399 4000 4400 8086 9010 9020 55432 7474 7687 8081 6274 5252 6333 6334 5433 9200 9300 4317 4318; do
       result=$(witr --port "$port" --short 2>/dev/null || true)
       [ -n "$result" ] && echo "⚠️  Port $port: $result"
     done


### PR DESCRIPTION
## なぜ (背景)

`emu`/`tel`/`emu-api` を起動した状態で外部リポ（例: runops-gateway の `just pubsub-init` + e2e）を回すと **OrbStack VM が落ちる** 事象を調査。多角的検証で根本原因を特定した:

- **H1 (乾いた薪)**: OrbStack VM が 10 GiB / 3 vCPU に手動キャップ（`~/.orbstack/vmconfig.json`、host は 64GB）。
- **H2 (着火点)**: `just emu-up` が profile 無指定で**重量級フルスタックを丸ごと**起動（firebase + neo4j 1G heap + ES 512m + bigtable/a2a の amd64 Rosetta + …）。そこに外部リポが 2 つ目の firebase suite 等を被せると host port 衝突 + メモリ二重消費で RSS が 10 GiB を突破 → guest OOM/thrash → VM 停止。

docker の host-port 二重 bind 拒否は clean exit を返すだけで VM は落とさない。VM Stopped は guest メモリ event。`emu-up` が常に全部入りなのが構造的な火種だった。

## 何を (この PR)

emulator スタックに **lite 既定 + capability profile** を導入し、起動対象を細かく選べるようにする。

| recipe | 起動内容 |
|---|---|
| `just emu-up` (= `emu-up-lite`) | **GCPコア**: firebase + spanner + pgadapter + postgres |
| `just emu-up-only <svc...>` | 名指しサービスのみ（profile gate を bypass。consumer が再利用） |
| `just emu-up-group <cap>` | lite + capability (`bigtable search graph vector ml inspect exporters full`) |
| `just emu-up-full` | 全データサービス（interactive `*-cli` 除く） |
| `just emu-start` / `emu-start-full` | clean+prebuild+up+wait の lite / full 版 |

- `emu-port-check` に、これまで盲点だった**クロススタック衝突ポート** (9399/4000/4400 firebase, 4317/4318 OTLP) を追加。
- `emu-up` は `COMPOSE_PROFILES=` を明示クリアし、shell 環境汚染で heavy が混入する事故を防止。

## コミット分割 (Tidy First)

1. `refactor(emulator)` — start/wait スクリプトを profile-aware + 引数駆動に（**挙動不変**な構造変更）
2. `feat(emulator)` — compose profiles + justfile recipe 群 + docs（既定を lite に変える挙動変更）

## 検証

- `docker compose config --services`: lite=4種 / `COMPOSE_PROFILES=full`=全データ / `=search`=lite+ES を確認
- `bash -n` + `shellcheck`: 両スクリプト clean
- `just --list`: パース成功・新 recipe / alias 表示
- `tests/test_justfile_env_checks.py`: 3 passed
- `markdownlint`: 0 error
- devcontainer サンドボックスの `just test` は OrbStack 稼働が前提のため CI 側で実行（ローカルは VM 停止中）

## 関連 / 後続

- 外部リポ側（runops-gateway 等）は本 PR の `emu-up-only firebase-emulator` で Pub/Sub(:9399) を**再利用**し、自前 emulator の二重起動をやめる方針（別途対応）。
- OrbStack VM のサイズ調整（16GiB/4vCPU）は各自のローカル設定（本 PR 対象外）。