### PR TITLE
feat(repo): normalize shell-script line endings via .gitattributes (ADR 0020)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,11 @@
 # scoop export on Windows can emit CRLF; force LF for diff stability.
 # See ADR 0019 (Windows scoop manifest in dump/ — record-only).
 dump/scoop.json text eol=lf
+
+# Shell scripts must be LF on every platform: shellcheck reads the working
+# tree and treats CR as SC1017 error, breaking `just lint` and the
+# test_install_sh_passes_shellcheck test on Windows hosts where
+# core.autocrlf=true would otherwise convert the working tree to CRLF.
+# See ADR 0020.
+*.sh   text eol=lf
+*.bash text eol=lf

--- a/docs/adr/0019-windows-scoop-dump-record-only.md
+++ b/docs/adr/0019-windows-scoop-dump-record-only.md
@@ -91,7 +91,7 @@ each ADR has a single responsibility.
     - `test_dump_has_windows_branch`
     - `test_dump_windows_writes_scoop_json`
     - `test_dump_windows_normalizes_with_jq` (asserts `jq` + `sort_by`
-      + that `Updated`/`Manifests` tokens are absent from the branch
+        - that `Updated`/`Manifests` tokens are absent from the branch
       body — a re-include would defeat diff stability)
     - `test_dump_windows_has_no_install_side` (asserts `scoop install`
       does NOT appear — record-only invariant, separates this ADR from

--- a/docs/adr/0020-normalize-shell-script-line-endings.md
+++ b/docs/adr/0020-normalize-shell-script-line-endings.md
@@ -1,0 +1,121 @@
+# 0020. Normalize shell-script line endings via `.gitattributes`
+
+**Date:** 2026-06-02
+**Status:** Accepted
+
+## Context
+
+PR #128 (ADR 0018, Windows native MVP) and PR #131 (ADR 0019, Windows scoop
+manifest dump) both hit the same wall on the maintainer's Windows native
+host:
+
+- The prek `just lint` hook (which runs
+  `git ls-files -z '*.sh' | xargs -r mise x -- shellcheck`) and the pytest
+  case `test_install_sh_passes_shellcheck` failed with
+  `SC1017 "Literal carriage return"` on every shell script in the repo.
+- Root cause: git's `core.autocrlf=true` (the Windows default, also true on
+  this host) converts the working tree to CRLF on every checkout.
+  shellcheck reads the working tree, so it sees CR characters and flags
+  them as errors.
+- The Linux CI runner has `core.autocrlf=false` (or equivalent), so its
+  working tree is LF and shellcheck passes. CI is green; only local Windows
+  is broken.
+
+Both PRs bypassed the hook with `--no-verify` and labelled the issue
+"Windows shellcheck environment is a separate task". This ADR closes that
+loop.
+
+A `git ls-files --eol '*.sh'` audit confirms the relevant facts:
+
+- All 27 `.sh` files report `i/lf w/crlf attr/` — the **index** is already
+  LF (the blob stored by git is LF); only the working tree differs because
+  of autocrlf.
+- Zero files are `i/crlf`. There is no file whose blob contents would
+  change if line endings were normalized — only the operator's working
+  tree changes.
+
+This means the fix is purely declarative: tell git that `*.sh` is LF, and
+the autocrlf default no longer matters.
+
+## Decision
+
+Add to `.gitattributes`:
+
+```gitattributes
+*.sh   text eol=lf
+*.bash text eol=lf
+```
+
+The `dump/scoop.json text eol=lf` rule introduced by ADR 0019 stays —
+it's a specific-file rule for a non-shell artifact (JSON), conceptually
+distinct from a wildcard rule for shell sources.
+
+After the rule is committed, a one-shot `git add --renormalize .` updates
+every operator's working tree to LF on the next pull, without changing
+blob content (because all blobs are already LF).
+
+**Scope is deliberately narrow:**
+
+- Only `.sh` and `.bash`. `.zsh` / `.bats` do not exist in the repo today;
+  adding them is future-proof but not required.
+- Repo-wide `* text=auto` is NOT introduced. It would silently re-encode
+  binary blobs that lack proper attribute coverage, and the blast radius
+  exceeds what this ADR's failure justifies.
+- Windows-native scripts (`.bat`, `.cmd`, `.ps1`) are NOT covered. The
+  repo has effectively none of these; if added later, they should be
+  pinned `text eol=crlf` (PowerShell tolerates LF but convention is CRLF)
+  in a follow-up ADR.
+
+## Enforcement inventory
+
+- **`.gitattributes`**: 5 lines added (1 blank + 4 comment + 2 rules)
+  alongside the existing ADR 0019 block.
+- **Working tree renormalize**: `git add --renormalize .` is run once at
+  ADR 0020 landing time. Expected to produce zero staged content diffs
+  (the audit confirms `i/lf` everywhere); if any file *does* show up, it
+  was an exceptional `i/crlf` blob and the diff is reviewed individually
+  before commit.
+- **Existing tests now pass hands-free on Windows**:
+    - `tests/test_install_os_dispatch.py::test_install_sh_passes_shellcheck`
+      no longer requires `--no-verify` (it already worked on CI; this just
+      brings local Windows into parity).
+    - `just lint` / `just check` (prek pre-push hook) work end-to-end on
+      Windows. PRs from a Windows operator do not need `--no-verify`.
+- **No new tests added**. The contract is enforced by git's own
+  `.gitattributes` mechanism and the existing shellcheck guard; a test that
+  asserts `.gitattributes` contains specific lines would be tautological
+  given the single source of truth.
+
+## Consequences
+
+**Positive**
+
+- Windows native operators can run `just lint` / `just check` / the full
+  prek hook chain without `--no-verify`. The `--no-verify` escape hatch
+  from PR #128 and PR #131 is no longer needed for shellcheck reasons
+  (other reasons may still apply in isolation).
+- Behaviour is reproducible across operator git configurations:
+  contributors with `core.autocrlf=true`, `false`, or `input` all get
+  the same working tree.
+- The "Windows shellcheck environment" line item from the recent ADR
+  follow-up list is closed.
+
+**Negative**
+
+- Win operators who previously edited a `.sh` in a CRLF-only editor
+  (notepad.exe) will see git convert it to LF on save / commit. Modern
+  editors (VS Code, Notepad++, etc.) already honour `.gitattributes`,
+  so this is mostly theoretical.
+- Anyone running `git status` for the first time after pulling this ADR
+  may see "no changes" but their working tree silently flipped from CRLF
+  to LF. This is the intended behaviour; documented here for transparency.
+
+**Neutral**
+
+- `dump/scoop.json text eol=lf` (ADR 0019) is now superficially redundant
+  with the wildcard rule on `*.sh`, but is kept verbatim: JSON is not a
+  shell script, and the specific-file rule documents its own ADR origin.
+  Removing it would create a cross-ADR coupling for a one-line save.
+- The `*.bash` rule covers zero files at landing time. It is future-proof
+  insurance for the next shell script someone wants to commit with an
+  explicit `.bash` extension.


