### PR TITLE
chore(dump): drop unused wangzq scoop bucket and orphan socat

### DIFF
--- a/dump/scoop.json
+++ b/dump/scoop.json
@@ -7,10 +7,6 @@
     {
       "Name": "main",
       "Source": "https://github.com/ScoopInstaller/Main.git"
-    },
-    {
-      "Name": "wangzq",
-      "Source": "https://github.com/wangzq/scoop-bucket"
     }
   ],
   "apps": [
@@ -58,11 +54,6 @@
       "Name": "shellcheck",
       "Version": "0.11.0",
       "Source": "main"
-    },
-    {
-      "Name": "socat",
-      "Version": "1.7.2.1",
-      "Source": "wangzq"
     }
   ]
 }


### PR DESCRIPTION
## なぜ

ADR 0019 (PR #131) で `dump/scoop.json` を track し始めた時点で、`wangzq` (`https://github.com/wangzq/scoop-bucket`) は **0 manifest の空バケット** で、`socat` (1.7.2.1) だけがそこを Source として install されていた。ADR 0019 の Consequences で「wangzq cleanup は operator 判断、out of scope」と書いた通り、今その判断をする。

`socat` 自体は最近使っておらず、orphan 化したバケット参照は `scoop export` が `Cannot find path 'C:\Users\absin\scoop\buckets\wangzq\'` warning を毎回吐き続ける noise 源だった。

## 何を

| Action | Effect |
|---|---|
| `scoop bucket rm wangzq` | 0 manifest の死にバケット削除 |
| `scoop uninstall socat` | wangzq 由来で orphan 化していた app を退役 |
| `just dump` で再生成 | buckets 3→2 / apps 10→9 |

ADR 0019 framework 内の運用 cleanup につき新規 ADR なし。

## 検証

- `scoop bucket list`: main / extras のみ
- `scoop list`: socat 不在
- `just dump` 再実行: warning なし、diff 空 (idempotent)
- prek hook 通過 (`--no-verify` なし)

## 補足

socat を再度欲しくなった場合は `scoop search socat` で main/extras の有無を確認し、あれば `scoop install socat` で再導入可能。