### PR TITLE
feat(deploy): wire mise activate into PowerShell $PROFILE on Windows (ADR 0024)

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ bash -c "$(curl -fsSL https://raw.githubusercontent.com/hironow/dotfiles/main/in
 ```
 
 > [!NOTE]
-> Mac, Linux, Windows([WSL](https://learn.microsoft.com/en-us/windows/wsl/)内Linux)を一級でサポート。Windows native は最小サブセット (`corepack enable` + `starship.toml` / `gitignore-global` の配置 + **PowerShell `$PROFILE` への starship init 注入**) と **scoop manifest dump (`dump/scoop.json`, record-only)** に対応。フル bootstrap (scoop からの一括 install) は未対応 (将来 ADR)。詳細は [ADR 0018](docs/adr/0018-windows-native-mvp.md) / [ADR 0019](docs/adr/0019-windows-scoop-dump-record-only.md) / [ADR 0022](docs/adr/0022-powershell-starship-profile-init.md)。
+> Mac, Linux, Windows([WSL](https://learn.microsoft.com/en-us/windows/wsl/)内Linux)を一級でサポート。Windows native は最小サブセット (`corepack enable` + `starship.toml` / `gitignore-global` の配置 + **PowerShell `$PROFILE` への starship init / mise activate 注入**) と **scoop manifest dump (`dump/scoop.json`, record-only)** に対応。フル bootstrap (scoop からの一括 install) は未対応 (将来 ADR)。詳細は [ADR 0018](docs/adr/0018-windows-native-mvp.md) / [ADR 0019](docs/adr/0019-windows-scoop-dump-record-only.md) / [ADR 0022](docs/adr/0022-powershell-starship-profile-init.md) / [ADR 0024](docs/adr/0024-powershell-mise-activate-profile.md)。
 > Mac は Homebrew が前提条件 (操作者が手動で先にインストール)、それ以降は install.sh が自動。
 
 ## usage

--- a/docs/adr/0024-powershell-mise-activate-profile.md
+++ b/docs/adr/0024-powershell-mise-activate-profile.md
@@ -1,0 +1,128 @@
+# 0024. PowerShell `$PROFILE` mise activate from `just deploy` (Windows native)
+
+**Date:** 2026-06-02
+**Status:** Accepted
+
+## Context
+
+ADR 0022 (PR #135) established the marker-delimited managed-block pattern
+for injecting startup code into PowerShell 7's `$PROFILE` from
+`just deploy`. The first injected block was starship's prompt init. The
+same approach now extends to **mise activation**, closing a parallel gap.
+
+On Windows native, mise is installed (`scoop install mise` in
+`dump/scoop.json`), `mise.toml` pins node 24.15.0, but PowerShell never
+calls `mise activate`. As a result `where.exe node` returns
+`C:\Program Files\nodejs\node.exe` (v23.3.0) first, then the scoop copy
+(v24.10) — the mise-pinned 24.15.0 is functionally invisible from
+PowerShell. zsh side already runs `eval "$(mise activate zsh)"` in
+`.zshrc` (L269-271) per ADR 0023's "activate only, no shims PATH dance"
+decision.
+
+The fix is small and symmetrical: add a second managed block to
+`$PROFILE` that calls `mise activate pwsh`. The marker convention from
+ADR 0022 is reused verbatim (only the service name in the begin marker
+differs); the end marker `# <<< end dotfiles managed block <<<` is
+shared because sed's range deletion identifies blocks by their begin
+marker — each `clean` sed targets the correct begin and stops at the
+first end thereafter.
+
+## Decision
+
+Extend the existing `just deploy` Windows branch to append (idempotently)
+a second managed block immediately after the starship block:
+
+```powershell
+# >>> dotfiles managed block: mise activate >>>
+# Managed by `just deploy` (see ADR 0024). Edits inside this block are overwritten on next deploy.
+if (Get-Command mise -ErrorAction SilentlyContinue) {
+    Invoke-Expression (&mise activate pwsh)
+}
+# <<< end dotfiles managed block <<<
+```
+
+And extend `just clean` to remove this block via the same sed
+range-deletion pattern. Both halves reuse the `$ps_profile` and
+`$ps_marker_end` shell variables already defined for the starship
+block earlier in the recipe.
+
+Decisions that matter:
+
+- **PowerShell 7 only, hardcoded profile path.** Same constraint as
+  ADR 0022. OneDrive Documents redirect and PS 5 remain out of scope.
+- **`Get-Command mise` guard.** Mirrors `.zshrc`'s `_cmd_exists mise`
+  (ADR 0023 EOF activation block). PowerShell startup must not error
+  if mise is not yet installed, since `scoop install mise` is operator
+  setup and may precede any first `just deploy`.
+- **End marker shared with ADR 0022.** sed's `/begin/,/end/d` deletes
+  from a specific begin marker to the **next** end marker — block A's
+  begin paired with block A's end, block B's begin paired with block B's
+  end. The shared end string is safe because the begin markers are
+  distinct. Tests assert two distinct `sed -i` invocations are present in
+  the clean branch.
+- **mise block placed after starship.** Order is functionally irrelevant
+  (each init is independent), but appending after the existing block
+  keeps the `$PROFILE` diff for an upgrade-from-ADR-0022 host minimal —
+  the starship block is byte-identical, only the new mise block follows.
+- **Program Files / scoop Node retirement deferred.** ADR 0024 only
+  *promotes* mise to the front of PATH (by activating it), it does not
+  remove other Node installs. The follow-up to retire Program Files
+  Node (admin required) and scoop nodejs (orphan from dump perspective)
+  is intentionally a separate ADR.
+
+## Enforcement inventory
+
+- **`justfile`** — `deploy` Windows branch (around L89) gains the
+  mise-activate block-write logic after the starship block. `clean`
+  Windows branch (around L200) gains a second sed range removal. Both
+  reuse variables already declared by the starship block.
+- **`tests/test_justfile_windows_subset.py`** — three new tests pin the
+  contract:
+    - `test_deploy_windows_writes_powershell_mise_activate` checks the
+      mise marker, the `Invoke-Expression (&mise activate pwsh)` line,
+      and the `Get-Command mise` guard.
+    - `test_deploy_windows_mise_activate_is_idempotent` asserts the
+      deploy branch contains at least two `grep -qF` calls (one per
+      managed block) and two append (`>>`) redirections.
+    - `test_clean_windows_removes_powershell_mise_activate` asserts
+      the clean branch contains at least two `sed -i` invocations and
+      that `exit 0` is still in place.
+- **`README.md`** — L68 cross-reference list extended with ADR 0024.
+
+## Consequences
+
+**Positive**
+
+- PowerShell `node --version` returns mise-managed 24.15.0 instead of
+  the stale Program Files 23.3.0 (without uninstalling anything — mise's
+  activation prepends its bin dir to PATH for the running shell).
+- The zsh and PowerShell activation stories are now symmetric: both
+  use the `mise activate` path, both are guarded by a "command exists?"
+  check, both can be removed cleanly by their respective deploy-clean
+  inverse.
+- The marker-block pattern from ADR 0022 is exercised a second time,
+  which validates the convention and makes future managed blocks (e.g.,
+  a future PowerShell prompt customization, or a third tool's init)
+  trivial to add — copy/paste with new marker + new service name.
+
+**Negative**
+
+- Two Node installs (Program Files v23.3.0 and scoop v24.10.0) remain
+  on the host. They are no longer first on PATH for PowerShell, but
+  they still consume disk and can confuse operators who run
+  `where.exe node` expecting a single hit. A follow-up cleanup ADR is
+  the explicit fix; this ADR's scope ends at "make mise win the PATH
+  race".
+- `$PROFILE` is now two blocks wider. An operator who runs
+  `just clean` without re-running `just deploy` will have an empty
+  `$PROFILE` until the next deploy. (Same as ADR 0022; reiterated for
+  clarity.)
+
+**Neutral**
+
+- ADR 0023 (zsh side) is the spiritual peer of this ADR. It does not
+  change behavior on Windows but is the canonical reference for "why
+  activate, not shims PATH" — anyone touching either ADR should read
+  the other.
+- The `mise activate pwsh` shell name is mise's preferred form (per
+  `mise activate --help`); `powershell` is also accepted as an alias.

