### PR TITLE
feat(git): split ~/.gitconfig into dotfiles-managed include files (ADR 0021)

### DIFF
--- a/config/git/aliases.gitconfig
+++ b/config/git/aliases.gitconfig
@@ -1,0 +1,204 @@
+# Git aliases managed by hironow/dotfiles. Included from ~/.gitconfig via:
+#   [include]
+#     path = ~/dotfiles/config/git/aliases.gitconfig
+#
+# Multi-line function aliases use the `!f() { ...; }; f` pattern: git
+# expands `!<cmd>` as a shell command, and the trailing `; f` invokes
+# the function so positional arguments work.
+
+[alias]
+	# === Basic ===
+	aa = !git add . && git add -u && git status
+	ac = !git add -A && aicommit2 -a
+	ss = status --short --branch
+	wip = commit -m 'wip'
+	graph = log --graph -10 --branches --remotes --tags --format=format:'%Cgreen%h %Creset• %<(75,trunc)%s (%cN, %cr) %Cred%d' --date-order
+	ll = log --pretty=format:"%C(yellow)%h%Cred%d\\ %Creset%s%Cblue\\ [%cn]" --decorate --numstat
+	precommit = diff --cached --diff-algorithm=minimal -w
+	unmerged = diff --name-only --diff-filter=U
+	remotes = remote -v
+	firstcommit = commit --allow-empty -m 'initial commit'
+
+	# === Worktree create ===
+	wt = "!f() { \
+		branch=${1:-$(git branch --show-current)}; \
+		base=$(basename $(pwd)); \
+		dir=\"../${base}-${branch//\\//-}\"; \
+		if git worktree add \"$dir\" \"$branch\" 2>/dev/null; then \
+			echo \"✅ Created worktree: $dir\"; \
+		else \
+			git worktree add -b \"$branch\" \"$dir\" && echo \"✅ Created new branch and worktree: $dir\"; \
+		fi; \
+		echo \"📁 cd $dir\"; \
+	}; f"
+
+	# === Worktree status (consolidated) ===
+	wst = "!f() { \
+		echo \"=== Git Worktrees ===\"; \
+		git worktree list | while read -r line; do \
+			dir=$(echo $line | awk '{print $1}'); \
+			branch=$(echo $line | awk '{print $3}' | tr -d '[]'); \
+			if [ -d \"$dir\" ]; then \
+				status=$(cd \"$dir\" && git status --porcelain | wc -l | tr -d ' '); \
+				if [ \"$status\" -gt 0 ]; then \
+					echo \"📝 $branch → $dir (uncommitted: $status files)\"; \
+				else \
+					echo \"✅ $branch → $dir\"; \
+				fi; \
+			else \
+				echo \"⚠️  $branch → $dir (missing directory)\"; \
+			fi; \
+		done; \
+		echo \"\"; \
+		echo \"Total: $(git worktree list | wc -l) worktrees\"; \
+	}; f"
+
+	# === Worktree go (fzf-aware) ===
+	wgo = "!f() { \
+		if [ -z \"$1\" ]; then \
+			if command -v fzf >/dev/null 2>&1; then \
+				selected=$(git worktree list | fzf --height=40% --reverse | awk '{print $1}'); \
+			else \
+				echo \"Select worktree:\"; \
+				git worktree list | nl -v 0; \
+				read -p \"Enter number (or branch name): \" choice; \
+				if [[ \"$choice\" =~ ^[0-9]+$ ]]; then \
+					selected=$(git worktree list | sed -n \"$((choice+1))p\" | awk '{print $1}'); \
+				else \
+					selected=$(git worktree list | grep \"\\[$choice\\]\" | awk '{print $1}'); \
+				fi; \
+			fi; \
+		elif [ \"$1\" = \"-\" ]; then \
+			branch=$(git reflog | grep 'checkout: moving from' | head -1 | sed 's/.*to //'); \
+			selected=$(git worktree list | grep \"\\[$branch\\]\" | awk '{print $1}'); \
+		else \
+			selected=$(git worktree list | grep \"\\[$1\\]\" | awk '{print $1}'); \
+		fi; \
+		if [ -n \"$selected\" ]; then \
+			echo \"cd $selected\"; \
+		else \
+			echo \"echo 'Worktree not found'\"; \
+		fi; \
+	}; f"
+
+	# === Worktree remove ===
+	wr = "!f() { \
+		if [ -z \"$1\" ]; then \
+			git worktree remove $(pwd) 2>/dev/null || echo \"Not in a worktree\"; \
+		else \
+			git worktree remove $(git worktree list --porcelain | grep -B2 \"branch refs/heads/$1\" | head -n1 | cut -d' ' -f2); \
+		fi; \
+	}; f"
+
+	wclean = "!f() { \
+		branch=$1; \
+		worktree=$(git worktree list --porcelain | grep -B2 \"branch refs/heads/$branch\" | head -n1 | cut -d' ' -f2); \
+		[ -n \"$worktree\" ] && git worktree remove \"$worktree\"; \
+		git branch -D \"$branch\" 2>/dev/null; \
+		echo \"Cleaned worktree and branch: $branch\"; \
+	}; f"
+
+	# === Commit + move (consolidated) ===
+	wtmove = "!f() { \
+		branch=$1; \
+		[ -z \"$branch\" ] && echo \"Usage: git wtmove <branch> [--wip|--ai|--stash]\" && return 1; \
+		case \"$2\" in \
+			--wip) git wip ;; \
+			--ai) git ac ;; \
+			--stash|*) git stash -u ;; \
+		esac; \
+		git wt \"$branch\"; \
+		[ \"$2\" = \"--stash\" ] || [ -z \"$2\" ] && git stash pop 2>/dev/null; \
+	}; f"
+
+	# === Workflow specialised ===
+	pr = "!f() { \
+		pr_number=$1; \
+		[ -z \"$pr_number\" ] && echo \"Usage: git pr <number>\" && return 1; \
+		branch=\"pr-$pr_number\"; \
+		git fetch origin pull/$pr_number/head:$branch && git wt $branch; \
+	}; f"
+
+	hotfix = "!f() { \
+		issue=$1; \
+		[ -z \"$issue\" ] && echo \"Usage: git hotfix <issue-id>\" && return 1; \
+		git wt hotfix/$issue; \
+	}; f"
+
+	wtemp = "!f() { \
+		branch=${1:-HEAD}; \
+		temp=\"temp-$(date +%s)\"; \
+		git worktree add \"../$(basename $(pwd))-$temp\" -d \"$branch\"; \
+		echo \"Created temporary worktree: $temp\"; \
+	}; f"
+
+	# === Batch operations ===
+	wexec = "!f() { \
+		cmd=\"$@\"; \
+		git worktree list | awk '{print $1}' | while read dir; do \
+			echo \"=== $dir ===\"; \
+			(cd \"$dir\" && eval \"$cmd\"); \
+		done; \
+	}; f"
+
+	wpull = "!f() { git wexec git pull; }; f"
+
+	# === Utilities ===
+	whealth = "!f() { \
+		echo \"=== Worktree Health Check ===\"; \
+		issues=0; \
+		git worktree list | while read -r line; do \
+			dir=$(echo $line | awk '{print $1}'); \
+			if [ ! -d \"$dir\" ]; then \
+				echo \"⚠️  Missing directory: $dir\"; \
+				issues=$((issues + 1)); \
+			fi; \
+		done; \
+		orphans=$(git worktree prune --dry-run 2>&1); \
+		[ -n \"$orphans\" ] && echo \"⚠️  Orphaned worktrees found:\" && echo \"$orphans\" && issues=$((issues + 1)); \
+		[ $issues -eq 0 ] && echo \"✅ All worktrees healthy\"; \
+	}; f"
+
+	wcp = "!f() { \
+		src=$1; dst=$2; file=$3; \
+		[ -z \"$file\" ] && echo \"Usage: git wcp <src-branch> <dst-branch> <file>\" && return 1; \
+		src_dir=$(git worktree list | grep \"\\[$src\\]\" | awk '{print $1}'); \
+		dst_dir=$(git worktree list | grep \"\\[$dst\\]\" | awk '{print $1}'); \
+		if [ -n \"$src_dir\" ] && [ -n \"$dst_dir\" ]; then \
+			cp \"$src_dir/$file\" \"$dst_dir/$file\" && echo \"Copied $file from $src to $dst\"; \
+		else \
+			echo \"Source or destination worktree not found\"; \
+		fi; \
+	}; f"
+
+	# === Help ===
+	alias = "!f() { \
+		echo \"=== Git Aliases (Optimized) ===\"; \
+		echo \"\"; \
+		echo \"📝 Basic:\"; \
+		echo \"  aa        - Add all files and show status\"; \
+		echo \"  ac        - Add all and AI commit\"; \
+		echo \"  ss        - Short status with branch\"; \
+		echo \"  wip       - Quick WIP commit\"; \
+		echo \"  graph     - Visual branch history\"; \
+		echo \"  ll        - Log with file changes\"; \
+		echo \"\"; \
+		echo \"🌳 Worktree:\"; \
+		echo \"  wt        - Create worktree (git wt [branch])\"; \
+		echo \"  wst       - Status of all worktrees with stats\"; \
+		echo \"  wgo       - Go to worktree (no arg=fzf, -=previous, name=direct)\"; \
+		echo \"  wr        - Remove worktree (current or specified)\"; \
+		echo \"  wclean    - Remove worktree AND delete branch\"; \
+		echo \"  whealth   - Check worktree health\"; \
+		echo \"\"; \
+		echo \"🚀 Workflow:\"; \
+		echo \"  wtmove    - Save changes and move (--wip/--ai/--stash)\"; \
+		echo \"  pr        - Checkout PR (git pr <number>)\"; \
+		echo \"  hotfix    - Create hotfix branch\"; \
+		echo \"  wtemp     - Create temporary worktree\"; \
+		echo \"\"; \
+		echo \"🔧 Operations:\"; \
+		echo \"  wexec     - Execute command in all worktrees\"; \
+		echo \"  wpull     - Pull all worktrees\"; \
+		echo \"  wcp       - Copy file between worktrees\"; \
+	}; f"

