### PR TITLE
fix(plugin-hooks): emit valid PreToolUse output schema in check-scope.sh

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -14,7 +14,7 @@
       "name": "autoresearch",
       "source": "./plugins/autoresearch",
       "description": "Autonomous experiment loop plugin inspired by karpathy/autoresearch. Iteratively modifies target code, evaluates against fixed metrics, and keeps only improvements via git-based keep/revert cycles.",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "category": "research",
       "tags": ["research", "optimization", "autonomous", "experiment", "tdd"]
     },
@@ -22,7 +22,7 @@
       "name": "paintress",
       "source": "./plugins/paintress",
       "description": "Autonomous TDD expedition agent with Gradient Gauge momentum, Lumina learning, and Review Gate. Picks Linear issues, implements fixes via TDD, and creates PRs.",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "category": "development",
       "tags": ["tdd", "linear", "autonomous", "expedition"]
     },
@@ -30,7 +30,7 @@
       "name": "autodesign",
       "source": "./plugins/autodesign",
       "description": "Autonomous web design exploration plugin. Explores design variations under quality constraints using git-based keep/revert cycles with bundled evaluators for a11y, readability, performance, and completeness.",
-      "version": "0.1.0",
+      "version": "0.2.1",
       "category": "design",
       "tags": ["design", "exploration", "autonomous", "web", "quality", "a11y", "lighthouse"]
     },
@@ -38,7 +38,7 @@
       "name": "autoreview",
       "source": "./plugins/autoreview",
       "description": "Autonomous code review plugin using guardrails/semgrep rules. Scans code, auto-fixes violations, and validates via git-based keep/revert cycles. Supports scan-fix and spec-review modes.",
-      "version": "0.1.0",
+      "version": "0.2.1",
       "category": "review",
       "tags": ["review", "semgrep", "guardrails", "autonomous", "code-quality", "architecture"]
     },

--- a/plugins/autodesign/.claude-plugin/plugin.json
+++ b/plugins/autodesign/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "autodesign",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Autonomous web design exploration plugin. Iteratively explores design variations under quality constraints using git-based keep/revert cycles, inspired by autoresearch.",
   "author": {
     "name": "hironow"

--- a/plugins/autodesign/hooks/scripts/check-scope.sh
+++ b/plugins/autodesign/hooks/scripts/check-scope.sh
@@ -2,18 +2,15 @@
 set -euo pipefail
 CONFIG="design-config.yaml"
 if [[ ! -f "$CONFIG" ]]; then
-  echo '{"decision": "allow"}'
   exit 0
 fi
 INPUT=$(cat)
 FILE_PATH=$(echo "$INPUT" | grep -o '"file_path"[[:space:]]*:[[:space:]]*"[^"]*"' | head -1 | sed 's/.*"file_path"[[:space:]]*:[[:space:]]*"//' | sed 's/"$//' || echo "")
 if [[ -z "$FILE_PATH" ]]; then
-  echo '{"decision": "allow"}'
   exit 0
 fi
 BASENAME=$(basename "$FILE_PATH")
 if [[ "$BASENAME" == "design-results.tsv" || "$BASENAME" == "run.log" ]]; then
-  echo '{"decision": "allow"}'
   exit 0
 fi
 IN_SCOPE=false
@@ -25,7 +22,8 @@ while IFS= read -r line; do
   fi
 done < <(sed -n '/^target_files:/,/^[^ ]/p' "$CONFIG" | head -n -1)
 if [[ "$IN_SCOPE" == "true" ]]; then
-  echo '{"decision": "allow"}'
-else
-  echo '{"decision": "allow", "message": "WARNING: This file is outside the design target scope."}'
+  exit 0
 fi
+cat <<'EOF'
+{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"allow","permissionDecisionReason":"WARNING: This file is outside the design target scope."}}
+EOF