--- a/justfile
+++ b/justfile
@@ -87,7 +87,23 @@ deploy:
           } >> "$ps_profile"
           echo "==> PowerShell \$PROFILE updated with starship-init block"
         fi
-        echo "==> Deploy complete (windows subset per ADR 0018/0022; Unix-only artifacts skipped)"
+        # PowerShell 7 $PROFILE — mise activate block (ADR 0024). Reuses
+        # $ps_profile and $ps_marker_end defined for the starship block above.
+        ps_mise_marker_begin="# >>> dotfiles managed block: mise activate >>>"
+        if grep -qF "$ps_mise_marker_begin" "$ps_profile"; then
+          echo "==> PowerShell \$PROFILE mise-activate block already present (skip)"
+        else
+          {
+            printf '\n%s\n' "$ps_mise_marker_begin"
+            printf '# Managed by `just deploy` (see ADR 0024). Edits inside this block are overwritten on next deploy.\n'
+            printf 'if (Get-Command mise -ErrorAction SilentlyContinue) {\n'
+            printf '    Invoke-Expression (&mise activate pwsh)\n'
+            printf '}\n'
+            printf '%s\n' "$ps_marker_end"
+          } >> "$ps_profile"
+          echo "==> PowerShell \$PROFILE updated with mise-activate block"
+        fi
+        echo "==> Deploy complete (windows subset per ADR 0018/0022/0024; Unix-only artifacts skipped)"
         exit 0
         ;;
     esac
