### PR TITLE
fix(emulator): tear down all profiles in emu-stop/clean/start

### DIFF
--- a/emulator/scripts/stop-services.sh
+++ b/emulator/scripts/stop-services.sh
@@ -18,5 +18,9 @@ else
 fi
 
 echo "🛑 Stopping containers..."
-docker compose down
+# `docker compose down` is profile-gated: with no profile active it only stops
+# the default (lite) services and leaves profiled heavy containers running.
+# Enable every profile (full covers all capability services, cli the helpers)
+# so a stop after `emu-up-full` / `emu-up-group` tears the whole stack down.
+COMPOSE_PROFILES=full,cli docker compose down --remove-orphans
 echo "✅ All emulators stopped."

--- a/justfile
+++ b/justfile
@@ -1102,7 +1102,9 @@ emu-start:
     set -euo pipefail
     cd emulator
     echo '🧹 Cleaning old volumes...'
-    docker compose down -v || true
+    # `down` is profile-gated: without all profiles enabled it only tears down
+    # the default (lite) services, orphaning any profiled heavy containers.
+    COMPOSE_PROFILES=full,cli docker compose down -v --remove-orphans || true
     bash scripts/prebuild-images.sh firebase-emulator postgres
     COMPOSE_PROFILES= bash scripts/start-services.sh
     bash scripts/wait-for-services.sh --default 30 --postgres 60
@@ -1114,7 +1116,8 @@ emu-start-full:
     set -euo pipefail
     cd emulator
     echo '🧹 Cleaning old volumes...'
-    docker compose down -v || true
+    # `down` is profile-gated; enable all profiles so every service is removed.
+    COMPOSE_PROFILES=full,cli docker compose down -v --remove-orphans || true
     bash scripts/prebuild-images.sh a2a-inspector firebase-emulator mcp-inspector postgres
     COMPOSE_PROFILES=full bash scripts/start-services.sh
     bash scripts/wait-for-services.sh --default 30 --a2a 60 --mcp 60 --postgres 60
@@ -1140,9 +1143,11 @@ emu-prebuild images='a2a-inspector firebase-emulator mcp-inspector postgres':
     cd emulator && bash scripts/prebuild-images.sh {{images}}
 
 # Clean up emulator volumes (deletes all data)
+# COMPOSE_PROFILES=full,cli so the profile-gated `down` removes every service
+# (lite + heavy + cli), not just the default-profile ones.
 [group('Emulator')]
 emu-clean:
-    cd emulator && docker compose down -v || true
+    cd emulator && COMPOSE_PROFILES=full,cli docker compose down -v --remove-orphans || true
 
 # Check emulator port usage before starting
 [group('Emulator')]


### PR DESCRIPTION
## なぜ（#120 の回帰）

PR #120 で compose profiles を導入したことで `docker compose down` が **profile-gated** になり、`emu-stop` / `emu-clean` / `emu-start` の pre-clean が **default(lite) サービスしか落とさず**、profiled な heavy コンテナ（neo4j / ES / qdrant / inspectors / exporters / bigtable …）を**取り残す**回帰が入っていた。

**動作確認で実機再現**: `emu-up-group graph`（lite + neo4j）→ `emu-stop` が「✅ All emulators stopped」と表示しつつ **neo4j 含む profiled 9コンテナが走ったまま**だった。`docker compose down --remove-orphans` 単体でも profile-disabled は掃除されず、`COMPOSE_PROFILES=full,cli docker compose down --remove-orphans` で初めて全部落ちることを確認。

## 何を

全 `docker compose down` 系を全 profile 有効化に修正（`full`=全 capability、`cli`=ヘルパー、+ `--remove-orphans`）:
- `emulator/scripts/stop-services.sh`（`emu-stop`）
- justfile `emu-clean` / `emu-start` / `emu-start-full` の pre-clean `down -v`

## 実機検証（このPRの変更で確認済み）

- `emu-up yes`（lite）→ firebase/spanner/pgadapter/postgres の **4つだけ**起動
- `emu-wait` → 稼働中4つを待ち、**absent 6サービスを skip して 1.5秒で完走**（hang なし）
- `emu-up-group graph yes` → lite + neo4j → **`emu-stop` で neo4j 含め全停止**（本修正の核心）
- `emu-up-only firebase-emulator` → **firebase のみ**起動、Pub/Sub :9399 / Firestore :8080 = 200
- `tel-up` → otel-collector OTLP :4317 OPEN
- firebase + tel 同時稼働でメモリ **<1GiB**（VM 16GiB に対し激余裕）

## 関連

- #120（profiles 導入、本回帰の原因）/ runops #139（自前 jaeger 廃止）
- フォローアップ案: justfile の `down` 系に `COMPOSE_PROFILES=full,cli` が付いているかを静的検査する guard test（`tests/test_justfile_env_checks.py` 流儀）を別途追加検討