### PR TITLE
fix(zshrc): guard vite-plus env sourcing to match other conditional loads

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -235,7 +235,9 @@ path_prepend "$HOME/.local/share/mise/shims"
 
 
 # Vite+ bin (https://viteplus.dev)
-. "$HOME/.vite-plus/env"
+if _file_exists "$HOME/.vite-plus/env"; then
+    . "$HOME/.vite-plus/env"
+fi
 
 # guard for Python package index
 # see: https://shisho.dev/docs/ja/r/202603-takumi-guard-pypi/


### PR DESCRIPTION
## なぜ

`.zshrc` line 238 の `. "$HOME/.vite-plus/env"` だけが **裸の unconditional source** で、他の framework/env 読み込み (gcloud SDK include / sheldon / starship / homebrew shellenv 等) は全て `_cmd_exists` / `_file_exists` / `if [ -x ... ]` で guard されている。

`vp` を install したばかりで `~/.vite-plus/env` がまだ生成されていない host (典型: fresh WSL setup) では、zsh 起動の度に

```
/home/<user>/.zshrc:.:238: no such file or directory: /home/<user>/.vite-plus/env
```

が出る。ADR 0017 完全対応の検証中 (PR #124 後の host 整合確認) に WSL2 環境で再現したのが発見の発端。

## 何を

該当行を他行と同じ `_file_exists` guard で囲む 1 ファイル 3 line の追加:

```diff
 # Vite+ bin (https://viteplus.dev)
-. "$HOME/.vite-plus/env"
+if _file_exists "\$HOME/.vite-plus/env"; then
+    . "\$HOME/.vite-plus/env"
+fi
```

`vp` が install され env が生成されていれば従来通り source される (behavior 等価)。未生成環境では silent に skip される。

## 検証

- `just check` (ruff format/check, shellcheck, markdownlint-cli2, vp check) ✅
- `just semgrep-test` ✅ 含む `just ci` の `.zshrc` 関連 fast gate 全 PASS
- 実機: zsh 5.9 login shell で起動 → warning 消失、`PNPM_HOME=~/Library/pnpm` 維持、`corepack pnpm --version` → 11.5.0 維持

(`just ci` の `test-iac` は host で `tofu` 未 install のため skip。`.zshrc` 変更とは無関係。)

## 補足

PR #124 (ADR 0017: pnpm-global 退役 → corepack) の host 整合確認の副産物として検出した、PR #124 とは独立な既存の小さな bug。`.zshrc` の guard 不変条件 (= 全 source 行が conditional) を回復するのみで、新規機能や設計変更は無し。

[BEHAVIORAL]