### PR TITLE
feat(mise): track global mise config in dotfiles and harden settings

### DIFF
--- a/config/mise/config.toml
+++ b/config/mise/config.toml
@@ -1,0 +1,49 @@
+# Global mise config for hironow's machines. Symlinked to
+# ~/.config/mise/config.toml by `just deploy`.
+#
+# Project-pinned tools live in /Users/nino/dotfiles/mise.toml (ADR 0006).
+# This file holds user-level tool defaults, security/quarantine settings,
+# and backend tweaks that follow CLAUDE.md global rules.
+
+[tools]
+bun = "latest"
+go = "latest"
+node = "lts"
+just = "latest"
+rust = "1.96.0"
+uv = "latest"
+kotlin = "latest"
+java = "latest"
+gradle = "latest"
+python = "latest"
+vp = "latest"
+markdownlint-cli2 = "latest"
+# portless (local-dev HTTPS proxy). De-orphaned from the retired
+# pnpm-global subsystem (ADR 0017): declare it here so `mise ls` shows
+# a config source instead of an untracked orphan.
+"npm:portless" = "0.13.0"
+
+[settings]
+# Disable asdf-style .python-version / .nvmrc auto-detection so only
+# mise.toml / .tool-versions drive tool resolution.
+idiomatic_version_file_enable_tools = []
+# Block surprise installs when invoking a missing command. `mise install`
+# must be explicit.
+not_found_auto_install = false
+# `mise use <tool>` (without a version) records the currently pinned
+# version instead of "latest", keeping mise.toml reproducible
+# (ADR 0006 pinned-versions philosophy).
+pin = true
+# Match the npmrc `min_release_age=7` quarantine for supply-chain risk
+# (mirrors uv's `exclude-newer = "7 days"`).
+minimum_release_age = "7d"
+
+[settings.python]
+# Auto-source uv-managed `.venv` when entering a Python project. uv is
+# the project-wide Python package manager per CLAUDE.md global rules.
+uv_venv_auto = "source"
+
+[settings.node]
+# Auto-install corepack shims so pnpm/yarn delivered via corepack work
+# out of the box (ADR 0017 — pnpm is corepack-only).
+corepack = true

--- a/justfile
+++ b/justfile
@@ -66,6 +66,8 @@ deploy:
         cp -f ~/dotfiles/starship.toml ~/.config/starship.toml
         mkdir -p ~/.config/git
         cp -f ~/dotfiles/dump/gitignore-global ~/.config/git/ignore
+        mkdir -p ~/.config/mise
+        cp -f ~/dotfiles/config/mise/config.toml ~/.config/mise/config.toml
         echo "==> Deploy complete (windows subset per ADR 0018; Unix-only artifacts skipped)"
         exit 0
         ;;
@@ -80,6 +82,8 @@ deploy:
     ln -sf ~/dotfiles/tools/ghostty-config ~/.config/ghostty/config
     mkdir -p ~/.config/git
     cp ~/dotfiles/dump/gitignore-global ~/.config/git/ignore
+    mkdir -p ~/.config/mise
+    ln -sf ~/dotfiles/config/mise/config.toml ~/.config/mise/config.toml
     echo "==> Installing plugins..."
     if command -v sheldon >/dev/null 2>&1; then
         sheldon lock
@@ -151,6 +155,7 @@ clean:
         echo "==> Remove dotfiles (windows subset)..."
         rm -vrf ~/.config/starship.toml
         rm -vrf ~/.config/git/ignore
+        rm -vrf ~/.config/mise/config.toml
         exit 0
         ;;
     esac
@@ -160,6 +165,7 @@ clean:
     rm -vrf ~/.config/starship.toml
     rm -vrf ~/.tmux.conf
     rm -vrf ~/.config/ghostty/config
+    rm -vrf ~/.config/mise/config.toml
 
 # Clean cache: remove zsh-related caches (compinit, fzf, zoxide, kubectl, sheldon)
 [group('Setup')]


### PR DESCRIPTION
## What

Move \`~/.config/mise/config.toml\` into the repo at \`config/mise/config.toml\` and symlink it from \`just deploy\`. Future config changes now ride through git review instead of being silently edited per-machine. Also adds five new \`[settings]\` overrides aligned with the CLAUDE.md / ADR guardrails, and pins \`rust\` explicitly.

## Why

\`mise doctor\` reports \"No problems found\", but the global config only overrode 1 setting (\`idiomatic_version_file_enable_tools = []\`) while running entirely on mise defaults otherwise. Comparing against the official mise 2026.5.18 settings reference surfaced five defaults worth tightening for this repo's runtime context (uv-everywhere, corepack-only pnpm, supply-chain quarantine, pinned-versions philosophy).

## Settings additions (default -> new)

| Setting | Default | New | Reason |
|---|---|---|---|
| \`not_found_auto_install\` | \`true\` | \`false\` | Blocks surprise installs when invoking missing commands |
| \`pin\` | \`false\` | \`true\` | \`mise use <tool>\` records the currently pinned version (ADR 0006 pinned-versions philosophy) |
| \`minimum_release_age\` | \`None\` | \`\"7d\"\` | Mirrors the npmrc \`min_release_age=7\` supply-chain quarantine |
| \`python.uv_venv_auto\` | \`false\` | \`\"source\"\` | Auto-sources uv-managed \`.venv\` on cd (uv is the global Python package manager per CLAUDE.md) |
| \`node.corepack\` | \`false\` | \`true\` | Auto-installs corepack shims so pnpm via corepack works out of the box (ADR 0017) |

## Tool change

- \`rust\`: \`\"latest\"\` -> \`\"1.96.0\"\` — explicit pin matches the pin-by-hand discipline already in \`/Users/nino/dotfiles/mise.toml\`. (rust upstream is already at 1.96.0.)

## Deploy plumbing

- \`justfile\` \`deploy\`: \`ln -sf ~/dotfiles/config/mise/config.toml ~/.config/mise/config.toml\` (Unix) and \`cp -f\` (Windows subset)
- \`justfile\` \`clean\`: paired \`rm -vrf\` so \`clean\` reverses \`deploy\` symmetrically

## Verification

\`mise doctor\` after deploy:
\`\`\`
settings:
  idiomatic_version_file_enable_tools  []       ~/.config/mise/config.toml
  minimum_release_age                  \"7d\"     ~/.config/mise/config.toml
  not_found_auto_install               false    ~/.config/mise/config.toml
  pin                                  true     ~/.config/mise/config.toml
  node.corepack                        true     ~/.config/mise/config.toml
  python.uv_venv_auto                  \"source\" ~/.config/mise/config.toml
\`\`\`

\`mise install rust@1.96.0\` succeeded; \`~/.config/mise/config.toml\` is now a symlink into the repo.

## Out of scope (separate PR)

\`mise doctor\` also reports \`shims are on PATH and mise is also activated\` — this is a pre-existing shell-init concern (zshrc / \`mise activate\` eval) unrelated to the config file and will be triaged separately.

## Migration

After merge, run \`just deploy\` once per machine to convert the file at \`~/.config/mise/config.toml\` into a symlink pointing at the repo copy. Existing tool versions in the global config are preserved; only the \`rust\` pin moved from \`\"latest\"\` to \`\"1.96.0\"\`.