### PR TITLE
docs(dump): fix npm-dlx pointer to retired dump/npm-global

### DIFF
--- a/dump/npm-dlx
+++ b/dump/npm-dlx
@@ -2,7 +2,9 @@
 #
 # 使い方: `pnpm dlx <package>` または `pnpx <package>`
 # このファイルは自動インストール対象外、記録専用。
-# pnpm global に常駐させるべきものは dump/npm-global を参照。
+# 常駐させたい global CLI は mise の npm: backend (mise.toml /
+# ~/.config/mise/config.toml) で宣言する。pnpm global は廃止
+# (ADR 0017: corepack + mise npm: に一本化)。
 
 # Next.js アップグレード時 (pnpm dlx @next/codemod@canary upgrade latest)
 @next/codemod


### PR DESCRIPTION
## なぜ

完全性検証で発見した #124 の取りこぼし。`dump/npm-global` は #124 (pnpm-global subsystem 退役) で削除したが、`dump/npm-dlx` のヘッダコメントが「常駐させたい物は `dump/npm-global` を参照」と**削除済みファイルを指したまま**残っていた (doc rot)。

## 何を

`dump/npm-dlx` のポインタを、生存している機構 (mise npm: backend) に向け直す。ADR 0017 準拠。

## 検証

- 1行コメント修正のみ。挙動変更なし。`pnpm dlx` / `check-pnpm-dlx` の record-only リスト本体は不変。
- #124 マージ後の host/repo 完全性検証の一環で発見・修正。他の pnpm-global 残骸は ADR 0005 (immutable な履歴記述) と意図的な言及 (test guard / 残置 PNPM_HOME comment) のみで、実ミスはこの1件だけだった。