### PR TITLE
fix(zshrc): guard cargo env sourcing to match other conditional loads

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -107,7 +107,9 @@ path_prepend "$HOME/go/bin"
 path_prepend "/opt/homebrew/opt/curl/bin"
 
 # cargo
-source "$HOME/.cargo/env"
+if _file_exists "$HOME/.cargo/env"; then
+    source "$HOME/.cargo/env"
+fi
 
 # bun
 path_prepend "$HOME/.bun/bin"


### PR DESCRIPTION
## なぜ

`.zshrc` line 110 の `source "$HOME/.cargo/env"` が **裸 source** で残っていた。PR #126 で同型の `vp` env 裸 source を guard 化したのと**全く同じ構造**の latent bug。`rustup` 未 install な host(`~/.cargo/env` 不在)では zsh 起動の度に warning が出る。

## 何を

PR #126 と同型の 1 ファイル 3 line guard 化:

```diff
 # cargo
-source "$HOME/.cargo/env"
+if _file_exists "$HOME/.cargo/env"; then
+    source "$HOME/.cargo/env"
+fi
```

## 検証

- `just check` (ruff format/check, shellcheck, markdownlint-cli2, vp check) ✅
- 実機: zsh 5.9 login shell で起動 OK

## 補足

PR #126 の host 整合確認の延長で host setup 拡張作業中に追加検出した既存 bug。PR #126 と同じパターン・同じ意図(`.zshrc` 内の全 source 行を conditional に揃える不変条件回復)。新規機能や設計変更なし。

[BEHAVIORAL]