### PR TITLE
refactor: retire pnpm-global subsystem, provision pnpm via corepack

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -63,16 +63,12 @@
     // Coder workspace `/home/<user>:/root` volume mount cannot mask
     // the build-time-baked installs. Shims live alongside.
     "MISE_DATA_DIR": "/opt/mise",
-    // pnpm 9+ requires PNPM_HOME on PATH; otherwise `pnpm list -g`
-    // and similar global commands abort with "configured global bin
-    // directory ... is not in PATH". This was a soft warning in
-    // pnpm 8 and became a hard error after pnpm 9.0 (corepack-shipped
-    // pnpm bumps as the upstream node release advances). Set the
-    // canonical PNPM_HOME and prepend it so the just sandbox tests
-    // (`check-pnpm-g`, `update-pnpm-g-safe`) see the expected layout
-    // without each test having to run `pnpm setup`.
-    "PNPM_HOME": "/root/.local/share/pnpm",
-    "PATH": "/root/.local/share/pnpm/bin:/root/.local/share/pnpm:/root/.local/bin:/opt/mise/shims:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin",
+    // pnpm is provided per-repo by corepack (the package-manager shim
+    // shipped with node); we no longer install pnpm globals, so no
+    // PNPM_HOME global-bin needs to be on PATH. corepack's pnpm shim
+    // lands in the node bin dir (/usr/local/bin), already on PATH.
+    // See docs/adr/0017-retire-pnpm-global-for-corepack.md.
+    "PATH": "/root/.local/bin:/opt/mise/shims:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin",
     // Surfaces the HOST workspace path to processes inside the
     // container. The pytest fixture reads this to bind-mount the
     // workspace into one-shot sub-containers it spins up via

--- a/.devcontainer/features/dotfiles-tools/install.sh
+++ b/.devcontainer/features/dotfiles-tools/install.sh
@@ -262,33 +262,19 @@ echo "[dotfiles-tools] pre-installing mise.toml tools at build time (MISE_DATA_D
 )
 MISE_TRUSTED_CONFIG_PATHS=/etc/mise mise reshim || true
 
