### PR TITLE
fix(docs): renumber mise activate ADR from 0022 to 0023 (collision with #135)

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -121,7 +121,7 @@ path_prepend "$HOME/.local/bin"
 # mise activate is intentionally NOT here — it lives at EOF so its
 # chpwd/precmd hook runs after every later PATH edit (vite-plus,
 # antigravity, dbt, ...) and mise-managed tool dirs end up first in
-# PATH. See ADR 0022.
+# PATH. See ADR 0023.
 
 
 # alias
@@ -265,7 +265,7 @@ export PATH="$HOME/.local/bin:$PATH"
 # etc. — and mise-managed versions end up first in PATH per
 # `mise doctor`. Shims are intentionally NOT on PATH (interactive shells
 # use activate only; cron/IDE/non-shell consumers should use
-# `mise exec --` or shims in ~/.zshenv). See ADR 0022.
+# `mise exec --` or shims in ~/.zshenv). See ADR 0023.
 if _cmd_exists mise; then
     eval "$(mise activate zsh)"
 fi

--- a/docs/adr/0023-mise-activate-only-no-shims-path.md
+++ b/docs/adr/0023-mise-activate-only-no-shims-path.md
@@ -1,4 +1,4 @@
-# 0022. Use `mise activate` only in interactive shells, drop manual `shims` PATH entries
+# 0023. Use `mise activate` only in interactive shells, drop manual `shims` PATH entries
 
 **Date:** 2026-06-02
 **Status:** Accepted


### PR DESCRIPTION
## What

PR #135 (powershell-starship-profile-init) and PR #136 (mise activate) both used ADR number **0022**, landing back-to-back. After both merged, `docs/adr/` ended up with two files named `0022-*` :

```
0022-mise-activate-only-no-shims-path.md     ← PR #136
0022-powershell-starship-profile-init.md     ← PR #135
```

This PR renumbers the mise activate ADR to **0023** and updates the two `.zshrc` breadcrumb comments that reference it.

## Why renumber mise rather than powershell

- PR #135 merged first (commit `56f5d6e`), PR #136 merged second (`a982368`). By the "first writer wins" convention from ADR 0019/0020 of similar collisions, the second one moves.

## No behaviour change

`mise doctor` still reports "No problems found". The decision content of the ADR is unchanged; only the heading number, the filename, and the two `See ADR 0022` references in `.zshrc` move.