### PR TITLE
feat(deploy): wire starship into PowerShell $PROFILE on Windows (ADR 0021)

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ bash -c "$(curl -fsSL https://raw.githubusercontent.com/hironow/dotfiles/main/in
 ```
 
 > [!NOTE]
-> Mac, Linux, Windows([WSL](https://learn.microsoft.com/en-us/windows/wsl/)内Linux)を一級でサポート。Windows native は最小サブセット (`corepack enable` + `starship.toml` / `gitignore-global` の配置) と **scoop manifest dump (`dump/scoop.json`, record-only)** に対応。フル bootstrap (scoop からの一括 install) は未対応 (将来 ADR)。詳細は [ADR 0018](docs/adr/0018-windows-native-mvp.md) / [ADR 0019](docs/adr/0019-windows-scoop-dump-record-only.md)。
+> Mac, Linux, Windows([WSL](https://learn.microsoft.com/en-us/windows/wsl/)内Linux)を一級でサポート。Windows native は最小サブセット (`corepack enable` + `starship.toml` / `gitignore-global` の配置 + **PowerShell `$PROFILE` への starship init 注入**) と **scoop manifest dump (`dump/scoop.json`, record-only)** に対応。フル bootstrap (scoop からの一括 install) は未対応 (将来 ADR)。詳細は [ADR 0018](docs/adr/0018-windows-native-mvp.md) / [ADR 0019](docs/adr/0019-windows-scoop-dump-record-only.md) / [ADR 0022](docs/adr/0022-powershell-starship-profile-init.md)。
 > Mac は Homebrew が前提条件 (操作者が手動で先にインストール)、それ以降は install.sh が自動。
 
 ## usage

--- a/docs/adr/0022-powershell-starship-profile-init.md
+++ b/docs/adr/0022-powershell-starship-profile-init.md
@@ -1,0 +1,134 @@
+# 0022. PowerShell `$PROFILE` starship init from `just deploy` (Windows native)
+
+**Date:** 2026-06-02
+**Status:** Accepted
+
+## Context
+
+ADR 0018 (PR #128) made `just deploy` on Windows native place
+`~/dotfiles/starship.toml` to `~/.config/starship.toml`. But the
+`starship.toml` is a config file: it does nothing until PowerShell runs
+`Invoke-Expression (&starship init powershell)` at session start. On
+Windows that init line lives in `$PROFILE`
+(`~/Documents/PowerShell/Microsoft.PowerShell_profile.ps1` for PowerShell
+7), which `just deploy` did not touch — operators had to add the line by
+hand on every new host.
+
+The Linux/macOS path already has the symmetric piece: `.zshrc` L41-44
+gates the init behind `_cmd_exists starship`, so the prompt activates
+automatically wherever `.zshrc` is sourced. PowerShell is missing the
+equivalent.
+
+Host audit on this maintainer's machine:
+
+- `~/Documents/PowerShell/` exists (only `powershell.config.json` inside);
+  the profile script is absent until first deploy.
+- No OneDrive Documents redirect (`~/Documents` resolves to the local
+  drive).
+- `pwsh.exe` (PowerShell 7) is installed.
+- No marker-block precedent (`# >>> ... # <<<`) exists anywhere in the
+  repo, so this ADR establishes the convention.
+
+## Decision
+
+Extend the `just deploy` Windows branch to write a marker-delimited
+starship-init block to PowerShell 7's `$PROFILE`, and extend `just clean`
+to remove it. The whole exchange is idempotent on both sides.
+
+Concretely, the deploy branch appends (only if the begin marker is
+absent):
+
+```powershell
+# >>> dotfiles managed block: starship init >>>
+# Managed by `just deploy` (see ADR 0022). Edits inside this block are overwritten on next deploy.
+if (Get-Command starship -ErrorAction SilentlyContinue) {
+    Invoke-Expression (&starship init powershell)
+}
+# <<< end dotfiles managed block <<<
+```
+
+Decisions that matter:
+
+- **PowerShell 7 only.** Path is hardcoded to
+  `~/Documents/PowerShell/Microsoft.PowerShell_profile.ps1`. PowerShell 5
+  (`WindowsPowerShell/`), OneDrive-redirected Documents, and `pwsh -Command
+  '$PROFILE.CurrentUserCurrentHost'`-style dynamic resolution are
+  deliberately out of scope. The maintainer's host fits this assumption;
+  if a second host doesn't, a follow-up ADR handles dynamic resolution
+  without re-litigating the marker design.
+- **`Get-Command starship` guard.** Mirrors the `.zshrc` `_cmd_exists
+  starship` pattern. PowerShell startup must not error on hosts where
+  `starship` is not yet installed (scoop bootstrap is still ADR 0018
+  future work).
+- **Marker-delimited block.** Lets `just clean` remove only what `just
+  deploy` placed, leaving any other operator-authored profile content
+  untouched. Idempotency on deploy is checked with `grep -qF` on the
+  begin marker; removal in clean is a `sed -i '/begin/,/end/d'` range
+  deletion (MSYS GNU sed accepts `-i` without an argument).
+- **LF, not CRLF.** PowerShell 7 reads `$PROFILE` correctly regardless of
+  line ending. Writing LF from bash matches what `.zshrc` and every other
+  shell artifact in this repo uses. `$PROFILE` is outside the repo so
+  ADR 0020's `.gitattributes` rules do not apply.
+
+## Enforcement inventory
+
+- **`justfile`** — `deploy` Windows branch (around line 63) gains the
+  $PROFILE block-write logic; `clean` Windows branch (around line 150)
+  gains the symmetric sed-range removal. Both keep their existing `exit
+  0` so the Unix-only tail of each recipe never runs on Windows.
+- **`tests/test_justfile_windows_subset.py`** — three new tests pin the
+  contract:
+    - `test_deploy_windows_writes_powershell_profile_init` checks the
+      profile path, both markers, the `Invoke-Expression` line, and the
+      `Get-Command` guard are present in the deploy Windows branch.
+    - `test_deploy_windows_powershell_init_is_idempotent` checks the
+      `grep -qF` marker guard exists and the writing path uses append
+      (`>>`) not overwrite (`>`).
+    - `test_clean_windows_removes_powershell_profile_init` checks the
+      `sed -i` range removal, both markers, the PS7 profile path, and
+      that the existing `exit 0` from ADR 0018 is still present after
+      the new block.
+- **`README.md`** — L68 cross-reference list is extended with ADR 0022.
+- **`.gitattributes`** — unchanged. `$PROFILE` lives outside the repo, so
+  ADR 0020's `.sh`/`.bash` LF rules do not cover it. A `.ps1` rule
+  belongs in a future ADR if a tracked `.ps1` file is ever added.
+
+## Consequences
+
+**Positive**
+
+- A fresh Windows host gets a working starship prompt from `just deploy`
+  alone — no manual `$PROFILE` edit, no follow-up instructions in the
+  README. This closes the loop opened by ADR 0018 (which placed
+  `starship.toml` but did not activate it).
+- `just clean` is now a true inverse of `just deploy` on the Windows
+  subset: a deploy/clean roundtrip leaves `$PROFILE` byte-identical to
+  its pre-deploy state, minus the managed block.
+- The `Get-Command` guard makes the init line safe to ship before
+  `starship` itself is installed. ADR 0018's "scoop bootstrap is future
+  work" stance is preserved without breaking PowerShell startup.
+- The marker convention (`# >>> ... # <<<`) is now established and can
+  be reused for any future managed-block injection (zsh, nu, fish, etc.)
+  without re-deciding the shape.
+
+**Negative**
+
+- Hardcoded `~/Documents/PowerShell/...` will not match hosts where
+  OneDrive has redirected the Documents folder, or hosts that only have
+  PowerShell 5. Those hosts get a no-op deploy (file ends up somewhere
+  the operator's PowerShell does not read). A follow-up ADR is the
+  intended fix; a louder failure mode (detecting OneDrive redirect or
+  PS 5 and skipping with a hint) is one possible direction.
+- If an operator has already written `Invoke-Expression (&starship init
+  powershell)` to `$PROFILE` manually outside the markers, both lines
+  will run on shell start. `starship init` is idempotent, so the only
+  visible effect is a tiny startup overhead.
+
+**Neutral**
+
+- The ADR 0019 `dump/scoop.json` and ADR 0020 `.gitattributes` rules are
+  independent of this change; ADR 0022 cross-references both for the
+  EOL-governance discussion but does not modify them.
+- The marker convention is repo-internal; nothing prevents an operator
+  from copying it for their own injections, but no policy is created
+  here for those copies.

--- a/justfile
+++ b/justfile
@@ -68,7 +68,26 @@ deploy:
         cp -f ~/dotfiles/dump/gitignore-global ~/.config/git/ignore
         mkdir -p ~/.config/mise
         cp -f ~/dotfiles/config/mise/config.toml ~/.config/mise/config.toml
-        echo "==> Deploy complete (windows subset per ADR 0018; Unix-only artifacts skipped)"
+        # PowerShell 7 $PROFILE — idempotent starship init block (ADR 0022).
+        ps_profile="$HOME/Documents/PowerShell/Microsoft.PowerShell_profile.ps1"
+        ps_marker_begin="# >>> dotfiles managed block: starship init >>>"
+        ps_marker_end="# <<< end dotfiles managed block <<<"
+        mkdir -p "$(dirname "$ps_profile")"
+        touch "$ps_profile"
+        if grep -qF "$ps_marker_begin" "$ps_profile"; then
+          echo "==> PowerShell \$PROFILE starship-init block already present (skip)"
+        else
+          {
+            printf '\n%s\n' "$ps_marker_begin"
+            printf '# Managed by `just deploy` (see ADR 0022). Edits inside this block are overwritten on next deploy.\n'
+            printf 'if (Get-Command starship -ErrorAction SilentlyContinue) {\n'
+            printf '    Invoke-Expression (&starship init powershell)\n'
+            printf '}\n'
+            printf '%s\n' "$ps_marker_end"
+          } >> "$ps_profile"
+          echo "==> PowerShell \$PROFILE updated with starship-init block"
+        fi
+        echo "==> Deploy complete (windows subset per ADR 0018/0022; Unix-only artifacts skipped)"
         exit 0
         ;;
     esac
@@ -156,6 +175,12 @@ clean:
         rm -vrf ~/.config/starship.toml
         rm -vrf ~/.config/git/ignore
         rm -vrf ~/.config/mise/config.toml
+        # Remove PowerShell starship-init block (idempotent; ADR 0022).
+        ps_profile="$HOME/Documents/PowerShell/Microsoft.PowerShell_profile.ps1"
+        if [ -f "$ps_profile" ] && grep -qF "# >>> dotfiles managed block: starship init >>>" "$ps_profile"; then
+          sed -i '/# >>> dotfiles managed block: starship init >>>/,/# <<< end dotfiles managed block <<</d' "$ps_profile"
+          echo "==> PowerShell \$PROFILE starship-init block removed"
+        fi
         exit 0
         ;;
     esac

--- a/tests/test_justfile_windows_subset.py
+++ b/tests/test_justfile_windows_subset.py
@@ -232,3 +232,90 @@ def test_dump_windows_exits_before_unix_path(justfile_text: str) -> None:
         "dump windows branch must `exit 0` before the Mac/Linux `brew bundle "
         "dump` block, otherwise scoop hosts will hit brew not-found errors."
     )