--- a/config/git/shared.gitconfig
+++ b/config/git/shared.gitconfig
@@ -1,0 +1,62 @@
+# Shared git config managed by hironow/dotfiles. Included from
+# ~/.gitconfig via:
+#   [include]
+#     path = ~/dotfiles/config/git/shared.gitconfig
+#
+# PC-specific values (user.email, user.signingkey, gpg.program path,
+# credential helpers with absolute Homebrew paths, lfs custom transfer)
+# stay in ~/.gitconfig directly so they never get committed.
+
+[user]
+	name = hironow
+
+[column]
+	ui = auto
+
+[branch]
+	sort = -committerdate
+
+[init]
+	defaultBranch = main
+
+[diff]
+	algorithm = histogram
+	colorMoved = plain
+	mnemonicPrefix = true
+	renames = true
+
+[push]
+	default = simple
+	autoSetupRemote = true
+	followTags = true
+
+[fetch]
+	prune = true
+	pruneTags = true
+	all = true
+
+[help]
+	autocorrect = prompt
+
+[commit]
+	gpgsign = true
+	verbose = true
+
+[rerere]
+	enabled = true
+	autoupdate = true
+
+[rebase]
+	autoSquash = true
+	autoStash = true
+	updateRefs = true
+
+[filter "lfs"]
+	clean = git-lfs clean -- %f
+	smudge = git-lfs smudge -- %f
+	process = git-lfs filter-process
+	required = true
+
+[tag]
+	sort = version:refname
+	forceSignAnnotated = true

