### PR TITLE
fix(test-iac): pin opentofu in mise SoT and invoke via mise x

### DIFF
--- a/config/mise/config.toml
+++ b/config/mise/config.toml
@@ -11,6 +11,11 @@ go = "latest"
 node = "lts"
 just = "latest"
 rust = "1.96.0"
+# opentofu — terraform-compatible IaC. Required by `just test-iac`
+# so `mise x -- tofu` resolves from the non-mise-activated bash
+# sub-shell that `just` spawns under ADR 0023 (mise-activate-only,
+# no shims PATH). Pinned for repeatable IaC test runs across machines.
+opentofu = "1.11.5"
 uv = "latest"
 kotlin = "latest"
 java = "latest"

--- a/justfile
+++ b/justfile
@@ -464,7 +464,7 @@ check-all: pre-commit ci-all
 # rewrites the lock to the terraform.io registry.
 [group('Check')]
 test-iac:
-    @cd exe/coder/templates/dotfiles-devcontainer && tofu init -backend=false >/dev/null && tofu test
+    @cd exe/coder/templates/dotfiles-devcontainer && mise x -- tofu init -backend=false >/dev/null && mise x -- tofu test
 
 # ------------------------------
 # Add sets


### PR DESCRIPTION
## なぜ

ローカルで `just ci` を実行すると **`test-iac` が `tofu: command not found` で fail** する状態。原因は同 session で merge された 2 つの PR が **無関係に見えて重なって落ち合う場所** で発症している:

1. **PR #132** (`config/mise/config.toml` を repo SoT 化、`just deploy` で symlink) — host 側で `mise use --global opentofu` した ad-hoc pin は次の deploy で symlink に上書きされて消える。SoT に entry が無い限り、opentofu は `~/.local/share/mise/installs/opentofu/<ver>/` に binary はあるけど pin の無い orphan install になり、`mise x -- tofu` でも解決不可。
2. **PR #136 / ADR 0023** (`.zshrc` から shims PATH 落として mise activate-only) — `just` が起動する **non-mise-activated bash sub-shell** には mise shim も activate も無い。`tofu init … && tofu test` は bare invocation だから PATH 解決できない。

**両方が同時に揃わないと recipe は通らない**(片方だけ直しても fail する不可分なペア)。今回 1 PR で両方を埋める。

## 何を

### config-side: `config/mise/config.toml` に opentofu を pin 追加

```toml
rust = "1.96.0"
+# opentofu — terraform-compatible IaC. Required by `just test-iac`
+# so `mise x -- tofu` resolves from the non-mise-activated bash
+# sub-shell that `just` spawns under ADR 0023 (mise-activate-only,
+# no shims PATH). Pinned for repeatable IaC test runs across machines.
+opentofu = "1.11.5"
 uv = "latest"
```

### invocation-side: `justfile` の `test-iac` を `mise x -- tofu` 経由化

```diff
 test-iac:
-    @cd exe/coder/templates/dotfiles-devcontainer && tofu init -backend=false >/dev/null && tofu test
+    @cd exe/coder/templates/dotfiles-devcontainer && mise x -- tofu init -backend=false >/dev/null && mise x -- tofu test
```

PR #129 で `sheldon` に対して入れたのと**同じ 「`mise x -- ` で再 invoke 」 パターン**でござる。

## 検証

- `just check` (ruff format/check, shellcheck, markdownlint-cli2, vp check, meta-semgrep, semgrep-test) ✅
- 実機 end-to-end: `~/.config/mise/conf.d/test-iac-temp.toml` に opentofu pin を一時 overlay して(PR merge + `just deploy` 後と等価な host state を再現)、`just test-iac` 実行 → **6 tofu test 全 pass**:

```
dmail.tofutest.hcl... pass
  run "runtime_variable_defaults_match_production"... pass
  run "image_variable_defaults_point_at_runops_artifact_registry"... pass
  run "runops_gateway_url_must_be_https"... pass
  run "runops_gateway_url_accepts_https"... pass
  run "runops_admin_token_secret_id_default_is_empty"... pass
  run "runops_gateway_url_default_is_empty"... pass

Success! 6 passed, 0 failed.
```

## 補足

`exe-validate` recipe (justfile line 1037) も同型の bare `tofu fmt -check`、`tofu init`、`tofu validate` を持っており、ADR 0023 環境下では同じ fail mode を起こすでござる。**スコープを `just ci` blocker 解消に絞る**ため今回 PR に巻き込まず、follow-up PR に残すでござる。

[BEHAVIORAL]