--- a/plugins/autoresearch/.claude-plugin/plugin.json
+++ b/plugins/autoresearch/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "autoresearch",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Autonomous experiment loop plugin inspired by karpathy/autoresearch. Iteratively modifies target code, evaluates against fixed metrics, and keeps only improvements via git-based keep/revert cycles.",
   "author": {
     "name": "hironow"

--- a/plugins/autoresearch/hooks/scripts/check-scope.sh
+++ b/plugins/autoresearch/hooks/scripts/check-scope.sh
@@ -6,7 +6,7 @@
 # If target file is outside scope (and not results.tsv/run.log), warns.
 #
 # Input: JSON on stdin with tool_input.file_path
-# Output: JSON with "decision" field
+# Output: empty (default allow) or PreToolUse hookSpecificOutput JSON with permissionDecision=allow + reason
 
 set -euo pipefail
 
@@ -14,7 +14,6 @@ CONFIG="experiment-config.yaml"
 
 # If no active experiment, allow silently
 if [[ ! -f "$CONFIG" ]]; then
-  echo '{"decision": "allow"}'
   exit 0
 fi
 
@@ -23,7 +22,6 @@ INPUT=$(cat)
 FILE_PATH=$(echo "$INPUT" | grep -o '"file_path"[[:space:]]*:[[:space:]]*"[^"]*"' | head -1 | sed 's/.*"file_path"[[:space:]]*:[[:space:]]*"//' | sed 's/"$//' || echo "")
 
 if [[ -z "$FILE_PATH" ]]; then
-  echo '{"decision": "allow"}'
   exit 0
 fi
 
@@ -32,7 +30,6 @@ BASENAME=$(basename "$FILE_PATH")
 
 # Whitelist: results.tsv and run.log are always allowed
 if [[ "$BASENAME" == "results.tsv" || "$BASENAME" == "run.log" ]]; then
-  echo '{"decision": "allow"}'
   exit 0
 fi
 
@@ -51,7 +48,9 @@ while IFS= read -r line; do
 done < <(sed -n '/^target_files:/,/^[^ ]/p' "$CONFIG" | head -n -1)
 
 if [[ "$IN_SCOPE" == "true" ]]; then
-  echo '{"decision": "allow"}'
-else
-  echo '{"decision": "allow", "message": "WARNING: This file is outside the experiment target scope. Modifying non-target files during an experiment loop may invalidate results. Proceed with caution."}'
+  exit 0
 fi
+
+cat <<'EOF'
+{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"allow","permissionDecisionReason":"WARNING: This file is outside the experiment target scope. Modifying non-target files during an experiment loop may invalidate results. Proceed with caution."}}
+EOF

--- a/plugins/autoreview/.claude-plugin/plugin.json
+++ b/plugins/autoreview/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "autoreview",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Autonomous code review plugin using guardrails/semgrep rules. Iteratively scans code with Semgrep, auto-fixes violations, and validates via git-based keep/revert cycles. Supports scan-fix mode, spec-review mode, and distill-rule for converting findings into reusable Semgrep rules.",
   "author": {
     "name": "hironow"

--- a/plugins/autoreview/hooks/scripts/check-scope.sh
+++ b/plugins/autoreview/hooks/scripts/check-scope.sh
@@ -7,7 +7,7 @@
 # warns the user.
 #
 # Input: JSON on stdin with tool_input.file_path
-# Output: JSON with "decision" field
+# Output: empty (default allow) or PreToolUse hookSpecificOutput JSON with permissionDecision=allow + reason
 
 set -euo pipefail
 
@@ -15,7 +15,6 @@ CONFIG="review-config.yaml"
 
 # If no active review, allow silently
 if [[ ! -f "$CONFIG" ]]; then
-  echo '{"decision": "allow"}'
   exit 0
 fi
 
@@ -24,7 +23,6 @@ INPUT=$(cat)
 FILE_PATH=$(echo "$INPUT" | grep -o '"file_path"[[:space:]]*:[[:space:]]*"[^"]*"' | head -1 | sed 's/.*"file_path"[[:space:]]*:[[:space:]]*"//' | sed 's/"$//' || echo "")
 
 if [[ -z "$FILE_PATH" ]]; then
-  echo '{"decision": "allow"}'
   exit 0
 fi
 
@@ -33,7 +31,6 @@ BASENAME=$(basename "$FILE_PATH")
 
 # Whitelist: review artifacts are always allowed
 if [[ "$BASENAME" == "review-results.tsv" || "$BASENAME" == "review-scan.json" ]]; then
-  echo '{"decision": "allow"}'
   exit 0
 fi
 
@@ -50,7 +47,9 @@ while IFS= read -r line; do
 done < <(sed -n '/^target_paths:/,/^[^ ]/p' "$CONFIG" | head -n -1)
 
 if [[ "$IN_SCOPE" == "true" ]]; then
-  echo '{"decision": "allow"}'
-else
-  echo '{"decision": "allow", "message": "WARNING: This file is outside the review target scope. Modifying non-target files during a review loop may introduce untracked changes. Proceed with caution."}'
+  exit 0
 fi
+
+cat <<'EOF'
+{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"allow","permissionDecisionReason":"WARNING: This file is outside the review target scope. Modifying non-target files during a review loop may introduce untracked changes. Proceed with caution."}}
+EOF

