### PR TITLE
feat(install): implement Windows native MVP, fill _todo_windows stubs (ADR 0018)

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ bash -c "$(curl -fsSL https://raw.githubusercontent.com/hironow/dotfiles/main/in
 ```
 
 > [!NOTE]
-> Mac, Linux, Windows([WSL](https://learn.microsoft.com/en-us/windows/wsl/)内Linux)へ対応。Windows native (scoop) は未対応。
+> Mac, Linux, Windows([WSL](https://learn.microsoft.com/en-us/windows/wsl/)内Linux)を一級でサポート。Windows native は最小サブセットのみ (`corepack enable` + `starship.toml` / `gitignore-global` の配置)。フル bootstrap (scoop ベース) は未対応 (将来 ADR)。詳細は [ADR 0018](docs/adr/0018-windows-native-mvp.md)。
 > Mac は Homebrew が前提条件 (操作者が手動で先にインストール)、それ以降は install.sh が自動。
 
 ## usage

--- a/docs/adr/0018-windows-native-mvp.md
+++ b/docs/adr/0018-windows-native-mvp.md
@@ -1,0 +1,151 @@
+# 0018. Windows native: minimum-viable deploy with explicit-skip step_*
+
+**Date:** 2026-06-02
+**Status:** Accepted
+
+## Context
+
+ADR 0005 (Accepted 2026-05-02) made `install.sh` OS-aware by routing every
+install responsibility through a `step_*` helper that branches on
+`DOTFILES_OS`. On Mac and Linux these branches run real install logic; on
+Windows native they all called a placeholder `_todo_windows "<step>"` that
+emitted a noisy `windows TODO (scoop bootstrap to be implemented)` line and
+moved on. ADR 0005 explicitly deferred the concrete Windows port to a
+"future ADR + PR when an actual Windows host enters the picture."
+
+That future has arrived: an actual Windows native host is in regular use
+(Powered by `mise`, `scoop`, and `corepack`-backed `pnpm`). Observing what
+the host actually needed exposed that **most of the deferred step_*
+functions are not "not yet implemented" — they are intentionally out of
+scope for Windows native**:
+
+- `brew`/`brew bundle` and the gcloud bundle have no Homebrew equivalent on
+  Windows native; provisioning happens through scoop and the official
+  Cloud SDK installer, both of which are operator-driven and not
+  part of `install.sh`'s remit.
+- `sheldon` is a zsh plugin manager and zsh is not used on Windows native
+  (the zsh story lives entirely in WSL).
+- `step_update_all` is a brew/apt/mise composite update; on Windows native
+  updates flow through scoop and `mise self-update` separately.
+
+Two pieces, however, *are* cross-platform-meaningful and currently
+unreachable on Windows because they share the `_todo_windows` stub:
+
+- **`step_corepack`**: `corepack` ships with Node.js and works on
+  Windows. We need it to enable per-repo `packageManager`-driven pnpm
+  resolution (ADR 0017's whole reason for being). The Windows-specific
+  wrinkle is that the Program Files Node install is typically read-only
+  for the operator account, so `corepack enable` EPERMs when it writes
+  pnpm shims there; routing through `mise exec --` fixes that.
+- **`just deploy` / `just clean`**: of the six artifacts deploy places,
+  only `starship.toml` and `dump/gitignore-global` make sense on Windows
+  native. The remaining four (`.zshrc`, sheldon plugins, tmux.conf,
+  ghostty config) are zsh/Unix-only.
+
+Leaving these on a single `_todo_windows` stub conflates "intentionally
+skipped" with "not yet implemented" and trains operators to ignore noisy
+TODO log lines that will never be acted on.
+
+## Decision
+
+Replace the `_todo_windows` placeholder with two separate concrete shapes
+per step:
+
+1. **`_skip_windows "<step>" "<reason>"`** — a new helper that requires a
+   reason argument. Used by the six steps that are out of scope on
+   Windows native: `step_homebrew`, `step_gcloud_components`,
+   `step_brew_bundle`, `step_gcloud_bundle`, `step_update_all`,
+   `step_sheldon`. (`step_just_bootstrap` already short-circuits via the
+   `command -v just` guard at the top of its body, so its windows branch
+   is a `_skip_windows` for the unlikely case where just is somehow not
+   installed.)
+2. **Real implementation** — used by `step_corepack`:
+
+   ```sh
+   windows)
+     if command -v mise >/dev/null 2>&1; then
+       mise exec -- corepack enable
+     elif command -v corepack >/dev/null 2>&1; then
+       corepack enable
+     else
+       echo "[install] step_corepack: corepack not on PATH; skipping ..."
+     fi
+     ;;
+   ```
+
+For the dotfiles placement layer, add an MSYS/MINGW/CYGWIN case at the
+top of the `deploy` and `clean` recipes in `justfile`. On Windows native
+the recipes:
+
+- `deploy`: `cp -f` `starship.toml` and `gitignore-global` into
+  `~/.config/`, then `exit 0` before the Unix-only `ln -sf` block.
+  `cp -f` is preferred over `ln -sf` on Windows because symlinks require
+  Developer Mode or admin privileges and degrade to copies in MSYS
+  anyway.
+- `clean`: remove only what the Windows `deploy` placed
+  (`~/.config/starship.toml`, `~/.config/git/ignore`).
+
+Full scoop-based provisioning (brew-equivalent), PowerShell `$PROFILE`
+integration for starship, and Windows CI runners remain **explicitly out
+of scope** for this ADR and are deferred to future work.
+
+## Enforcement inventory
+
+- **`install.sh`**: `_todo_windows()` removed; `_skip_windows()` added.
+  Eight `windows)` branches rewritten — seven `_skip_windows` calls with
+  explicit reasons, one real `corepack enable` implementation in
+  `step_corepack`.
+- **`justfile`**: `deploy` and `clean` recipes converted to shebang-style
+  bash bodies so a `case "$(uname -s)"` dispatch can early-return for
+  Windows. Linux/macOS paths preserved verbatim below the switch.
+- **`tests/test_install_os_dispatch.py`**: three new tests pin the
+  contract:
+    - `test_install_sh_no_todo_windows_stub_remains` — `_todo_windows` token
+    must not reappear.
+    - `test_install_sh_windows_step_corepack_implemented` — `step_corepack`
+    windows branch must contain `corepack enable` (not `_skip_windows`).
+    - `test_install_sh_skip_windows_calls_have_reason` — every
+    `_skip_windows` invocation must be the 2-arg shape with a non-empty
+    reason.
+- **`tests/test_justfile_windows_subset.py`** (new): static-parses the
+  `deploy` / `clean` recipes and asserts the Windows branch contains the
+  expected subset (starship + git ignore) and no Unix-only tokens
+  (zsh/sheldon/tmux/ghostty/fzf-tab), plus an `exit 0` to short-circuit.
+- **`README.md`**: the L68 note is rewritten from "Windows native (scoop)
+  is unsupported" to "Windows native supports the minimum subset; full
+  scoop bootstrap is future work — see ADR 0018".
+- **`mise.toml`**: the L4 "(future scoop host)" comment is refreshed to
+  point at ADR 0018.
+
+## Consequences
+
+**Positive**
+
+- `bash install.sh` on Windows native completes without noisy TODO log
+  lines; the only Windows-relevant work (corepack enable + subset deploy)
+  actually happens.
+- The boundary between "deferred" and "deliberately skipped" becomes
+  explicit and reviewable — the reason argument to `_skip_windows`
+  documents *why* each step is out of scope so a future contributor does
+  not "fix the TODO" by accident.
+- starship and the global gitignore now stay in sync on Windows hosts
+  the same way they do on Mac/Linux, instead of drifting because they
+  were never placed.
+
+**Negative**
+
+- Windows-side tool provisioning (brew, gcloud bundle, sheldon, the
+  composite `update-all`) still requires manual operator action. ADR 0018
+  legitimizes the gap rather than closing it.
+- The Linux-only `test_just_sandbox.py` cannot exercise the Windows
+  branch end-to-end; the new `test_justfile_windows_subset.py` is
+  static-parse only. A genuine Windows CI runner would be required for
+  full coverage and is out of scope here.
+
+**Neutral**
+
+- The `_todo_windows` removal narrows ADR 0005's "future ADR" commitment:
+  the dispatch shape is unchanged, but the Windows column is now
+  explicit per-step instead of a single placeholder. A future scoop
+  bootstrap ADR can replace any of the seven `_skip_windows` calls with
+  real implementations without further structural changes.

--- a/install.sh
+++ b/install.sh
@@ -53,12 +53,13 @@ _eval_brew() {
   fi
 }
 
-_todo_windows() {
-  # Marker for steps that don't have a Windows implementation yet.
-  # Per ADR 0005 decision the structure is OS-aware now; concrete
-  # Windows logic lands in a future ADR + PR when an actual
-  # Windows host enters the picture.
-  echo "[install] $1: windows TODO (scoop bootstrap to be implemented)"
+_skip_windows() {
+  # Marker for steps deliberately skipped on Windows native (per ADR 0018).
+  # $1 = step name, $2 = reason. The reason is required and kept inline so
+  # future maintainers see why the step is "intentionally out of scope" and
+  # not just "not yet implemented". Full scoop-based bootstrap remains a
+  # future ADR.
+  echo "[install] $1: skip (windows; $2)"
 }
 
 # ---- Repository bootstrap ------------------------------------------
@@ -110,7 +111,7 @@ step_homebrew() {
       echo "[install] step_homebrew: skip (Linux uses apt + dev container feature)"
       ;;
     windows)
-      _todo_windows "step_homebrew"
+      _skip_windows "step_homebrew" "brew is not available on Windows native; tool provisioning uses scoop/mise separately (full bootstrap out of scope, see ADR 0018)"
       ;;
   esac
 }
@@ -140,7 +141,7 @@ step_gcloud_components() {
       echo "[install] step_gcloud_components: skip (gcloud installed at build time via dev container feature)"
       ;;
     windows)
-      _todo_windows "step_gcloud_components"
+      _skip_windows "step_gcloud_components" "install Google Cloud SDK for Windows manually (scoop install gcloud or the official installer)"
       ;;
   esac
 }
@@ -193,7 +194,7 @@ step_just_bootstrap() {
       export PATH="$HOME/.local/bin:$PATH"
       ;;
     windows)
-      _todo_windows "step_just_bootstrap"
+      _skip_windows "step_just_bootstrap" "just is provided by mise (mise.toml pin) or scoop; install separately if the command -v just guard above did not hit"
       ;;
   esac
 }
@@ -211,7 +212,7 @@ step_brew_bundle() {
       echo "[install] step_brew_bundle: skip (Linux equivalents covered by apt + dev container feature)"
       ;;
     windows)
-      _todo_windows "step_brew_bundle"
+      _skip_windows "step_brew_bundle" "brew bundle is not applicable on Windows native (no brew); equivalent provisioning is out of scope for ADR 0018"
       ;;
   esac
 }
@@ -229,7 +230,7 @@ step_gcloud_bundle() {
       echo "[install] step_gcloud_bundle: skip (gcloud components in dev container feature)"
       ;;
     windows)
-      _todo_windows "step_gcloud_bundle"
+      _skip_windows "step_gcloud_bundle" "gcloud component bundle is not applicable; install components manually after step_gcloud_components"
       ;;
   esac
 }
@@ -252,7 +253,17 @@ step_corepack() {
       fi
       ;;
     windows)
-      _todo_windows "step_corepack"
+      # corepack ships with node. On Windows native the Program Files
+      # node install is typically read-only for the operator account
+      # (corepack enable EPERMs writing pnpm shims there), so prefer
+      # the mise-managed node when available.
+      if command -v mise >/dev/null 2>&1; then
+        mise exec -- corepack enable
+      elif command -v corepack >/dev/null 2>&1; then
+        corepack enable
+      else
+        echo "[install] step_corepack: corepack not on PATH; skipping (install node via mise/scoop first)"
+      fi
       ;;
   esac
 }
@@ -270,7 +281,7 @@ step_update_all() {
       echo "[install] step_update_all: skip (apt + mise manage updates)"
       ;;
     windows)
-      _todo_windows "step_update_all"
+      _skip_windows "step_update_all" "tool updates are managed per-backend (mise self-update / scoop update); a unified update entry is out of scope for ADR 0018"
       ;;
   esac
 }
@@ -295,7 +306,7 @@ step_sheldon() {
       fi
       ;;
     windows)
-      _todo_windows "step_sheldon"
+      _skip_windows "step_sheldon" "sheldon is a zsh plugin manager; zsh is not used on Windows native (WSL covers the zsh use case)"
       ;;
   esac
 }

--- a/justfile
+++ b/justfile
@@ -52,9 +52,25 @@ install:
     mise install
 
 # Deploy: symlink dotfiles to home and install plugins
+# Windows native (MSYS/MINGW/CYGWIN) gets a cross-platform subset only
+# (starship.toml + gitignore-global). zsh/sheldon/tmux/ghostty/fzf-tab
+# are Unix-only and are skipped. See ADR 0018.
 [group('Setup')]
 deploy:
-    @echo "==> Start to deploy dotfiles to home directory."
+    #!/usr/bin/env bash
+    set -eu
+    case "$(uname -s)" in
+      MINGW*|MSYS*|CYGWIN*)
+        echo "==> Deploy dotfiles (windows subset)..."
+        mkdir -p ~/.config
+        cp -f ~/dotfiles/starship.toml ~/.config/starship.toml
+        mkdir -p ~/.config/git
+        cp -f ~/dotfiles/dump/gitignore-global ~/.config/git/ignore
+        echo "==> Deploy complete (windows subset per ADR 0018; Unix-only artifacts skipped)"
+        exit 0
+        ;;
+    esac
+    echo "==> Start to deploy dotfiles to home directory."
     ln -sf ~/dotfiles/.zshrc ~/.zshrc
     mkdir -p ~/.config/sheldon
     ln -sf ~/dotfiles/sheldon-plugins.toml ~/.config/sheldon/plugins.toml
@@ -64,19 +80,19 @@ deploy:
     ln -sf ~/dotfiles/tools/ghostty-config ~/.config/ghostty/config
     mkdir -p ~/.config/git
     cp ~/dotfiles/dump/gitignore-global ~/.config/git/ignore
-    @echo "==> Installing plugins..."
-    @if command -v sheldon >/dev/null 2>&1; then \
-        sheldon lock; \
-    elif command -v mise >/dev/null 2>&1 && mise x -- sh -c 'command -v sheldon' >/dev/null 2>&1; then \
-        mise x -- sheldon lock; \
-    else \
-        echo "==> sheldon not found; skipping lock (provided by brew / devcontainer feature / mise)"; \
+    echo "==> Installing plugins..."
+    if command -v sheldon >/dev/null 2>&1; then
+        sheldon lock
+    elif command -v mise >/dev/null 2>&1 && mise x -- sh -c 'command -v sheldon' >/dev/null 2>&1; then
+        mise x -- sheldon lock
+    else
+        echo "==> sheldon not found; skipping lock (provided by brew / devcontainer feature / mise)"
     fi
-    @if [ ! -d ~/.local/share/fzf-tab ]; then \
-        echo "==> Installing fzf-tab..."; \
-        git clone --depth 1 https://github.com/Aloxaf/fzf-tab ~/.local/share/fzf-tab; \
+    if [ ! -d ~/.local/share/fzf-tab ]; then
+        echo "==> Installing fzf-tab..."
+        git clone --depth 1 https://github.com/Aloxaf/fzf-tab ~/.local/share/fzf-tab
     fi
-    @echo "==> Deploy complete!"
+    echo "==> Deploy complete!"
 
 # Sync: copy ROOT_AGENTS files to agent instruction directories
 # Default scope = .claude only. Pass targets to widen:
@@ -124,9 +140,21 @@ import-agents-preview *args:
     @uv run scripts/sync_agents.py --import-only --preview {{ args }}
 
 # Clean: remove deployed dotfiles (~/.zshrc, ~/.config/sheldon/plugins.toml, ~/.config/starship.toml)
+# Windows native (MSYS/MINGW/CYGWIN) only removes the subset that `deploy` placed
+# (starship.toml + git ignore); Unix-only artifacts are not touched. See ADR 0018.
 [group('Setup')]
 clean:
-    @echo "==> Remove dotfiles in your home directory..."
+    #!/usr/bin/env bash
+    set -eu
+    case "$(uname -s)" in
+      MINGW*|MSYS*|CYGWIN*)
+        echo "==> Remove dotfiles (windows subset)..."
+        rm -vrf ~/.config/starship.toml
+        rm -vrf ~/.config/git/ignore
+        exit 0
+        ;;
+    esac
+    echo "==> Remove dotfiles in your home directory..."
     rm -vrf ~/.zshrc
     rm -vrf ~/.config/sheldon/plugins.toml
     rm -vrf ~/.config/starship.toml

--- a/mise.toml
+++ b/mise.toml
@@ -1,7 +1,7 @@
 [tools]
 # Pinned versions per ADR 0006 (Accepted 2026-05-02). One pin
 # applies to Mac, Linux (dev container workspace), and Windows
-# (future scoop host). Bump these by hand in a dedicated PR; the
+# native (MVP scope; see ADR 0018). Bump these by hand in a dedicated PR; the
 # build-time consistency check in tests/test_mise_pin_consistency.py
 # fails the image build if these drift from the SHA-verified
 # constants in .devcontainer/features/dotfiles-tools/install.sh.

--- a/tests/test_install_os_dispatch.py
+++ b/tests/test_install_os_dispatch.py
@@ -274,3 +274,69 @@ def test_install_sh_enables_corepack_not_pnpm_globals(install_sh_text: str) -> N
             f"{retired!r}. ADR 0017 removed the pnpm-global subsystem; "
             f"pnpm is corepack-provided per-repo now."
         )
+
+
+# ---------- Windows native MVP (ADR 0018) --------------------------
+
+
+def test_install_sh_no_todo_windows_stub_remains(install_sh_text: str) -> None:
+    """ADR 0018 replaces the `_todo_windows` placeholder with either a
+    real implementation (step_corepack) or an explicit `_skip_windows`
+    call with a written reason. No `_todo_windows` references should
+    remain — otherwise a future maintainer might re-stub a new step."""
+    assert "_todo_windows" not in install_sh_text, (
+        "install.sh still references `_todo_windows`. ADR 0018 retired "
+        "the placeholder; each windows) branch must call `_skip_windows "
+        '"<step>" "<reason>"` or implement the step directly.'
+    )
+
+
+def test_install_sh_windows_step_corepack_implemented(install_sh_text: str) -> None:
+    """ADR 0018 implements `step_corepack` on Windows native (corepack
+    ships with node and works cross-platform). The windows) branch must
+    invoke `corepack enable` — not a `_skip_windows` call."""
+    # Isolate the step_corepack function body, then check the windows branch.
+    m = re.search(
+        r"^step_corepack\s*\(\s*\)\s*\{([\s\S]*?)^\}",
+        install_sh_text,
+        re.MULTILINE,
+    )
+    assert m is not None, "step_corepack function definition not found"
+    body = m.group(1)
+    win_m = re.search(r"windows\)([\s\S]*?);;", body)
+    assert win_m is not None, "step_corepack has no windows) branch"
+    win_branch = win_m.group(1)
+    assert "corepack enable" in win_branch, (
+        "step_corepack windows) branch must invoke `corepack enable` "
+        "(ADR 0018: corepack is cross-platform and supplies pnpm on Windows too)."
+    )
+    assert "_skip_windows" not in win_branch, (
+        "step_corepack windows) branch must implement, not skip "
+        "(ADR 0018 decision: corepack is the one cross-platform-meaningful step)."
+    )
+
+
+def test_install_sh_skip_windows_calls_have_reason(install_sh_text: str) -> None:
+    """`_skip_windows` requires two args: step name + non-empty reason.
+    A bare `_skip_windows "step_foo"` (no reason) would silently pass
+    shellcheck but leave operators guessing why the step was skipped.
+    Pin the 2-arg shape so future additions stay self-documenting."""
+    # Find every _skip_windows invocation (not the function definition).
+    calls = re.findall(
+        r'_skip_windows\s+"([^"]*)"\s+"([^"]*)"',
+        install_sh_text,
+    )
+    # At least the 7 skipped steps from ADR 0018 must show up.
+    assert len(calls) >= 7, (
+        f"Expected at least 7 `_skip_windows` calls (ADR 0018: 7 skipped "
+        f"steps), found {len(calls)}. Definitions: {calls!r}"
+    )
+    for step_name, reason in calls:
+        assert step_name.startswith("step_"), (
+            f"_skip_windows first arg must be a step name (step_*); got {step_name!r}"
+        )
+        assert reason.strip(), (
+            f"_skip_windows reason for {step_name!r} is empty. ADR 0018 "
+            f"requires every skip to document why the step is "
+            f"intentionally out of scope on Windows native."
+        )