### PR DESCRIPTION
## なぜ

PR #128 (ADR 0018) と #131 (ADR 0019) は両方とも Win local の prek hook `just lint` (= shellcheck) と pytest の `test_install_sh_passes_shellcheck` が **SC1017 "Literal carriage return"** で fail し、両 PR とも `--no-verify` で bypass を強いられた。

Root cause:

- git の `core.autocrlf=true` (Win default) が checkout 時に WT を CRLF 変換
- shellcheck は WT を直接読むので CR を見て error 扱い
- Linux CI runner は LF で読むため CI は緑、Win local だけ赤

`git ls-files --eol '*.sh'` 監査で確認: **全 27 個の .sh は index=lf** (`i/crlf` 0 件)。つまり blob 書き換えゼロで normalize 可能。

## 何を

- **`.gitattributes`**: `*.sh   text eol=lf` と `*.bash text eol=lf` を追加 (ADR 0019 の `dump/scoop.json` 行はそのまま残置、JSON layer)
- **WT renormalize**: `git add --renormalize .` + 全 .sh の WT を `tr -d '\r'` で LF 化。**staged 内容は `.gitattributes` + ADR 0020 + ADR 0019 軽微修正のみ** (.sh の blob は元から LF で diff ゼロ)
- **`docs/adr/0020-normalize-shell-script-line-endings.md`** (新規): 設計判断と enforcement inventory
- **`docs/adr/0019-windows-scoop-dump-record-only.md`**: prek の markdownlint が auto-fix した bullet 整形 (1 文字)。PR #131 で `--no-verify` した時の指摘事項が hook 通過で同時に掃除された

## 検証

| Check | Result |
|---|---|
| `shellcheck --severity=error install.sh` (Win local) | exit 0 |
| pytest (`test_install_os_dispatch.py` + `test_justfile_windows_subset.py`) | **29 passed** |
| `git diff --cached --stat` | 3 ファイルのみ、.sh content diff なし |
| **prek hook 通過 (`--no-verify` なし)** | **✅** (本 PR の commit がその証) |

## 補足

- `* text=auto` (repo-wide normalization) は副作用大なので out of scope
- `.bat` / `.cmd` / `.ps1` は現状ゼロ件、追加時は別 ADR で `eol=crlf` 推奨
- `*.bash` は現状ゼロ件だが future-proof で追加