### PR TITLE
fix(exe-*): wire mise activate into all exe-* recipes so bare tofu resolves

### DIFF
--- a/justfile
+++ b/justfile
@@ -989,6 +989,7 @@ _exe-encryption:
 exe-init:
     #!/usr/bin/env bash
     set -euo pipefail
+    eval "$(mise activate bash)"
     export TF_ENCRYPTION="$(just _exe-encryption)"
     cd tofu/exe && tofu init
 
@@ -997,6 +998,7 @@ exe-init:
 exe-plan:
     #!/usr/bin/env bash
     set -euo pipefail
+    eval "$(mise activate bash)"
     : "${CLOUDFLARE_API_TOKEN:?set CLOUDFLARE_API_TOKEN before running}"
     : "${TAILSCALE_API_KEY:?set TAILSCALE_API_KEY before running}"
     export TF_ENCRYPTION="$(just _exe-encryption)"
@@ -1007,6 +1009,7 @@ exe-plan:
 exe-apply:
     #!/usr/bin/env bash
     set -euo pipefail
+    eval "$(mise activate bash)"
     : "${CLOUDFLARE_API_TOKEN:?set CLOUDFLARE_API_TOKEN before running}"
     : "${TAILSCALE_API_KEY:?set TAILSCALE_API_KEY before running}"
     export TF_ENCRYPTION="$(just _exe-encryption)"
@@ -1024,6 +1027,7 @@ exe-apply:
 exe-replace target:
     #!/usr/bin/env bash
     set -euo pipefail
+    eval "$(mise activate bash)"
     : "${CLOUDFLARE_API_TOKEN:?set CLOUDFLARE_API_TOKEN before running}"
     : "${TAILSCALE_API_KEY:?set TAILSCALE_API_KEY before running}"
     export TF_ENCRYPTION="$(just _exe-encryption)"
@@ -1034,6 +1038,7 @@ exe-replace target:
 exe-down:
     #!/usr/bin/env bash
     set -euo pipefail
+    eval "$(mise activate bash)"
     : "${CLOUDFLARE_API_TOKEN:?set CLOUDFLARE_API_TOKEN before running}"
     : "${TAILSCALE_API_KEY:?set TAILSCALE_API_KEY before running}"
     export TF_ENCRYPTION="$(just _exe-encryption)"
@@ -1045,6 +1050,7 @@ exe-down:
 exe-down-all:
     #!/usr/bin/env bash
     set -euo pipefail
+    eval "$(mise activate bash)"
     : "${CLOUDFLARE_API_TOKEN:?set CLOUDFLARE_API_TOKEN before running}"
     : "${TAILSCALE_API_KEY:?set TAILSCALE_API_KEY before running}"
     export TF_ENCRYPTION="$(just _exe-encryption)"
@@ -1055,6 +1061,7 @@ exe-down-all:
 exe-validate:
     #!/usr/bin/env bash
     set -euo pipefail
+    eval "$(mise activate bash)"
     cd tofu/exe
     tofu fmt -check -diff
     tofu init -backend=false -input=false >/dev/null
@@ -1065,6 +1072,7 @@ exe-validate:
 exe-output *args:
     #!/usr/bin/env bash
     set -euo pipefail
+    eval "$(mise activate bash)"
     export TF_ENCRYPTION="$(just _exe-encryption)"
     cd tofu/exe && tofu output {{ args }}
 


### PR DESCRIPTION
## なぜ

PR #140 で `just test-iac` の `tofu: command not found` を解消した時、本文に「`exe-validate` recipe (justfile line 1037) は同型の bare tofu invocation を持っており、ADR 0023 環境下では同じ fail mode を起こす — 今回スコープから外して follow-up PR に残す」と明記した。本 PR がその follow-up でござる。

実際に grep を取り直すと、対象は `exe-validate` だけでなく **`exe-*` recipe ファミリー全 8 つ** に同型 problem があった:

| recipe | naked tofu calls |
|---|---|
| `exe-init` | `tofu init` |
| `exe-plan` | `tofu plan` |
| `exe-apply` | `tofu apply` |
| `exe-replace` | `tofu apply -replace=…` |
| `exe-down` | `tofu destroy -target=…` (line-continuation) |
| `exe-down-all` | `tofu destroy` |
| `exe-validate` | `tofu fmt -check -diff`, `tofu init -backend=false …`, `tofu validate` |
| `exe-output` | `tofu output {{args}}` |

ADR 0023 で `.zshrc` から shims PATH を落として activate-only にした結果、`just` が起動する **非 mise-activated bash sub-shell** には mise activate も shim も無い。bare `tofu …` は全部 `command not found` で落ちる。

## 何を

PR #140 (test-iac) は **single-command recipe form** (`@cd … && tofu …`) だったので `mise x -- tofu` prefix で解決した。一方 `exe-*` family は **全てが shebang-script form** (`#!/usr/bin/env bash` + `set -euo pipefail` + 本文) — ここでは **冒頭に `eval "$(mise activate bash)"` を 1 行追加するだけで recipe 内全 tofu 呼出を救える** cleaner な解が成立する。

8 recipe × 1 line 追加、**+8 / -0 lines、addition-only**:

```diff
 exe-init:
     #!/usr/bin/env bash
     set -euo pipefail
+    eval "$(mise activate bash)"
     export TF_ENCRYPTION="$(just _exe-encryption)"
     cd tofu/exe && tofu init
```

(残り 7 recipe も全く同じ pattern)

## なぜ `mise x -- tofu` ではなく `mise activate` か

- shebang-script form は 1 spawn で複数 command 実行する。**activate 1 行で recipe 内の全 tofu 呼出を一括カバー**できる(`exe-validate` は tofu を 3 回呼ぶ、`exe-down` は line-continuation を含む)。
- ADR 0023 が向かう先(「shim PATH 経由ではなく activate 経由」)と整合。recipe も interactive zsh も同じ resolution path を通る。
- 既存 recipe 本文に**一切手を入れない**ので blast radius は最小限。

PR #140 の `mise x -- tofu` pattern は **single-command form (`test-iac`)** に対する正解で引き続き有効。**recipe の form に応じて pattern を選ぶ** という mental rule が成立する形でござる。

## 検証

- `just check` ✅ (ruff format/check, shellcheck, markdownlint-cli2, vp check, meta-semgrep, semgrep-test)
- bash sub-shell sanity:

```
$ bash -c 'set -euo pipefail; eval "$(mise activate bash)"; command -v tofu; tofu --version | head -1'
/home/absin/.local/share/mise/installs/opentofu/1.11.5/tofu
OpenTofu v1.11.5
```

(`opentofu = "1.11.5"` pin は PR #140 で `config/mise/config.toml` に追加済)

- 実 recipe 実行 (`exe-apply` 等) は GCS state と Cloudflare/Tailscale live API を触るため意図的に skip。recipe-resolution fix のスコープ外。

[BEHAVIORAL]