### PR TITLE
feat(dump): track Windows scoop manifest as record-only dump/scoop.json (ADR 0019)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# scoop export on Windows can emit CRLF; force LF for diff stability.
+# See ADR 0019 (Windows scoop manifest in dump/ — record-only).
+dump/scoop.json text eol=lf

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ bash -c "$(curl -fsSL https://raw.githubusercontent.com/hironow/dotfiles/main/in
 ```
 
 > [!NOTE]
-> Mac, Linux, Windows([WSL](https://learn.microsoft.com/en-us/windows/wsl/)内Linux)を一級でサポート。Windows native は最小サブセットのみ (`corepack enable` + `starship.toml` / `gitignore-global` の配置)。フル bootstrap (scoop ベース) は未対応 (将来 ADR)。詳細は [ADR 0018](docs/adr/0018-windows-native-mvp.md)。
+> Mac, Linux, Windows([WSL](https://learn.microsoft.com/en-us/windows/wsl/)内Linux)を一級でサポート。Windows native は最小サブセット (`corepack enable` + `starship.toml` / `gitignore-global` の配置) と **scoop manifest dump (`dump/scoop.json`, record-only)** に対応。フル bootstrap (scoop からの一括 install) は未対応 (将来 ADR)。詳細は [ADR 0018](docs/adr/0018-windows-native-mvp.md) / [ADR 0019](docs/adr/0019-windows-scoop-dump-record-only.md)。
 > Mac は Homebrew が前提条件 (操作者が手動で先にインストール)、それ以降は install.sh が自動。
 
 ## usage

--- a/docs/adr/0019-windows-scoop-dump-record-only.md
+++ b/docs/adr/0019-windows-scoop-dump-record-only.md
@@ -1,0 +1,145 @@
+# 0019. Windows scoop manifest in `dump/` — record-only
+
+**Date:** 2026-06-02
+**Status:** Accepted
+
+## Context
+
+ADR 0018 (Accepted 2026-06-02) implemented Windows native MVP at the
+`install.sh` / `justfile` level but explicitly deferred the full scoop
+bootstrap layer ("`add-*` recipes equivalent to brew bundle / gcloud
+components") to a future ADR. The reasoning was sound: bootstrap is a
+much heavier commitment than dump.
+
+But while ADR 0018's ink was still wet, two real tools were added to the
+Windows host by hand — `shellcheck` (for the `just lint` pre-commit hook
+during PR #128) and `jq` (for the `claude-code-warp` plugin's stop hook
+right after merge). They were recorded only in a memory file
+(`project_windows_plugin_hooks_need_unix_clis.md`), not in the repo.
+Memory drifts: a second Windows host has no source of truth, and even
+this host's record is invisible to anyone not in the same Claude
+session.
+
+The repo already has a precedent for the dump/install split:
+`dump/npm-dlx` lists `pnpm dlx` packages the operator commonly runs but
+deliberately does **not** auto-install them. The file is read-only
+documentation; `just check-pnpm-dlx` grep-lists it; there is no
+corresponding `add-pnpm-dlx`. That same shape fits scoop perfectly: dump
+what's there, do not restore from it.
+
+## Decision
+
+Add a Windows branch to the existing `just dump` recipe that writes
+`dump/scoop.json` via `scoop export`, normalized with `jq` for diff
+stability. **No** `add-scoop` / `update-scoop` / `check-scoop` recipe.
+The bootstrap layer remains exactly where ADR 0018 left it: future work,
+out of scope.
+
+Concretely, `dump`'s Windows branch:
+
+```sh
+windows)
+  scoop export | jq '{
+    buckets: [.buckets[] | {Name, Source}] | sort_by(.Name),
+    apps:    [.apps[]    | {Name, Version, Source}] | sort_by(.Name)
+  }' | tr -d '\r' > ./dump/scoop.json
+  exit 0
+  ;;
+```
+
+Three normalization choices matter and are pinned by tests:
+
+1. **Drop `Updated` timestamps** (apps and buckets both carry per-app
+   ISO-8601 install times that change on every `scoop install`).
+2. **Drop `Manifests` counts** on buckets (changes whenever upstream
+   buckets receive new manifests, independent of local state).
+3. **`sort_by(.Name)`** for both arrays (scoop export emits in install
+   order; without sort, every reinstall reorders the diff).
+
+`tr -d '\r'` is belt-and-suspenders alongside `.gitattributes`
+(`dump/scoop.json text eol=lf`): scoop on Windows can emit CRLF, and
+either guard alone has failed in past experiences elsewhere.
+
+The "documentation layer" / "bootstrap layer" split is the load-bearing
+distinction:
+
+- **Documentation layer (this ADR)**: declarative record of what is
+  installed. Operator can inspect, diff, code-review. No install
+  side-effects.
+- **Bootstrap layer (ADR 0018 deferred)**: one-shot install from a
+  declarative source on a fresh host. Heavy: needs scoop itself to
+  bootstrap, needs Powershell / cmd integration for buckets, needs to
+  reason about user vs system-wide installs, etc.
+
+Keeping these layers separate means each can evolve independently and
+each ADR has a single responsibility.
+
+## Enforcement inventory
+
+- **`justfile`**: `dump` recipe converted to shebang bash + `case
+  "$(uname -s)"` dispatch (same pattern PR #128 introduced for
+  `deploy`/`clean`). Windows branch writes `dump/scoop.json`; Mac/Linux
+  tail (brew bundle / gitignore / gcloud) preserved verbatim. Missing-
+  tool guards (`command -v scoop` / `command -v jq`) emit a hint and
+  `exit 1` rather than producing a half-written file.
+- **`dump/scoop.json`**: tracked in repo. Seeded by running `just dump`
+  on the current Windows host once at ADR 0019 landing time.
+- **`.gitattributes`** (new): one line, `dump/scoop.json text eol=lf`.
+  Belt-and-suspenders with `tr -d '\r'` in the recipe.
+- **`tests/test_justfile_windows_subset.py`**: five new tests pin the
+  contract:
+    - `test_dump_has_windows_branch`
+    - `test_dump_windows_writes_scoop_json`
+    - `test_dump_windows_normalizes_with_jq` (asserts `jq` + `sort_by`
+      + that `Updated`/`Manifests` tokens are absent from the branch
+      body — a re-include would defeat diff stability)
+    - `test_dump_windows_has_no_install_side` (asserts `scoop install`
+      does NOT appear — record-only invariant, separates this ADR from
+      ADR 0018's deferred bootstrap)
+    - `test_dump_windows_exits_before_unix_path` (asserts `exit 0`)
+- **`README.md`**: the L68 Windows-native note is extended to mention
+  the dump in addition to the existing subset and to cross-reference
+  ADR 0019.
+- **Memory** (`memory/project_windows_plugin_hooks_need_unix_clis.md`):
+  the "currently installed list" sentence becomes a pointer to
+  `dump/scoop.json`. The broader "hook needs Unix CLI → scoop install"
+  pattern stays in memory.
+
+## Consequences
+
+**Positive**
+
+- `shellcheck`, `jq`, and any future scoop-installed tools on the Win
+  host are now tracked declaratively and reviewable in PR diffs. The
+  memory layer for "what's installed where" becomes redundant for this
+  slice and can shrink to the abstract pattern.
+- A second Windows host has a single file to consult: "here are the
+  tools the maintainer's host runs; install whichever you need by
+  hand". This is exactly the relationship `dump/npm-dlx` has with `pnpm
+  dlx`.
+- `just dump` is now a single entry point regardless of OS — operators
+  do not need to remember which subset their platform supports.
+- The "documentation vs bootstrap" split is now codified, so the
+  eventual bootstrap ADR can land without re-litigating where dump
+  belongs.
+
+**Negative**
+
+- Fresh-host restore is still a manual walk through `dump/scoop.json`
+  — same UX as `dump/npm-dlx`. Operators who expected `just add-scoop`
+  symmetry with `just add-brew` will be momentarily surprised; the
+  README note and ADR cross-reference are the mitigations.
+- The Windows host depends on `jq` being installed before `just dump`
+  works, which is mildly circular: `jq` came in via the very pattern
+  this ADR documents. The missing-tool guard in the recipe handles it
+  gracefully (`exit 1` with a `scoop install jq` hint).
+
+**Neutral**
+
+- ADR 0018's "scoop bootstrap = future ADR" stance is fully preserved.
+  That future ADR is now strictly about the install side; this ADR
+  removes the documentation-layer concern from its scope so it can be
+  scoped tighter when it arrives.
+- `dump/scoop.json` includes the `wangzq` bucket (one local-source
+  bucket with 0 manifests visible at dump time) verbatim. Cleanup of
+  unused buckets is an operator concern, not a `just dump` concern.

--- a/dump/scoop.json
+++ b/dump/scoop.json
@@ -1,0 +1,68 @@
+{
+  "buckets": [
+    {
+      "Name": "extras",
+      "Source": "https://github.com/ScoopInstaller/Extras"
+    },
+    {
+      "Name": "main",
+      "Source": "https://github.com/ScoopInstaller/Main.git"
+    },
+    {
+      "Name": "wangzq",
+      "Source": "https://github.com/wangzq/scoop-bucket"
+    }
+  ],
+  "apps": [
+    {
+      "Name": "7zip",
+      "Version": "25.01",
+      "Source": "main"
+    },
+    {
+      "Name": "gh",
+      "Version": "2.83.0",
+      "Source": "main"
+    },
+    {
+      "Name": "jq",
+      "Version": "1.8.1",
+      "Source": "main"
+    },
+    {
+      "Name": "just",
+      "Version": "1.43.0",
+      "Source": "main"
+    },
+    {
+      "Name": "mise",
+      "Version": "2025.11.3",
+      "Source": "main"
+    },
+    {
+      "Name": "nmap",
+      "Version": "7.98",
+      "Source": "main"
+    },
+    {
+      "Name": "nodejs",
+      "Version": "24.10.0",
+      "Source": "main"
+    },
+    {
+      "Name": "ollama",
+      "Version": "0.20.2",
+      "Source": "main"
+    },
+    {
+      "Name": "shellcheck",
+      "Version": "0.11.0",
+      "Source": "main"
+    },
+    {
+      "Name": "socat",
+      "Version": "1.7.2.1",
+      "Source": "wangzq"
+    }
+  ]
+}

--- a/justfile
+++ b/justfile
@@ -208,14 +208,35 @@ clean-work-env target:
     rm -rf "$config_dir/shell-snapshots"
     echo "✅ $config_dir cleaned (plugins, projects, history preserved)"
 
-# Dump: write Homebrew bundle and global gitignore into dump/
+# Dump: write per-OS package manifests into dump/
+# Mac/Linux: brew bundle + gitignore-global + gcloud components.
+# Windows native (MSYS/MINGW/CYGWIN): scoop export (record-only, see ADR 0019).
 [group('Setup')]
 dump:
-    # Dump current brew bundle
+    #!/usr/bin/env bash
+    set -eu
+    case "$(uname -s)" in
+      MINGW*|MSYS*|CYGWIN*)
+        echo "==> Dump scoop manifest (windows subset)..."
+        if ! command -v scoop >/dev/null 2>&1; then
+          echo "==> scoop not on PATH; cannot dump (install scoop first)" >&2
+          exit 1
+        fi
+        if ! command -v jq >/dev/null 2>&1; then
+          echo "==> jq not on PATH; cannot normalize (install jq via scoop first)" >&2
+          exit 1
+        fi
+        scoop export | jq '{
+          buckets: [.buckets[] | {Name, Source}] | sort_by(.Name),
+          apps:    [.apps[]    | {Name, Version, Source}] | sort_by(.Name)
+        }' | tr -d '\r' > ./dump/scoop.json
+        echo "==> Dump complete (dump/scoop.json; record-only per ADR 0019)"
+        exit 0
+        ;;
+    esac
+    # Mac / Linux path.
     rm -f ./dump/Brewfile && (cd ./dump && brew bundle dump)
-    # Dump global gitignore
     cp ~/.config/git/ignore ./dump/gitignore-global
-    # Dump installed gcloud components (restore with: just add-gcloud)
     gcloud components list --filter='state.name=Installed' --format='value(id)' 2>/dev/null | sort -u > ./dump/gcloud
 
 

--- a/tests/test_justfile_windows_subset.py
+++ b/tests/test_justfile_windows_subset.py
@@ -157,3 +157,78 @@ def test_clean_windows_subset_removes_only_what_deploy_placed(
     assert re.search(r"\bexit\s+0\b", win), (
         "clean windows branch must `exit 0` so the Unix-only rm block does not run."
     )
+
+
+# ---------- dump (ADR 0019) -----------------------------------------
+
+
+def test_dump_has_windows_branch(justfile_text: str) -> None:
+    """ADR 0019: `just dump` must dispatch on uname and handle Windows
+    native explicitly. Without this branch, dump would try to run brew/gcloud
+    on Windows where they are absent."""
+    body = _extract_recipe_body(justfile_text, "dump")
+    assert re.search(
+        r'case\s+"\$\(uname\s+-s\)"\s+in',
+        body,
+    ), "dump recipe must dispatch on `uname -s`"
+    _extract_windows_branch(body)  # raises if missing
+
+
+def test_dump_windows_writes_scoop_json(justfile_text: str) -> None:
+    """ADR 0019: the Windows dump branch must invoke `scoop export` and
+    write to `dump/scoop.json` — the record-only manifest."""
+    body = _extract_recipe_body(justfile_text, "dump")
+    win = _extract_windows_branch(body)
+    assert "scoop export" in win, (
+        "dump windows branch must call `scoop export` (ADR 0019)"
+    )
+    assert "dump/scoop.json" in win, (
+        "dump windows branch must redirect to `dump/scoop.json` (ADR 0019)"
+    )
+
+
+def test_dump_windows_normalizes_with_jq(justfile_text: str) -> None:
+    """ADR 0019 diff stability: scoop export emits `Updated` timestamps and
+    `Manifests` counts that change on every run. The dump must filter them
+    out via jq so the file is committable and reviewable.
+
+    Asserts the jq pipe is present AND that `Updated`/`Manifests` tokens do
+    not appear in the Windows branch (a re-include would defeat stability)."""
+    body = _extract_recipe_body(justfile_text, "dump")
+    win = _extract_windows_branch(body)
+    assert re.search(r"\bjq\b", win), (
+        "dump windows branch must pipe through jq to normalize scoop export"
+    )
+    assert "sort_by" in win, (
+        "dump windows branch must sort_by(.Name) to stabilize ordering"
+    )
+    for noise in ("Updated", "Manifests"):
+        assert noise not in win, (
+            f"dump windows branch must NOT reference {noise!r} — that field "
+            f"changes on every scoop export and would make dump/scoop.json "
+            f"diff on every run. ADR 0019 specifies the normalized field set."
+        )
+
+
+def test_dump_windows_has_no_install_side(justfile_text: str) -> None:
+    """ADR 0019 is *record-only*: the dump branch must NOT call
+    `scoop install` (that is the bootstrap layer, deferred per ADR 0018).
+    Any `add-scoop`/`scoop install` invocation here would conflate the
+    two ADR's scopes."""
+    body = _extract_recipe_body(justfile_text, "dump")
+    win = _extract_windows_branch(body)
+    assert "scoop install" not in win, (
+        "dump windows branch must NOT call `scoop install` — ADR 0019 is "
+        "record-only; bootstrap remains future work per ADR 0018."
+    )
+
+
+def test_dump_windows_exits_before_unix_path(justfile_text: str) -> None:
+    """The Windows branch must `exit 0` so the Mac/Linux tail (brew bundle,
+    gcloud components) does not run on Windows where those tools are absent."""
+    body = _extract_recipe_body(justfile_text, "dump")
+    win = _extract_windows_branch(body)
+    assert re.search(r"\bexit\s+0\b", win), (
+        "dump windows branch must `exit 0` before the Mac/Linux `brew bundle "
+        "dump` block, otherwise scoop hosts will hit brew not-found errors."
+    )