-# pnpm 9+ requires PNPM_HOME on PATH; otherwise `pnpm list -g` /
-# `pnpm add -g` abort with "configured global bin directory ... is
-# not in PATH". devcontainer.json's `containerEnv` covers the IDE /
-# Coder workspace path, but the just sandbox tests run via `docker
-# run --rm bash -lc` which inherits ENV from the saved image layer
-# only — and dev container's containerEnv is applied at runtime, not
-# baked. Write a /etc/profile.d snippet so `bash -lc` (login shell)
-# sources it through /etc/profile -> /etc/profile.d/*.sh and the
-# PATH layout matches what `pnpm setup` would produce.
-echo "[dotfiles-tools] writing /etc/profile.d/pnpm.sh"
-mkdir -p /root/.local/share/pnpm/bin
-cat > /etc/profile.d/pnpm.sh <<'PNPM_PROFILE'
-# pnpm 9+ global bin directory bootstrap (build-time baked).
-# pnpm reports the bin dir as $PNPM_HOME/bin and aborts global
-# operations when it is missing from PATH; mirror what `pnpm setup`
-# writes to the user shell rc plus the bin subdir prepend.
-export PNPM_HOME="/root/.local/share/pnpm"
-case ":${PATH}:" in
-  *":${PNPM_HOME}/bin:"*) ;;
-  *) export PATH="${PNPM_HOME}/bin:${PATH}" ;;
-esac
-case ":${PATH}:" in
-  *":${PNPM_HOME}:"*) ;;
-  *) export PATH="${PNPM_HOME}:${PATH}" ;;
-esac
-PNPM_PROFILE
-chmod 0755 /etc/profile.d/pnpm.sh
+# pnpm/yarn are provided per-repo by corepack (the package-manager
+# shim shipped with node). We no longer install pnpm globals, so there
+# is no PNPM_HOME global-bin to bootstrap. Enable corepack at build
+# time so its pnpm shim lands in the node bin dir (already on PATH);
+# each project pins its PM via the `packageManager` field and corepack
+# runs that exact version on demand. Global CLIs live in mise's npm:
+# backend instead. See docs/adr/0017-retire-pnpm-global-for-corepack.md.
+if command -v corepack >/dev/null 2>&1; then
+  echo "[dotfiles-tools] enabling corepack"
+  corepack enable || true
+else
+  echo "[dotfiles-tools] corepack not on PATH; skipping (node feature should provide it)"
+fi
 
 # Cleanup apt cache to keep the image lean.
 rm -rf /var/lib/apt/lists/*

--- a/.zshrc
+++ b/.zshrc
@@ -49,12 +49,13 @@ ZSH_AUTOSUGGEST_BUFFER_MAX_SIZE=20
 ZSH_AUTOSUGGEST_STRATEGY=(history completion)
 
 # Precedence tweaks
-# PNPM first for Node CLIs
+# pnpm is provided per-repo by corepack; we do NOT install pnpm globals.
+# Keep PNPM_HOME so the content-addressed store stays at ~/Library/pnpm/store
+# (shared by per-project `pnpm install`), but deliberately do NOT put the
+# global bin dir on PATH — that makes `pnpm add -g` abort, steering global
+# CLIs to mise's npm: backend instead.
+# See docs/adr/0017-retire-pnpm-global-for-corepack.md.
 export PNPM_HOME="$HOME/Library/pnpm"
-path_prepend "$PNPM_HOME"
-# pnpm 9+ reports the global bin dir as $PNPM_HOME/bin and aborts
-# `pnpm add/update -g` when it is missing from PATH (mirror `pnpm setup`)
-path_prepend "$PNPM_HOME/bin"
 
 # Prefer OrbStack Docker if present
 path_prepend "$HOME/.orbstack/bin"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,6 +92,9 @@ ADR 0014 (vendoring) / 0015 (portless) / 0016 (emulate)。
   (memory `feedback_git_history_rewrite_gpg`)。
 - **mise の npm backend は `--ignore-scripts=true`** — postinstall 必須の npm ツール
   (claude-code native binary 等) は `npm_args` で上書き (memory `project_mise_npm_ignore_scripts`)。
+- **pnpm は corepack 供給の per-repo 専用、global CLI は mise npm: のみ** (ADR 0017)。
+  `pnpm add -g` 禁止 (`$PNPM_HOME/bin` を PATH に載せないので自然に abort する)。
+  `dump/npm-global` / `add-pnpm-g` / `update-pnpm-g*` / `check-pnpm-g` は退役済み。
 - devcontainer features は Microsoft 公式のみ (community 不可、memory
   `feedback_no_community_devcontainer_features`)。
 

--- a/docs/adr/0017-retire-pnpm-global-for-corepack.md
+++ b/docs/adr/0017-retire-pnpm-global-for-corepack.md
@@ -1,0 +1,123 @@
+# 0017. Retire the pnpm-global subsystem in favor of corepack + mise npm
+
+**Date:** 2026-06-02
+**Status:** Accepted
+
+## Context
+
+This repo maintained **two parallel declarative systems** for global Node
+CLIs:
+
+1. **mise npm: backend** — `mise.toml` pins AI CLIs as `"npm:@openai/codex"`
+   etc. (ADR 0006). This is the modern, version-pinned, SHA-consistency-checked
+   path.
+2. **pnpm-global subsystem** — a `dump/npm-global` manifest restored/updated by
+   `just add-pnpm-g` / `update-pnpm-g(-safe)` / `check-pnpm-g`, wired into
+   `install.sh` via `step_pnpm_globals`, with `PNPM_HOME` + global-bin PATH
+   baked into `.zshrc` (host) and the dev container (`devcontainer.json`
+   `containerEnv` + `/etc/profile.d/pnpm.sh` in the feature), and asserted by
+   sandbox tests.
+
+The two systems fight on `PATH` and double-own the same responsibility (make a
+global CLI available declaratively). The friction surfaced when corepack-shipped
+pnpm advanced from major 10 to 11: `pnpm list -g` reads the new global state
+directory (`~/Library/pnpm/global/v11`) while every package installed under
+pnpm 10 sits in `~/Library/pnpm/global/5`. The pnpm-global subsystem silently
+broke — `pnpm list --global` reported "No global packages found" even though the
+CLIs were physically present and still runnable via their bin shims. A
+same-day band-aid (`263a222`, "path fix for pnpm") prepended `$PNPM_HOME/bin`
+to keep `pnpm add -g` from aborting, deepening the dependence on a subsystem we
+no longer want.
+
+`pnpm` is not the daily Node package manager here: `bun` is the default and
+`pnpm` is a fallback used only when a repo carries a `pnpm-lock.yaml`. That makes
+a globally-managed pnpm an over-investment.
+
+## Decision
+
+**Retire the pnpm-global subsystem entirely. pnpm is provided per-repo by
+corepack; global Node CLIs live exclusively in mise's npm: backend.**
+
+Concretely:
+
+- `pnpm` comes from **corepack** (the package-manager shim shipped with node).
+  Each project pins its version via the `packageManager` field; corepack runs
+  that exact version on demand. `install.sh` and the dev container feature
+  run `corepack enable` (guarded by `command -v corepack`).
+- The dump-manifest provisioning (`dump/npm-global`, `add-pnpm-g`,
+  `update-pnpm-g`, `update-pnpm-g-safe`, `check-pnpm-g`, `step_pnpm_globals`)
+  is removed.
+- `PNPM_HOME` global-bin is no longer prepended to `PATH` on host or in the
+  container. `export PNPM_HOME` is kept on host only so the content-addressed
+  **store** stays at `~/Library/pnpm/store` (shared by per-project
+  `pnpm install`); deliberately omitting the global-bin from PATH makes
+  `pnpm add -g` abort, steering global installs to mise.
+- New global CLIs are declared in mise's npm: backend (`mise.toml` for the
+  dev-container/workspace set, host global mise config for host-only tools).
+- `check-pnpm-dlx` + `dump/npm-dlx` are **kept**: `pnpm dlx` is ephemeral
+  execution, not a global install, and remains valid under corepack.
+
+## Enforcement inventory
+
+This ADR pins the invariant: **pnpm is never installed globally; global Node
+CLIs always go through mise npm:.**
+
+### Entry points
+
+- `install.sh` bootstrap (`step_corepack`) — host day-1 provisioning.
+- `.devcontainer/features/dotfiles-tools/install.sh` — dev container build.
+- `.devcontainer/devcontainer.json` `containerEnv.PATH` — runtime PATH layout.
+- `.zshrc` — host interactive shell PATH/env.
+- `justfile` add/update/check recipe families — operator-driven provisioning.
+
+### Persistent / carried data needed at each enforcement point
+
+- `corepack` binary on PATH (from `npm "corepack"` in `dump/Brewfile`, or the
+  dev container node feature).
+- `mise.toml` npm: pins for the global CLI set (SHA-consistency-checked against
+  the feature's `/etc/mise/config.toml` heredoc per ADR 0006).
+- `PNPM_HOME` (host) pointing at the store root only.
+
+### Bypass candidates ("where can this go wrong?")
+
+- A future edit re-adding `pnpm add -g` / `add-pnpm-g` to `install.sh` or the
+  justfile.
+- Re-prepending `$PNPM_HOME/bin` to PATH in `.zshrc` or `devcontainer.json`,
+  re-enabling silent global installs.
+- A new `dump/npm-global`-style manifest.
+
+### Tests proving coverage
+
+- `tests/test_install_os_dispatch.py::test_install_sh_enables_corepack_not_pnpm_globals`
+  — asserts `install.sh` runs `corepack enable` and contains neither
+  `step_pnpm_globals` nor `add-pnpm-g`.
+- `tests/test_install_os_dispatch.py` `REQUIRED_STEPS` — pins `step_corepack`
+  as a named, invoked step.
+- `tests/test_mise_pin_consistency.py::test_system_mise_config_matches_workspace_mise_toml`
+  — keeps mise.toml ↔ feature heredoc in lockstep, so the npm: SoT cannot drift.
+- `tests/test_just_sandbox.py` — no longer exercises pnpm-global recipes; the
+  `add-all` guard test no longer seeds `dump/npm-global`.
+
+## Consequences
+
+### Positive
+
+- One declarative system for global CLIs (mise npm:), not two.
+- pnpm version is per-repo and correct-by-construction via `packageManager`.
+- The pnpm major-bump breakage class (global state dir `5` vs `v11`) is gone.
+- Less host/container PATH surface; `pnpm add -g` is naturally discouraged.
+
+### Negative
+
+- Global CLIs that previously lived in `dump/npm-global`
+  (`@smithery/cli`, `@vonage/cli`, `ajv-cli`, `surge`, `takt`) are retired;
+  any still wanted must be re-declared in mise npm: explicitly.
+- corepack download-on-demand interacts with the npm `min-release-age`
+  quarantine; brand-new pnpm versions may need a one-off override.
+
+### Neutral
+
+- `portless` (a host-only local-dev CLI, already a mise npm: tool, never part of
+  `dump/npm-global`) is unaffected functionally. Fully repo-tracking it depends
+  on bringing the host global mise config into the repo, tracked separately.
+- `export PNPM_HOME` remains on host purely as the store-dir anchor.

--- a/dump/npm-global
+++ b/dump/npm-global
@@ -1,6 +1,0 @@
-@smithery/cli
-@vonage/cli
-ajv-cli
-pnpm
-surge
-takt

--- a/install.sh
+++ b/install.sh
@@ -234,24 +234,25 @@ step_gcloud_bundle() {
   esac
 }
 
-step_pnpm_globals() {
-  if [ -n "${INSTALL_SKIP_ADD_UPDATE:-}" ]; then
-    echo "[install] step_pnpm_globals: skip (INSTALL_SKIP_ADD_UPDATE=1)"
-    return
-  fi
+step_corepack() {
+  # pnpm/yarn are provided per-repo by corepack (the package-manager
+  # shim shipped with node). We no longer install pnpm globals: each
+  # project pins its PM via the `packageManager` field and corepack
+  # runs that exact version on demand. Global CLIs live in mise's npm:
+  # backend instead. See docs/adr/0017-retire-pnpm-global-for-corepack.md.
   case "$DOTFILES_OS" in
     mac|linux)
-      # Linux runs this too: pnpm is provided by the dev container
-      # feature and the operator wants the same npm-globals set
-      # (vp, markdownlint-cli2, etc.) available on workspaces.
-      if command -v pnpm >/dev/null 2>&1; then
-        just add-pnpm-g
+      # Guard: the minimal Ubuntu install-test image has no node/corepack.
+      # corepack is provided by `npm "corepack"` in dump/Brewfile (brew
+      # bundle) or by the dev container node feature.
+      if command -v corepack >/dev/null 2>&1; then
+        corepack enable
       else
-        echo "[install] step_pnpm_globals: pnpm not on PATH; skipping (dev container feature should install it)"
+        echo "[install] step_corepack: corepack not on PATH; skipping (provided by brew bundle / dev container feature)"
       fi
       ;;
     windows)
-      _todo_windows "step_pnpm_globals"
+      _todo_windows "step_corepack"
       ;;
   esac
 }
@@ -306,7 +307,7 @@ step_gcloud_components
 step_just_bootstrap
 step_brew_bundle
 step_gcloud_bundle
-step_pnpm_globals
+step_corepack
 step_update_all
 step_symlink_dotfiles
 step_sheldon

--- a/justfile
+++ b/justfile
@@ -187,9 +187,6 @@ dump:
     cp ~/.config/git/ignore ./dump/gitignore-global
     # Dump installed gcloud components (restore with: just add-gcloud)
     gcloud components list --filter='state.name=Installed' --format='value(id)' 2>/dev/null | sort -u > ./dump/gcloud
-    # Dump installed pnpm globals (restore with: just add-pnpm-g)
-    # Use --json so only top-level deps are captured; --parseable would also include the .pnpm content-addressed store.
-    env -C "$HOME" pnpm ls -g --depth 0 --json 2>/dev/null | jq -r '.[0].dependencies | keys[]' | sort -u > ./dump/npm-global
 
 
 # ------------------------------
@@ -391,12 +388,11 @@ test-iac:
 # Add sets
 # ------------------------------
 
-# Add (all): install gcloud/brew/pnpm sets
+# Add (all): install gcloud/brew sets
 [group('Add')]
 add-all:
     just add-gcloud
     just add-brew
-    just add-pnpm-g
 
 # Add: install Homebrew bundle from dump/Brewfile (idempotent via brew bundle)
 [group('Add')]
@@ -428,29 +424,6 @@ add-gcloud:
     echo "$missing" | sed 's/^/  - /'
     sudo gcloud components install --quiet $missing
 
-# Add: install pnpm globals from dump/npm-global (skips already-installed)
-[group('Add')]
-add-pnpm-g:
-    #!/usr/bin/env bash
-    set -euo pipefail
-    dump="./dump/npm-global"
-    if [[ ! -s "$dump" ]]; then
-        echo "❌ $dump is missing or empty"; exit 1
-    fi
-    # Strip trailing @version (keep scoped "@scope/name" intact)
-    want=$(sed -E 's/(^.+)@[^@]+$/\1/' "$dump" | sort -u)
-    # Use --json so only top-level deps are captured (parseable would include the .pnpm store too).
-    installed=$(env -C "$HOME" pnpm ls -g --depth 0 --json 2>/dev/null | jq -r '.[0].dependencies | keys[]' | sort -u)
-    missing=$(comm -23 <(echo "$want") <(echo "$installed"))
-    if [[ -z "$missing" ]]; then
-        echo "✅ all pnpm globals in $dump are already installed"
-        exit 0
-    fi
-    echo "📦 installing missing pnpm globals:"
-    echo "$missing" | sed 's/^/  - /'
-    # pnpm refuses to run inside projects pinning packageManager; run from $HOME.
-    env -C "$HOME" pnpm add --global $missing
-
 # ------------------------------
 # Update sets
 # ------------------------------
@@ -462,12 +435,11 @@ update-my-submodules:
     git submodule update --remote skills
     @echo "✅ Submodules updated."
 
-# Update (all): update gcloud/brew/pnpm and tools (pnpm safe mode)
+# Update (all): update gcloud/brew and tools (pnpm is corepack/per-repo, not global)
 [group('Update')]
 update-all:
     just update-gcloud
     just update-brew
-    just update-pnpm-g-safe
     @echo "◆ mise..."
     @if command -v mise >/dev/null 2>&1; then mise up && mise plugins up; else echo 'mise not found; skip'; fi
     @echo "◆ gh..."
@@ -479,12 +451,11 @@ update-all:
     @echo "◆ vscode extensions..."
     @if command -v code >/dev/null 2>&1; then code --update-extensions; else echo 'code not found; skip'; fi
 
-# Update (all, safe): update pnpm individually; skip failures
+# Update (all, safe): same as update-all (kept as alias for muscle memory)
 [group('Update')]
 update-all-safe:
     just update-gcloud
     just update-brew
-    just update-pnpm-g-safe
     @echo "◆ mise..."
     @if command -v mise >/dev/null 2>&1; then mise up && mise plugins up; else echo 'mise not found; skip'; fi
     @echo "◆ gh..."
@@ -507,27 +478,6 @@ update-brew:
 update-gcloud:
     @echo "◆ gcloud..."
     sudo gcloud components update --quiet
-
-# Update: update pnpm global packages
-[group('Update')]
-update-pnpm-g:
-    @echo "◆ pnpm..."
-    pnpm update --global
-
-# Update: safely update pnpm globals (per-package; skip failures)
-[group('Update')]
-update-pnpm-g-safe:
-    @echo "◆ pnpm(safe)..."
-    @if command -v jq >/dev/null 2>&1; then \
-      global_pkg_json="$(pnpm root -g 2>/dev/null)/../package.json"; \
-      pkgs=$(jq -r '.dependencies | keys[]' "$$global_pkg_json" 2>/dev/null || true); \
-      if [ -z "$$pkgs" ]; then echo 'No global packages found.'; exit 0; fi; \
-      for p in $$pkgs; do echo "→ updating $$p"; pnpm add -g "$$p@latest" || echo "skip $$p"; done; \
-    else \
-      echo '⚠️ jq not found; falling back to pnpm update --global (best effort)'; \
-      pnpm update --global || true; \
-    fi
-    pnpm store prune || true
 
 # Repair: reset Homebrew state (rebase leftovers, inconsistencies)
 [group('Setup')]
@@ -578,11 +528,6 @@ check-gcloud:
 [group('Check')]
 check-npm-g:
     npm ls --global --depth 0
-
-# Check: list pnpm global packages
-[group('Check')]
-check-pnpm-g:
-    pnpm list -g --depth=0
 
 # Check: list pnpm dlx packages (record-only; not auto-installed)
 [group('Check')]

--- a/tests/test_install_os_dispatch.py
+++ b/tests/test_install_os_dispatch.py
@@ -8,7 +8,7 @@ each install step wrapped in a `step_*` helper function. The
 helpers branch on `DOTFILES_OS` so:
 
   - mac:     runs the historical Homebrew + brew bundle + gcloud
-             components + pnpm globals + update-all flow
+             components + corepack enable + update-all flow
   - linux:   runs only symlink + sheldon (the dev container
              feature already provided everything else with SHA/
              SLSA verification at build time)
@@ -116,7 +116,7 @@ REQUIRED_STEPS = (
     "step_sheldon",
     "step_brew_bundle",
     "step_gcloud_components",
-    "step_pnpm_globals",
+    "step_corepack",
     "step_update_all",
 )
 
@@ -254,3 +254,23 @@ def test_install_sh_unknown_uname_exits_nonzero(tmp_path: Path) -> None:
         f"should see an unsupported-OS message. Combined output:\n"
         f"{combined}"
     )
+
+
+# ---------- corepack migration (retire pnpm-global) ----------------
+
+
+def test_install_sh_enables_corepack_not_pnpm_globals(install_sh_text: str) -> None:
+    """ADR 0017 retires the pnpm-global subsystem: pnpm is provided
+    per-repo by corepack, and `install.sh` enables corepack instead of
+    restoring pnpm globals from a dump manifest. Pin both halves so a
+    future edit cannot silently resurrect `pnpm add -g` provisioning."""
+    assert "corepack enable" in install_sh_text, (
+        "install.sh must enable corepack (the per-repo pnpm provider) "
+        "in step_corepack. See ADR 0017."
+    )
+    for retired in ("step_pnpm_globals", "add-pnpm-g"):
+        assert retired not in install_sh_text, (
+            f"install.sh still references the retired pnpm-global token "
+            f"{retired!r}. ADR 0017 removed the pnpm-global subsystem; "
+            f"pnpm is corepack-provided per-repo now."
+        )

--- a/tests/test_just_sandbox.py
+++ b/tests/test_just_sandbox.py
@@ -440,19 +440,6 @@ def test_just_commands_sandbox(
             id="Doctor: PATH duplicates warn",
             marks=pytest.mark.validate,
         ),
-        pytest.param(
-            # The "jq not found" fallback was meaningful on alpine
-            # where jq was absent; debian + Microsoft features ship
-            # jq via common-utils / git-core deps, so the recipe
-            # takes the jq-present path. Just assert it succeeds.
-            "pnpm_safe_fallback_runs",
-            "just update-pnpm-g-safe",
-            0,
-            "",
-            "",
-            id="Update: pnpm safe fallback",
-            marks=pytest.mark.check,
-        ),
     ],
 )
 def test_additional_scenarios_sandbox(
@@ -535,17 +522,6 @@ def test_doctor_reports_just(docker_image):
             marks=pytest.mark.check,
         ),
         pytest.param(
-            # pnpm may or may not be present depending on the node
-            # devcontainer feature config; either branch should
-            # exit 0. No stdout assertion.
-            "Check: pnpm globals guarded",
-            "if command -v pnpm >/dev/null 2>&1; then just check-pnpm-g; else echo skip-pnpm; fi",
-            0,
-            "",
-            id="Check: pnpm globals guarded",
-            marks=pytest.mark.check,
-        ),
-        pytest.param(
             # check-pnpm-dlx is a record-only listing (grep over dump/npm-dlx).
             # pnpm itself is not required; the recipe always exits 0 and
             # prints the header line.
@@ -603,9 +579,6 @@ def test_doctor_sandbox(docker_image):
     [
         pytest.param("add-brew", "dump/Brewfile", id="add-brew guards empty Brewfile"),
         pytest.param("add-gcloud", "dump/gcloud", id="add-gcloud guards empty dump"),
-        pytest.param(
-            "add-pnpm-g", "dump/npm-global", id="add-pnpm-g guards empty dump"
-        ),
     ],
 )
 @pytest.mark.check
@@ -941,9 +914,7 @@ def test_just_self_check_succeeds(docker_image):
 def test_just_add_all_fails_when_dumps_empty(docker_image):
     """`just add-all` is a composite. With empty dump files it must fail at
     the first add-* guard (rc=1, "missing or empty"), not silently succeed."""
-    script = (
-        ": > dump/Brewfile && : > dump/gcloud && : > dump/npm-global && just add-all"
-    )
+    script = ": > dump/Brewfile && : > dump/gcloud && just add-all"
     result = run_in_sandbox(docker_image, script)
     assert result.returncode != 0
     assert "missing or empty" in result.stdout


### PR DESCRIPTION
## なぜ

`pnpm list --global` が空になる症状の調査から、このリポが **global Node CLI の declarative 管理を2系統並走**させていたことが判明:

1. **mise npm: backend** (`mise.toml`、ADR 0006) — modern・version pin・SHA 一貫性 check 済み
2. **pnpm-global subsystem** — `dump/npm-global` manifest を `add-pnpm-g`/`update-pnpm-g(-safe)`/`check-pnpm-g` で復元/更新、`install.sh` の `step_pnpm_globals`、`.zshrc`/devcontainer の `PNPM_HOME` 焼き込み、sandbox test まで

corepack 同梱の pnpm が major 10→11 に進んだ際、global state dir が `5`→`v11` に変わり、②が静かに機能不全に (`No global packages found`)。直前の band-aid (`263a222`) は ② への依存を深めるだけだった。bun が標準・pnpm は fallback というこのリポの実態では、pnpm の global 管理は over-investment。

## 何を

**② を全廃し、corepack + mise npm: の1系統に集約** (ADR 0017)。pnpm は per-repo の `packageManager` 経由で corepack が供給。global CLI は mise npm: のみ。

- **justfile**: `add-pnpm-g`/`update-pnpm-g(-safe)`/`check-pnpm-g` 削除、`dump` の pnpm 部除去、`add-all`/`update-all` から除去。`check-pnpm-dlx`(record-only) は維持
- **install.sh**: `step_pnpm_globals` → `step_corepack` (`command -v corepack` guard。最小 Ubuntu は graceful skip)
- **devcontainer**: `PNPM_HOME` 焼き込み + `/etc/profile.d/pnpm.sh` 除去 → build 時 `corepack enable`
- **.zshrc**: `$PNPM_HOME(/bin)` の PATH 前置除去。`export PNPM_HOME` は store-dir anchor として残置 (= `pnpm add -g` が自然に abort)
- **dump/npm-global** 削除 (5 CLI 退役。mise.toml は無改変)
- **tests**: `REQUIRED_STEPS` → `step_corepack`、pnpm-global の sandbox ケース除去、corepack 移行の regression guard 追加

製品挙動は保存 (pnpm は corepack 経由で引き続き利用可、global CLI は mise 経由のまま)。

## 検証

- `just ci` (fast gate) ✅
- `just test` (devcontainer sandbox) **88 passed** ✅
- `just test-install` (最小 Ubuntu install.sh) **Verification passed** — `step_corepack` guard が `corepack not on PATH; skipping` で正しく skip ✅
- ruff / prek (fmt + lint) ✅

## レビュー

`codex` で3ラウンドレビュー済み (corepack guard / `step_corepack` 改名と契約テスト / 移住先 tracked 化 / test サイト網羅 を反映)。

## 補足 (このPRの範囲外)

- **host 実体撤去** (`rm -rf ~/Library/pnpm/global` + mise の死に駒 uninstall) は各自の machine state なので別途
- **portless** は dump/npm-global の管轄外 (既に mise npm: の orphan)。mise.toml に入れると SHA 一貫性 test が heredoc 同時編集を要求し dev container に不要な物が焼き込まれるため無改変とした。完全 repo-tracking は global mise config の取り込み (別タスク) 待ち