### PR TITLE
fix(justfile): add mise x -- sheldon fallback in deploy

### DIFF
--- a/justfile
+++ b/justfile
@@ -67,8 +67,10 @@ deploy:
     @echo "==> Installing plugins..."
     @if command -v sheldon >/dev/null 2>&1; then \
         sheldon lock; \
+    elif command -v mise >/dev/null 2>&1 && mise x -- sh -c 'command -v sheldon' >/dev/null 2>&1; then \
+        mise x -- sheldon lock; \
     else \
-        echo "==> sheldon not found; skipping lock (provided by brew / devcontainer feature)"; \
+        echo "==> sheldon not found; skipping lock (provided by brew / devcontainer feature / mise)"; \
     fi
     @if [ ! -d ~/.local/share/fzf-tab ]; then \
         echo "==> Installing fzf-tab..."; \


### PR DESCRIPTION
## なぜ

host が `sheldon` を mise 経由で install (e.g. WSL host with `aqua:rossmacarthur/sheldon@0.8.5`) しているとき、`just deploy` が起動する **non-mise-activated bash sub-shell** の PATH には `~/.local/share/mise/shims` が乗っていない。既存の `command -v sheldon` guard が false hit し、`sheldon lock` が **silent に skip** されてしまう。sheldon 自体は `mise x --` 経由で reachable なのに、recipe が brew/devcontainer feature 由来の sheldon しか見ない設計だったため。結果として `~/.local/share/sheldon/plugins.lock` は古いまま、plugin install が走らない。

これは PR #124 (pnpm → corepack 移行) と同型の「provisioning 経路の変化に既存 invocation context が追従していない」latent bug。

## 何を

deploy recipe の sheldon 起動ロジックを **3 段 fallback** に変更:

1. 第 1 段(従来): `command -v sheldon` が PATH で見つかれば直接 `sheldon lock` (brew on Mac / devcontainer feature on Linux container 想定)
2. 第 2 段(新規): mise が居て、かつ `mise x -- sh -c 'command -v sheldon'` が成功すれば `mise x -- sheldon lock` (WSL host で mise 経由 install したケース)
3. 第 3 段(従来): 両方 fail なら skip(message に `/ mise` を追記)

```diff
 @if command -v sheldon >/dev/null 2>&1; then \
     sheldon lock; \
+elif command -v mise >/dev/null 2>&1 && mise x -- sh -c 'command -v sheldon' >/dev/null 2>&1; then \
+    mise x -- sheldon lock; \
 else \
-    echo "==> sheldon not found; skipping lock (provided by brew / devcontainer feature)"; \
+    echo "==> sheldon not found; skipping lock (provided by brew / devcontainer feature / mise)"; \
 fi
```

## 検証

- `just check` (ruff format/check, shellcheck, markdownlint-cli2, vp check) ✅
- 実機: bash sub-shell で mise shims を PATH から strip した最悪条件でも `just deploy` が `mise x -- sheldon lock` 経由で 4 plugin (`zsh-users/zsh-history-substring-search`, `zsh-autosuggestions`, `zsh-completions`, `zsh-syntax-highlighting`) を CHECKED & LOCKED:

```
==> Installing plugins...
LOADED ~/.config/sheldon/plugins.toml
   CHECKED https://github.com/zsh-users/zsh-history-substring-search
   CHECKED https://github.com/zsh-users/zsh-autosuggestions
   CHECKED https://github.com/zsh-users/zsh-completions
   CHECKED https://github.com/zsh-users/zsh-syntax-highlighting
LOCKED ~/.local/share/sheldon/plugins.lock
```

## 補足

PR #126/#127 の「裸 invocation を guard で囲む」パターンと同型の修正だが、対象が `.zshrc` ではなく `justfile`、guard が `_file_exists` ではなく `command -v` + `mise x` の 3 段 fallback、という点だけが違う。三系統 (mac brew / devcontainer feature / WSL host mise) 全てで sheldon lock が走るようになる。

[BEHAVIORAL]