--- a/plugins/paintress/.claude-plugin/plugin.json
+++ b/plugins/paintress/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "paintress",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Autonomous TDD expedition agent that picks Linear issues, implements fixes, and creates PRs",
   "author": {
     "name": "Hiroto Nishiyama"

--- a/plugins/paintress/hooks/scripts/check-scope.sh
+++ b/plugins/paintress/hooks/scripts/check-scope.sh
@@ -6,7 +6,7 @@
 # If target file is outside repository scope (and not journal.tsv/continent-config.yaml), warns.
 #
 # Input: JSON on stdin with tool_input.file_path
-# Output: JSON with "decision" field
+# Output: empty (default allow) or PreToolUse hookSpecificOutput JSON with permissionDecision=allow + reason
 
 set -euo pipefail
 
@@ -14,7 +14,6 @@ CONFIG="continent-config.yaml"
 
 # If no active expedition, allow silently
 if [[ ! -f "$CONFIG" ]]; then
-  echo '{"decision": "allow"}'
   exit 0
 fi
 
@@ -23,7 +22,6 @@ INPUT=$(cat)
 FILE_PATH=$(echo "$INPUT" | grep -o '"file_path"[[:space:]]*:[[:space:]]*"[^"]*"' | head -1 | sed 's/.*"file_path"[[:space:]]*:[[:space:]]*"//' | sed 's/"$//' || echo "")
 
 if [[ -z "$FILE_PATH" ]]; then
-  echo '{"decision": "allow"}'
   exit 0
 fi
 
@@ -32,7 +30,6 @@ BASENAME=$(basename "$FILE_PATH")
 
 # Whitelist: journal.tsv and continent-config.yaml are always allowed
 if [[ "$BASENAME" == "journal.tsv" || "$BASENAME" == "continent-config.yaml" ]]; then
-  echo '{"decision": "allow"}'
   exit 0
 fi
 
@@ -40,7 +37,6 @@ fi
 REPO_PATH=$(grep -E '^\s*repository:' "$CONFIG" | head -1 | sed 's/.*repository:[[:space:]]*//' | tr -d '"' | tr -d "'" || echo "")
 
 if [[ -z "$REPO_PATH" ]]; then
-  echo '{"decision": "allow"}'
   exit 0
 fi
 
@@ -52,7 +48,9 @@ REPO_PATH=$(cd "$REPO_PATH" 2>/dev/null && pwd || echo "$REPO_PATH")
 
 # Check if file is within repository scope
 if [[ "$FILE_PATH" == "$REPO_PATH"* ]]; then
-  echo '{"decision": "allow"}'
-else
-  echo '{"decision": "allow", "message": "WARNING: This file is outside the expedition target repository. Expedition scope is limited to the configured repository. Proceed only if intentional."}'
+  exit 0
 fi
+
+cat <<'EOF'
+{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"allow","permissionDecisionReason":"WARNING: This file is outside the expedition target repository. Expedition scope is limited to the configured repository. Proceed only if intentional."}}
+EOF


### PR DESCRIPTION
## What

`check-scope.sh` in `autodesign` / `autoresearch` / `autoreview` / `paintress` was emitting `{\"decision\": \"allow\"}` from PreToolUse hooks. This is **not a valid PreToolUse hook output schema** — it belongs to `Stop` / `SubagentStop`. The mismatch produced `Hook JSON output validation failed — (root): Invalid input` errors on every `Edit` / `Write` operation while these plugins were enabled.

## Symptom

```
⎿  PreToolUse:Write hook error
⎿  Hook JSON output validation failed — (root): Invalid input
```

8 such errors per multi-mutation batch (one per active plugin × matcher match). exit code was still 0 so behaviour was unaffected, but log was spammed continuously.

## Root cause

PreToolUse requires:

```json
{
  \"hookSpecificOutput\": {
    \"hookEventName\": \"PreToolUse\",
    \"permissionDecision\": \"allow|deny|ask\",
    \"permissionDecisionReason\": \"...\"
  }
}
```

The scripts used the legacy `{\"decision\": \"allow\"}` form (correct for Stop / SubagentStop, **invalid** for PreToolUse).

## Fix

| File | Change |
|---|---|
| `plugins/{autodesign,autoresearch,autoreview,paintress}/hooks/scripts/check-scope.sh` | Pure allow → `exit 0` with empty stdout (default allow). Out-of-scope warning → new schema with \`permissionDecision=allow\` + reason in \`permissionDecisionReason\`. |
| `plugins/*/.claude-plugin/plugin.json` | Patch bump (0.1.0 → 0.1.1, 0.2.0 → 0.2.1) so users pick up the fix via \`/plugin update\`. |
| `.claude-plugin/marketplace.json` | Align \`version\` with each \`plugin.json\` (\`autodesign\` and \`autoreview\` had stale 0.1.0 marketplace entries while \`plugin.json\` reported 0.2.0). |

## Verification

After applying the fix and syncing the cache (\`~/.claude/plugins/cache/hironow-plugins/<name>/<version>/hooks/scripts/check-scope.sh\`), 4 consecutive \`Edit\` operations in the same session produced **zero** hook validation errors (previously every batch fired 4–8 errors).

## Migration

End users on existing 0.1.0 / 0.2.0 cache will keep seeing the errors until they run \`/plugin update\` (cache is keyed by \`plugin.json\` version, so the patch bump triggers a fresh cache directory). No config changes needed.

## Memory captured

- \`feedback_claude_hook_pretooluse_schema\` — PreToolUse schema is event-specific, do not reuse \`{\"decision\"}\` from Stop/SubagentStop.
- \`feedback_claude_plugin_cache_structure\` — source edits do not propagate to \`~/.claude/plugins/cache/<marketplace>/<name>/<version>/\` automatically; version bump is the canonical delivery path.