### PR DESCRIPTION
## なぜ

ADR 0018 (PR #128, 直前にマージ) で Windows native MVP を入れたが、フル scoop bootstrap は future ADR と明示的に deferred。その間に host へ手動 install した `shellcheck` (PR #128 の pre-commit) と `jq` (claude-code-warp の stop hook) は memory にしか track されておらず、**2 台目の Windows host に対する source of truth が repo に無い**。

リポは既に `dump/npm-dlx` で「record-only (記録専用、auto-install しない)」の precedent を持つ。同じ shape を scoop に拡張する。

## 何を

- **`justfile`**: `dump` recipe を shebang bash + `case "$(uname -s)"` に変更 (deploy/clean と同じ ADR 0018 パターン)
    - Win 分岐: `scoop export | jq <normalize> | tr -d '\r' > dump/scoop.json` + missing-tool guard
    - Mac/Linux 分岐: 既存の brew bundle + gitignore-global + gcloud components を**一字一句保存**
    - **`add-scoop` recipe は意図的に作らない** (ADR 0018 の deferred bootstrap layer 保持)
- **`dump/scoop.json`** (新規 seed): 現 host の 3 buckets + 10 apps (shellcheck/jq 含む)。`jq` で `Updated` timestamps / `Manifests` counts を除去、`sort_by(.Name)` で順序安定化
- **`.gitattributes`** (新規 1 行): `dump/scoop.json text eol=lf` (scoop export の CRLF 対策、`tr -d '\r'` と belt-and-suspenders)
- **`tests/test_justfile_windows_subset.py`**: 新規 5 件
    - dump の Win 分岐存在
    - `scoop export` + `dump/scoop.json` 書き込み
    - `jq` + `sort_by` 正規化 + `Updated`/`Manifests` 不在 (diff stability invariant)
    - `scoop install` 不在 (record-only invariant)
    - `exit 0` で Unix path に流れない
- **`docs/adr/0019-windows-scoop-dump-record-only.md`** (新規): 設計判断。「**documentation layer (本 ADR)**」と「**bootstrap layer (ADR 0018 deferred)**」の分離を明文化
- **`README.md` L68**: ADR 0019 リンク追加
- **memory**: `project_windows_plugin_hooks_need_unix_clis` の「現在入手済 list」文を `dump/scoop.json` 参照に置換

製品挙動: Mac/Linux 経路は完全不変 (esac 以降 byte-identical)。Win では `just dump` が brew/gcloud not found → `scoop export` 成功に変わる。**install 系は完全に noop** (record-only)。

## 検証

| Check | Result |
|---|---|
| `just --list`: dump recipe parse | OK |
| `just dump`: `dump/scoop.json` 生成 | 1184 byte, JSON, no CRLF |
| diff stability: 2 連続 `just dump` | `git diff` 空 |
| `git check-attr eol dump/scoop.json` | `eol: lf` |
| pytest `tests/test_justfile_windows_subset.py` | **9 passed** (4 既存 + 5 新規) |

## 補足 (このPRの範囲外)

- `add-scoop` / `update-scoop` recipe (= scoop bootstrap、ADR 0018 future)
- PowerShell $PROFILE 自動化
- repo-wide `.gitattributes` (`*.sh text eol=lf` 等、別 ADR の余地あり)
- Win shellcheck console encoding 問題 (別タスク)
- prek hook の `just lint` は Win 上の shellcheck encoding 問題で fail するため、ユーザ承諾の上 `--no-verify` で bypass