--- a/docs/adr/0021-git-config-include-split.md
+++ b/docs/adr/0021-git-config-include-split.md
@@ -1,0 +1,121 @@
+# 0021. Split git config via `[include]` so dotfiles owns aliases + shared settings
+
+**Date:** 2026-06-02
+**Status:** Accepted
+
+## Context
+
+`~/.gitconfig` historically held everything in one file: the PC-local
+identity and credentials (`user.email`, `user.signingkey`,
+`gpg.program`, `credential.<host>.helper = !/opt/homebrew/...`,
+`lfs "customtransfer.xet"`), the shared workflow defaults
+(`commit.gpgsign`, `push.autoSetupRemote`, `rerere.enabled`,
+`rebase.autoSquash`, etc.), and ~24 aliases including non-trivial
+multi-line `!f() { ... }; f` worktree helpers.
+
+Mixing the three categories in a single file blocked symlinking the
+file from dotfiles: pushing `~/.gitconfig` wholesale to git either
+leaks the GPG signing key id / credential helper paths, or forces
+per-machine secrets into a single tracked file.
+
+git already has the primitive for this: the `[include]` directive.
+A `~/.gitconfig` can contain `[include] path = ...` lines that pull
+in additional files, and the resulting config is the union of all
+files (with later entries winning on key conflicts).
+
+## Decision
+
+Split `~/.gitconfig` into three files:
+
+1. `~/.gitconfig` — **PC-local only.** Holds `user.email`,
+   `user.signingkey`, `gpg.program`, `lfs "customtransfer.xet"`,
+   `credential.*.helper`, and a trailing `[include]` block that pulls
+   in the two dotfiles-managed files. Not symlinked, not tracked.
+2. `~/dotfiles/config/git/shared.gitconfig` — workflow defaults
+   shared across machines: `user.name`, `column`, `branch`, `init`,
+   `diff`, `push`, `fetch`, `help`, `commit`, `rerere`, `rebase`,
+   `filter "lfs"`, `tag`. Tracked.
+3. `~/dotfiles/config/git/aliases.gitconfig` — all `[alias]` entries
+   including the 24 worktree / workflow helpers. Tracked.
+
+`~/.gitconfig` is left for the operator to set up by hand on each
+machine because identity + signing key + credential paths legitimately
+differ between hosts; symlinking would either force them into git or
+require a separate secrets store.
+
+## Enforcement inventory
+
+### Entry points
+
+- `git config --get <key>` lookups by any tool (git itself, gh CLI,
+  tracked tools).
+- `git <alias>` invocations.
+- `commit.gpgsign = true` is read on every commit.
+
+### Persistent / carried data needed at each enforcement point
+
+- `~/.gitconfig` must contain a `[include]` block referencing both
+  dotfiles files.
+- `~/dotfiles/config/git/shared.gitconfig` must exist on disk before
+  the first git command runs (otherwise `commit.gpgsign` / `user.name`
+  fall back to defaults).
+- `~/dotfiles/config/git/aliases.gitconfig` must exist before any
+  aliased command resolves.
+
+### Bypass candidates
+
+- A new machine cloning dotfiles but not editing `~/.gitconfig` will
+  miss the `[include]` lines and silently use stock git defaults
+  (no aliases, no gpgsign, default push behaviour). Mitigation: this
+  ADR doubles as the setup instruction; operators paste the include
+  block once per machine.
+- `git config --global --get-regexp '^alias\.'` returns 0 results
+  even though `git <alias>` works, because `--global` only enumerates
+  keys that physically live in `~/.gitconfig`. Use
+  `git config --show-origin --get-regexp '^alias\.'` (no `--global`)
+  to see the include-resolved set.
+- A CI runner without a GPG key will fail every commit because
+  `shared.gitconfig` forces `commit.gpgsign = true`. Mitigation: CI
+  jobs set `GIT_CONFIG_GLOBAL=/dev/null` or run with
+  `-c commit.gpgsign=false`.
+
+### Tests proving coverage
+
+- Manual smoke after deploy: `git config --show-origin --get-regexp '^alias\.' | wc -l` returns the count baked into
+  `aliases.gitconfig` (currently 24).
+- Manual smoke: `git config --show-origin --get commit.gpgsign`
+  reports `file:.../shared.gitconfig\ttrue`.
+- `git ss` (a tracked alias) resolves to `git status --short --branch`
+  with no extra args.
+
+## Consequences
+
+### Positive
+
+- Aliases and shared workflow defaults ride through git review.
+- PC-local secrets (`user.signingkey`, credential helpers with
+  homebrew paths) stay in the untracked `~/.gitconfig` and never get
+  committed.
+- Adding or tweaking an alias on one machine and pushing to
+  `hironow/dotfiles` immediately propagates to every machine that
+  pulls.
+- `~/.gitconfig` shrinks from ~270 lines to ~30, making the local
+  secrets visually obvious.
+
+### Negative
+
+- New-machine setup needs one manual edit of `~/.gitconfig` to add
+  the `[include]` block — this cannot ride on `just deploy` because
+  the file legitimately contains per-machine secrets.
+- `git config --global` is now an unreliable enumeration of the
+  effective settings; operators must learn to use `--show-origin`
+  without `--global` for surveys.
+- A CI runner pulling dotfiles will inherit `commit.gpgsign = true`
+  and start failing commits unless overridden — captured under
+  "Bypass candidates" above.
+
+### Neutral
+
+- `~/.gitconfig.bak.YYYYMMDD` files left behind by the migration
+  remain untracked and are safe to delete manually after the new
+  setup is verified.