--- a/tests/test_justfile_windows_subset.py
+++ b/tests/test_justfile_windows_subset.py
@@ -1,0 +1,159 @@
+"""Regression tests for justfile deploy/clean Windows native subset (ADR 0018).
+
+What this guards
+----------------
+ADR 0018 (Accepted 2026-06-02) decides that `just deploy` / `just clean`
+on Windows native handle only a *cross-platform subset* of the deploy
+targets: `starship.toml` and `dump/gitignore-global`. Unix-only assets
+(zsh / sheldon / tmux / ghostty / fzf-tab) are intentionally skipped
+because the underlying tools are not present on Windows native.
+
+These tests static-parse the justfile to verify the `deploy` and `clean`
+recipes contain the expected MSYS/MINGW/CYGWIN branch and that the branch
+body contains the subset (and nothing more). The Linux sandbox tests in
+`test_just_sandbox.py` continue to cover the macOS/Linux path end-to-end.
+
+Why these exist
+---------------
+Running `just deploy` on Windows native cannot be exercised in the Linux
+devcontainer sandbox (uname is Linux there), so a regression where the
+windows branch is removed / mangled / silently drops the subset would
+only surface on a real Windows host. Static-parse guards make that
+regression visible at PR-review time.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+JUSTFILE = ROOT / "justfile"
+
+
+@pytest.fixture(scope="module")
+def justfile_text() -> str:
+    assert JUSTFILE.is_file(), f"justfile missing at {JUSTFILE}"
+    return JUSTFILE.read_text(encoding="utf-8")
+
+
+def _extract_recipe_body(text: str, name: str) -> str:
+    """Return the body of a top-level recipe, stopping at the next recipe
+    header (a line that starts at column 0 and contains `:`)."""
+    # Match `^name:` at column 0, then capture until the next column-0
+    # non-comment, non-blank line that looks like a recipe header
+    # (`word(s):` optionally followed by deps).
+    m = re.search(
+        rf"(?ms)^{re.escape(name)}\s*:.*?\n(.*?)(?=^[A-Za-z_][\w-]*\s*(?:[^\n=]*?)?:\s*\n|\Z)",
+        text,
+    )
+    assert m is not None, f"recipe {name!r} not found in justfile"
+    return m.group(1)
+
+
+def _extract_windows_branch(body: str) -> str:
+    """Return the body of the `MINGW*|MSYS*|CYGWIN*)` case branch, up to
+    the first `;;`."""
+    m = re.search(
+        r"(?:MINGW\*\|MSYS\*\|CYGWIN\*|MSYS\*\|MINGW\*\|CYGWIN\*)\)([\s\S]*?);;",
+        body,
+    )
+    assert m is not None, "windows (MSYS/MINGW/CYGWIN) case branch not found"
+    return m.group(1)
+
+
+# ---------- deploy --------------------------------------------------
+
+
+def test_deploy_has_windows_branch(justfile_text: str) -> None:
+    """ADR 0018: `just deploy` must dispatch on uname and handle Windows
+    native explicitly. Without this branch, deploy would try to symlink
+    zsh/sheldon/tmux artifacts on Windows where they make no sense."""
+    body = _extract_recipe_body(justfile_text, "deploy")
+    assert re.search(
+        r'case\s+"\$\(uname\s+-s\)"\s+in',
+        body,
+    ), "deploy recipe must dispatch on `uname -s`"
+    _extract_windows_branch(body)  # raises if missing
+
+
+def test_deploy_windows_subset_places_cross_platform_only(
+    justfile_text: str,
+) -> None:
+    """The windows branch must place exactly the cross-platform subset:
+    starship.toml and gitignore-global. Anything else (zsh, sheldon,
+    tmux, ghostty, fzf-tab) is Unix-only and must NOT appear in the
+    windows branch — they belong on the Linux/macOS path below."""
+    body = _extract_recipe_body(justfile_text, "deploy")
+    win = _extract_windows_branch(body)
+
+    # Required cross-platform placements.
+    assert "starship.toml" in win, (
+        "deploy windows branch must place starship.toml (ADR 0018 subset)"
+    )
+    assert "gitignore-global" in win, (
+        "deploy windows branch must place dump/gitignore-global (ADR 0018 subset)"
+    )
+
+    # Forbidden Unix-only placements.
+    for forbidden in (
+        ".zshrc",
+        "sheldon-plugins.toml",
+        "tmux.conf",
+        "ghostty",
+        "fzf-tab",
+    ):
+        assert forbidden not in win, (
+            f"deploy windows branch leaked Unix-only token {forbidden!r}. "
+            f"ADR 0018 limits the Windows subset to starship + git ignore."
+        )
+
+    # Windows branch must terminate early (exit 0) so the unix code below
+    # is not executed on Windows.
+    assert re.search(r"\bexit\s+0\b", win), (
+        "deploy windows branch must `exit 0` after placing the subset, "
+        "otherwise the Unix-only ln -sf block runs and fails on Windows."
+    )
+
+
+# ---------- clean ---------------------------------------------------
+
+
+def test_clean_has_windows_branch(justfile_text: str) -> None:
+    """ADR 0018: `just clean` must mirror deploy and remove only what
+    deploy placed on Windows."""
+    body = _extract_recipe_body(justfile_text, "clean")
+    assert re.search(
+        r'case\s+"\$\(uname\s+-s\)"\s+in',
+        body,
+    ), "clean recipe must dispatch on `uname -s`"
+    _extract_windows_branch(body)  # raises if missing
+
+
+def test_clean_windows_subset_removes_only_what_deploy_placed(
+    justfile_text: str,
+) -> None:
+    """Symmetry with deploy: clean must remove the same files (starship
+    + git ignore) and nothing Unix-only."""
+    body = _extract_recipe_body(justfile_text, "clean")
+    win = _extract_windows_branch(body)
+
+    assert "starship.toml" in win, (
+        "clean windows branch must remove ~/.config/starship.toml"
+    )
+    assert re.search(r"git/ignore|gitignore-global", win), (
+        "clean windows branch must remove ~/.config/git/ignore"
+    )
+
+    for forbidden in (".zshrc", "sheldon", "tmux", "ghostty"):
+        assert forbidden not in win, (
+            f"clean windows branch leaked Unix-only token {forbidden!r}. "
+            f"ADR 0018 limits the Windows subset to starship + git ignore."
+        )
+
+    assert re.search(r"\bexit\s+0\b", win), (
+        "clean windows branch must `exit 0` so the Unix-only rm block does not run."
+    )


### PR DESCRIPTION
## なぜ

ADR 0005 が `install.sh` を OS dispatch 化した時点で Windows native の `step_*` は **全 8 件が `_todo_windows` プレースホルダ** のまま積まれていた。実機 Windows native を運用してみると、その大半は「未実装」ではなく「**意図的に out of scope**」だと判明:

- `brew` / `brew bundle` / `gcloud bundle` / `sheldon` → そもそも対応物が Win に存在しない or zsh 専用
- `step_corepack` と一部の deploy 対象 (`starship.toml`, `gitignore-global`) **だけ** はクロスプラットフォーム性があり、実装可能

`_todo_windows` を 1 つの noise 源にまとめておくと「いずれ scoop bootstrap で全部埋める」誤った将来像を温存する。本 PR は ADR 0005 が予告した *future ADR* を **ADR 0018** として実体化する。

## 何を

- **`install.sh`**: `_todo_windows()` 廃止 → `_skip_windows(step, reason)` 新設。8 件の `windows)` ケースを書き換え:
    - 7 件は `_skip_windows` + **理由付き** skip
    - `step_corepack` のみ実装 (Win では Program Files node が EPERM なので `mise exec -- corepack enable` 経由を優先)
- **`justfile`**: `deploy` / `clean` を shebang bash + `case "$(uname -s)"` 分岐に。`MSYS*/MINGW*/CYGWIN*` では `starship.toml` と `dump/gitignore-global` の `cp -f` のみ実行、Unix-only 配置はスキップして `exit 0`
- **`tests/test_install_os_dispatch.py`**: 新規 3 件
    - `_todo_windows` 残骸検出 (regression guard)
    - `step_corepack` windows 分岐に `corepack enable` 含むこと
    - `_skip_windows` 呼び出しの 2 引数 + 空理由禁止
- **`tests/test_justfile_windows_subset.py`** (新規): deploy/clean の Win 分岐を static-parse して subset 妥当性を guard
- **`docs/adr/0018-windows-native-mvp.md`** (新規): 設計判断と enforcement inventory
- **`README.md` / `mise.toml`**: コメント / note を ADR 0018 参照に更新

### Decision summary (per step)

| step | windows ケース | 理由 |
|---|---|---|
| `step_homebrew` | 明示 skip | brew は Windows 非対応 |
| `step_gcloud_components` | 明示 skip | Cloud SDK は手動 / scoop install |
| `step_just_bootstrap` | 明示 skip | `command -v just` 既存ガードで通常抜ける、mise/scoop が供給 |
| `step_brew_bundle` | 明示 skip | brew 同上 |
| `step_gcloud_bundle` | 明示 skip | gcloud 同上 |
| **`step_corepack`** | **実装** | corepack は node にバンドル、Win でも `mise exec` 経由で動く |
| `step_update_all` | 明示 skip | mise/scoop 個別 update |
| `step_sheldon` | 明示 skip | zsh plugin manager、Win native では zsh 不在 |

製品挙動: Mac/Linux 経路は完全不変 (`justfile` の MSYS/MINGW/CYGWIN 分岐を踏まない)。Windows native では `install.sh` が **noiseless 完走** し `just deploy` が cross-platform subset を配置する。

## 検証

- `bash -n install.sh`: OK
- `uvx pytest tests/test_install_os_dispatch.py tests/test_justfile_windows_subset.py`: **23 passed, 1 skipped** (環境依存 skip)
- `just --list`: deploy/clean とも parse 成功
- **Windows native 実機**: `just deploy && just clean` で `starship.toml` / `git/ignore` の配置・削除を確認
- `install.sh` dry-run (`INSTALL_SKIP_*` で重いステップ skip): 全 `_skip_windows` ログが理由付きで表示、`step_corepack` は mise 経由で enable 実行

## 補足 (このPRの範囲外)

- 検証中、`install.sh` 内の `git stash; git checkout main; git pull` が feat ブランチで実行されて変更が stash 退避 → main 切替する **既知挙動** を踏んだ。stash pop で復旧済み。bootstrap 順序の安全化は別件 ADR の余地あり
- prek hook の `just lint` は Win 上の shellcheck console encoding 問題 (cp932 上で em dash 出力不能) + リポ全体の CRLF 検出で本 PR の scope を超える規模のエラーを出すため、ユーザ承諾の上 `--no-verify` で bypass。**Win shellcheck 環境整備は別タスク**
- フル scoop bootstrap / PowerShell $PROFILE 自動化 / Windows CI runner は引き続き未対応 (将来 ADR)