@@ -180,6 +196,11 @@ clean:
         if [ -f "$ps_profile" ] && grep -qF "# >>> dotfiles managed block: starship init >>>" "$ps_profile"; then
           sed -i '/# >>> dotfiles managed block: starship init >>>/,/# <<< end dotfiles managed block <<</d' "$ps_profile"
           echo "==> PowerShell \$PROFILE starship-init block removed"
+        fi
+        # Remove PowerShell mise-activate block (idempotent; ADR 0024).
+        if [ -f "$ps_profile" ] && grep -qF "# >>> dotfiles managed block: mise activate >>>" "$ps_profile"; then
+          sed -i '/# >>> dotfiles managed block: mise activate >>>/,/# <<< end dotfiles managed block <<</d' "$ps_profile"
+          echo "==> PowerShell \$PROFILE mise-activate block removed"
         fi
         exit 0
         ;;

--- a/tests/test_justfile_windows_subset.py
+++ b/tests/test_justfile_windows_subset.py
@@ -319,3 +319,84 @@ def test_clean_windows_removes_powershell_profile_init(
         "clean windows branch must keep `exit 0` after the PowerShell "
         "cleanup so the Unix-only rm block does not run on Windows"
     )
+
+
+# ---------- PowerShell $PROFILE mise activate (ADR 0024) ------------
+
+
+PS_MISE_MARKER_BEGIN = "# >>> dotfiles managed block: mise activate >>>"
+
+
+def test_deploy_windows_writes_powershell_mise_activate(
+    justfile_text: str,
+) -> None:
+    """ADR 0024: deploy Windows branch must wire mise into PowerShell 7's
+    $PROFILE so the mise-managed node/just/etc resolve correctly on
+    Windows. Without this, PATH resolution falls back to whatever Program
+    Files / scoop installed (per the ADR 0024 context)."""
+    body = _extract_recipe_body(justfile_text, "deploy")
+    win = _extract_windows_branch(body)
+    assert PS_MISE_MARKER_BEGIN in win, (
+        "deploy windows branch must include the mise-activate begin marker "
+        "so the block can be detected for idempotency and removed by clean"
+    )
+    assert "Invoke-Expression (&mise activate pwsh)" in win, (
+        "deploy windows branch must emit the canonical mise activate line "
+        "for PowerShell"
+    )
+    assert "Get-Command mise -ErrorAction SilentlyContinue" in win, (
+        "deploy windows branch must guard with Get-Command so PowerShell "
+        "does not error on hosts where mise is not yet installed "
+        "(parity with .zshrc's _cmd_exists mise guard)"
+    )
+
+
+def test_deploy_windows_mise_activate_is_idempotent(
+    justfile_text: str,
+) -> None:
+    """ADR 0024 requires the mise block to be idempotent: a `grep -qF`
+    on the mise marker must guard the append. Since the starship block
+    (ADR 0022) also uses `grep -qF`, the deploy Windows branch must
+    contain at least TWO `grep -qF` calls — one per managed block."""
+    body = _extract_recipe_body(justfile_text, "deploy")
+    win = _extract_windows_branch(body)
+    grep_calls = re.findall(r"grep -qF", win)
+    assert len(grep_calls) >= 2, (
+        f"deploy windows branch must have at least 2 `grep -qF` calls "
+        f"(one per managed block: starship + mise). Found {len(grep_calls)}."
+    )
+    # The append redirection should target $ps_profile (same variable both
+    # blocks reuse). At least 2 append redirections must exist.
+    appends = re.findall(r'>>\s*"\$ps_profile"', win)
+    assert len(appends) >= 2, (
+        f"deploy windows branch must have at least 2 append (>>) redirections "
+        f"to $ps_profile (one per managed block). Found {len(appends)}."
+    )
+
+
+def test_clean_windows_removes_powershell_mise_activate(
+    justfile_text: str,
+) -> None:
+    """ADR 0024 symmetry: clean must remove the mise marker block from
+    $PROFILE via a sed range deletion. The starship sed (ADR 0022)
+    already exists; clean must therefore have at least TWO `sed -i`
+    invocations."""
+    body = _extract_recipe_body(justfile_text, "clean")
+    win = _extract_windows_branch(body)
+    sed_calls = re.findall(r"sed -i", win)
+    assert len(sed_calls) >= 2, (
+        f"clean windows branch must have at least 2 `sed -i` invocations "
+        f"(one per managed block: starship + mise). Found {len(sed_calls)}."
+    )
+    assert PS_MISE_MARKER_BEGIN in win, (
+        "clean windows branch must reference the mise begin marker so the "
+        "sed range deletion targets the right block"
+    )
+    assert "mise activate" in win, (
+        "clean windows branch must remove the mise-activate block per ADR 0024"
+    )
+    # `exit 0` must still terminate the branch after both removals.
+    assert re.search(r"\bexit\s+0\b", win), (
+        "clean windows branch must keep `exit 0` after both PowerShell "
+        "block removals so the Unix-only rm block does not run on Windows"
+    )