+
+
+# ---------- PowerShell $PROFILE starship init (ADR 0022) ------------
+
+
+PS_MARKER_BEGIN = "# >>> dotfiles managed block: starship init >>>"
+PS_MARKER_END = "# <<< end dotfiles managed block <<<"
+
+
+def test_deploy_windows_writes_powershell_profile_init(
+    justfile_text: str,
+) -> None:
+    """ADR 0022: deploy Windows branch must wire starship into PowerShell 7's
+    $PROFILE. Without this, placing starship.toml is a no-op on Windows
+    because the shell never invokes `starship init`."""
+    body = _extract_recipe_body(justfile_text, "deploy")
+    win = _extract_windows_branch(body)
+    assert "Microsoft.PowerShell_profile.ps1" in win, (
+        "deploy windows branch must reference the PowerShell 7 profile path "
+        "(ADR 0022 targets PS7 only)"
+    )
+    assert PS_MARKER_BEGIN in win, (
+        "deploy windows branch must include the begin marker so the block "
+        "can be detected for idempotency and removed by clean"
+    )
+    assert PS_MARKER_END in win, (
+        "deploy windows branch must include the end marker so sed range "
+        "deletion in clean has both anchors"
+    )
+    assert "Invoke-Expression (&starship init powershell)" in win, (
+        "deploy windows branch must emit the canonical starship init line"
+    )
+    assert "Get-Command starship -ErrorAction SilentlyContinue" in win, (
+        "deploy windows branch must guard with Get-Command so PowerShell "
+        "does not error on hosts where starship is not yet installed "
+        "(parity with .zshrc's _cmd_exists guard)"
+    )
+
+
+def test_deploy_windows_powershell_init_is_idempotent(
+    justfile_text: str,
+) -> None:
+    """ADR 0022 requires the deploy block to be idempotent: running `just
+    deploy` twice must not duplicate the marker block in $PROFILE.
+
+    Asserts a `grep -qF` marker check exists AND that the writing path uses
+    append (`>>`) rather than overwrite (`>`), so other operator content in
+    $PROFILE is preserved."""
+    body = _extract_recipe_body(justfile_text, "deploy")
+    win = _extract_windows_branch(body)
+    assert "grep -qF" in win, (
+        "deploy windows branch must `grep -qF` for the marker before "
+        "writing, to make the block placement idempotent"
+    )
+    # The append redirection should target $ps_profile. Allow optional
+    # whitespace between `>>` and the variable.
+    assert re.search(r'>>\s*"\$ps_profile"', win), (
+        "deploy windows branch must append (>>) to $ps_profile, not "
+        "overwrite (>), so existing operator content is preserved"
+    )
+
+
+def test_clean_windows_removes_powershell_profile_init(
+    justfile_text: str,
+) -> None:
+    """ADR 0022 symmetry: clean must remove the marker block from $PROFILE
+    so a deploy/clean roundtrip leaves the file in its pre-deploy state
+    (minus the managed block)."""
+    body = _extract_recipe_body(justfile_text, "clean")
+    win = _extract_windows_branch(body)
+    assert "Microsoft.PowerShell_profile.ps1" in win, (
+        "clean windows branch must reference the PowerShell 7 profile path"
+    )
+    assert "sed -i" in win, (
+        "clean windows branch must use `sed -i` to delete the marker block "
+        "range in-place"
+    )
+    assert PS_MARKER_BEGIN in win and PS_MARKER_END in win, (
+        "clean windows branch must reference both markers so the sed range "
+        "deletion has both anchors"
+    )
+    # Original `exit 0` from ADR 0018 must still be present after the
+    # PowerShell block is removed, otherwise Unix-only rm lines would run.
+    assert re.search(r"\bexit\s+0\b", win), (
+        "clean windows branch must keep `exit 0` after the PowerShell "
+        "cleanup so the Unix-only rm block does not run on Windows"
+    )