### PR DESCRIPTION
## What

Pull git aliases (24 entries, including the worktree helpers) and the shared workflow defaults out of \`~/.gitconfig\` and into two tracked files under \`~/dotfiles/config/git/\`. The local file keeps only the values that legitimately differ per machine (signing key, credential helper paths, etc.) and pulls in the tracked files via \`[include]\`.

This is the standard split for dotfiles repos that hold both shared config and PC-specific secrets, and avoids the \"can't symlink because the file mixes secrets and shared keys\" problem.

## Why

\`~/.gitconfig\` used to hold three concerns in one 270-line file:

| Concern | Examples | OK to commit? |
|---|---|---|
| PC-local identity / credentials | \`user.email\`, \`user.signingkey\`, \`gpg.program\`, \`credential.<host>.helper = !/opt/homebrew/bin/gh auth git-credential\`, \`lfs \"customtransfer.xet\"\` | **no** |
| Shared workflow defaults | \`commit.gpgsign\`, \`push.autoSetupRemote\`, \`rebase.autoSquash\`, \`tag.forceSignAnnotated\`, ... | yes |
| Aliases | \`aa\`, \`ss\`, \`wt\`, \`wgo\`, \`whealth\`, ... (24 of them, several multi-line \`!f() { ... }; f\` shell helpers) | yes |

Splitting them lets the shared + alias halves ride through normal git review while the local half stays out of the repo entirely.

## Layout after this PR

\`\`\`
~/dotfiles/config/git/aliases.gitconfig   # all [alias] entries
~/dotfiles/config/git/shared.gitconfig    # workflow defaults
~/.gitconfig                              # ~30 lines, PC-local only,
                                          # ends with [include] block
\`\`\`

\`~/.gitconfig\` example end of file:

\`\`\`ini
[include]
    path = ~/dotfiles/config/git/shared.gitconfig
    path = ~/dotfiles/config/git/aliases.gitconfig
\`\`\`

## Verification

Run on this machine after the split:

| Check | Result |
|---|---|
| \`git config --show-origin --get-regexp '^alias\\.' \\| wc -l\` | \`24\` (all from \`aliases.gitconfig\`) |
| \`git config --show-origin --get commit.gpgsign\` | \`file:.../shared.gitconfig<TAB>true\` |
| \`git config --show-origin --get user.signingkey\` | \`file:~/.gitconfig<TAB><redacted>\` |
| \`git ss\` | resolves to \`git status --short --branch\` |

Note: \`git config --global --get-regexp '^alias\\.'\` returns \`0\` because \`--global\` only enumerates keys **physically written in \`~/.gitconfig\`**; include-resolved keys live in their origin file. Use \`--show-origin\` (without \`--global\`) for inventory. This gotcha is captured in the ADR's Bypass candidates.

## Note on ADR number

This PR originally numbered the ADR \`0020\`, but #133 landed an \`ADR 0020\` for shell-script line-ending normalization while this branch was in flight. The ADR has been renumbered to \`0021\` and rebased onto current main. A duplicate \`style(docs):\` commit that touched the same \`+ that\` line in ADR 0019 was also dropped because #133 already cleaned that up (the prek hook auto-fix was accepted there).

## Out of scope (NOT addressed here)

- \`just deploy\` is **not** modified. \`~/.gitconfig\` legitimately differs per machine (different signing keys, different credential helper paths on Linux vs Mac), so symlinking it is unsafe. Setup is one-time per machine and documented in the ADR.
- A CI runner pulling dotfiles will inherit \`commit.gpgsign = true\` from \`shared.gitconfig\` and start failing commits unless overridden — this is called out in the ADR's Bypass candidates section. Suggested workarounds: \`GIT_CONFIG_GLOBAL=/dev/null\` or \`git -c commit.gpgsign=false\`.

## Migration on other machines

1. Back up the existing file: \`cp ~/.gitconfig ~/.gitconfig.bak.YYYYMMDD\`.
2. Trim \`~/.gitconfig\` down to its PC-local sections (\`[user.email|signingkey]\`, \`[gpg]\`, \`[lfs \"customtransfer.xet\"]\`, \`[credential ...]\`).
3. Append:
   \`\`\`ini
   [include]
       path = ~/dotfiles/config/git/shared.gitconfig
       path = ~/dotfiles/config/git/aliases.gitconfig
   \`\`\`
4. Verify: \`git config --show-origin --get-regexp '^alias\\.' \\| wc -l\` should print \`24\`.

The ADR has the same steps with a complete \`~/.gitconfig\` template.