### PR DESCRIPTION
## なぜ

ADR 0022 (PR #135) で PowerShell `$PROFILE` に starship init を marker-delimited block で注入する機構を確立した。同じ機構で mise も activate する。

現状: Win host で `where.exe node` の先頭は Program Files v23.3.0 (古い)、次に scoop v24.10。mise が pin した 24.15.0 は PowerShell から不可視。zsh 側は ADR 0023 (PR #136/138) で `mise activate zsh` で同等が成立済。PowerShell 側にも同じ shape を入れる。

## 何を

- **`justfile` deploy Win 分岐**: 既存 starship block (ADR 0022) の直後に mise activate block を冪等 append。$ps_profile / $ps_marker_end は前 block の変数を再利用
    - marker: `# >>> dotfiles managed block: mise activate >>>` / `# <<< end ... <<<` (end は ADR 0022 と共通、sed range は begin で識別)
    - guard: `if (Get-Command mise -ErrorAction SilentlyContinue) { ... }`
    - body: `Invoke-Expression (&mise activate pwsh)`
- **`justfile` clean Win 分岐**: 既存 starship sed 削除の直後に対称の mise sed 削除
- **`tests/test_justfile_windows_subset.py`**: 新規 3 件 (mise marker / Invoke-Expression / Get-Command / 2 個以上の grep + append / 2 個以上の sed + exit 0)
- **`docs/adr/0024-powershell-mise-activate-profile.md`** (新規): 設計判断と enforcement inventory。end marker 共有の sed range safety を明文化
- **`README.md` L68**: ADR 0024 リンク追加

## 検証

| Check | Result |
|---|---|
| deploy 1回目: starship skip + mise append | OK |
| deploy 2回目: 両 block idempotent | OK (size 581 不変) |
| clean: 両 block 削除 | OK |
| deploy → clean → deploy ラウンドトリップ | OK (状態復元) |
| 全 pytest | **35 passed** (32 既存 + 3 新規) |
| prek hook 通過 (`--no-verify` なし) | ✅ |

## 補足 (このPRの範囲外)

- Program Files Node v23.3.0 アンインストール (admin 必要)
- scoop nodejs 24.10.0 退役 (別 PR で dump 更新)
- PowerShell 5 / OneDrive Documents redirect