### PR DESCRIPTION
## なぜ

ADR 0018 (PR #128) で `just deploy` Win 分岐が `starship.toml` を `~/.config/starship.toml` に配置するようになったが、PowerShell からは `$PROFILE` に `Invoke-Expression (&starship init powershell)` を書かないと有効化されない。これまで operator が手動で追記しており、新 Win host を立てるたびに同じ手作業 = 「deploy 1 コマンドで完成」の理想から逸脱していた。

`.zshrc` 側 (L41-44) は `if _cmd_exists starship; then eval "$(starship init zsh)"; fi` で同等が成立。PowerShell 側にも同じ shape を入れる。

## 何を

- **`justfile` deploy Win 分岐**: PowerShell 7 の `$PROFILE` (`~/Documents/PowerShell/Microsoft.PowerShell_profile.ps1`) に marker-delimited な block を冪等 append。block 内容:
    - `# >>> dotfiles managed block: starship init >>>` / `# <<< end ... <<<` marker
    - `if (Get-Command starship -ErrorAction SilentlyContinue)` ガード (.zshrc の `_cmd_exists` と等価、starship 未インストール時に PS 起動が error にならない)
    - `Invoke-Expression (&starship init powershell)`
- **`justfile` clean Win 分岐**: `sed -i '/begin/,/end/d'` で marker block だけ削除 (operator の他 $PROFILE 内容は touch せず)
- **`tests/test_justfile_windows_subset.py`**: 新規 3 件
    - deploy が marker / Invoke-Expression / Get-Command ガード / PS7 path を含む
    - deploy が `grep -qF` 冪等性ガード + append (`>>`) を使う
    - clean が `sed -i` で marker 範囲削除 + `exit 0` 維持
- **`docs/adr/0021-powershell-starship-profile-init.md`** (新規): 設計判断と enforcement inventory
- **`README.md` L68**: ADR 0021 リンク追加

## 検証

| Check | Result |
|---|---|
| deploy 1回目: $PROFILE 新規作成 + block 書き込み | OK (295 byte) |
| deploy 2回目: idempotent | OK ("already present (skip)"、size 不変) |
| clean: marker block 削除 | OK |
| 全 pytest (29 既存 + 3 新規) | **32 passed** |
| **prek hook 通過 (`--no-verify` なし)** | ✅ (ADR 0020 の .gitattributes 効果) |

## 補足 (このPRの範囲外)

- PowerShell 5 / OneDrive Documents redirect / cmd.exe / Nu shell
- $PROFILE 動的解決 (`pwsh -Command '$PROFILE.CurrentUserCurrentHost'`) は `powershell.exe` 起動が deny rule 該当のため決め打ち path
- starship 自体の install は引き続き operator 責任 (ADR 0018 future bootstrap)