### PR TITLE
fix(windows): pipe mise activate through Out-String in PowerShell $PROFILE

### DIFF
--- a/docs/adr/0024-powershell-mise-activate-profile.md
+++ b/docs/adr/0024-powershell-mise-activate-profile.md
@@ -36,7 +36,7 @@ a second managed block immediately after the starship block:
 # >>> dotfiles managed block: mise activate >>>
 # Managed by `just deploy` (see ADR 0024). Edits inside this block are overwritten on next deploy.
 if (Get-Command mise -ErrorAction SilentlyContinue) {
-    Invoke-Expression (&mise activate pwsh)
+    Invoke-Expression (&mise activate pwsh | Out-String)
 }
 # <<< end dotfiles managed block <<<
 ```
@@ -79,7 +79,7 @@ Decisions that matter:
 - **`tests/test_justfile_windows_subset.py`** — three new tests pin the
   contract:
     - `test_deploy_windows_writes_powershell_mise_activate` checks the
-      mise marker, the `Invoke-Expression (&mise activate pwsh)` line,
+      mise marker, the `Invoke-Expression (&mise activate pwsh | Out-String)` line,
       and the `Get-Command mise` guard.
     - `test_deploy_windows_mise_activate_is_idempotent` asserts the
       deploy branch contains at least two `grep -qF` calls (one per

--- a/justfile
+++ b/justfile
@@ -97,7 +97,7 @@ deploy:
             printf '\n%s\n' "$ps_mise_marker_begin"
             printf '# Managed by `just deploy` (see ADR 0024). Edits inside this block are overwritten on next deploy.\n'
             printf 'if (Get-Command mise -ErrorAction SilentlyContinue) {\n'
-            printf '    Invoke-Expression (&mise activate pwsh)\n'
+            printf '    Invoke-Expression (&mise activate pwsh | Out-String)\n'
             printf '}\n'
             printf '%s\n' "$ps_marker_end"
           } >> "$ps_profile"

--- a/tests/test_justfile_windows_subset.py
+++ b/tests/test_justfile_windows_subset.py
@@ -340,7 +340,7 @@ def test_deploy_windows_writes_powershell_mise_activate(
         "deploy windows branch must include the mise-activate begin marker "
         "so the block can be detected for idempotency and removed by clean"
     )
-    assert "Invoke-Expression (&mise activate pwsh)" in win, (
+    assert "Invoke-Expression (&mise activate pwsh | Out-String)" in win, (
         "deploy windows branch must emit the canonical mise activate line "
         "for PowerShell"
     )


### PR DESCRIPTION
## Problem

On Windows, PowerShell 7 failed at startup with:

```
At ...\Microsoft.PowerShell_profile.ps1:15 char:23
+     Invoke-Expression (&mise activate pwsh)
System.Management.Automation.ParameterBindingException: Cannot convert
'System.Object[]' to the type 'System.String' required by parameter 'Command'.
```

`&mise activate pwsh` emits **multiple lines**, which PowerShell returns as a
`string[]`. `Invoke-Expression`'s `-Command` parameter only accepts a single
`string`, so binding fails. (The sibling `starship init` block was unaffected
because it returns a single line.)

## Fix

Pipe the activation script through `Out-String` to join it into one string —
mise's documented PowerShell activation pattern:

```powershell
Invoke-Expression (&mise activate pwsh | Out-String)
```

## Changes

- **`justfile`** — the `just deploy` generator that writes the managed block into `$PROFILE`
- **`tests/test_justfile_windows_subset.py`** — contract test pinning the generated line
- **`docs/adr/0024-powershell-mise-activate-profile.md`** — ADR code block + test-contract description

All three kept in sync.

## Verification

`uvx pytest tests/test_justfile_windows_subset.py` → **15 passed**.
Manually confirmed a fresh `pwsh` session activates mise cleanly with the new line.

## Note on existing profiles

`just deploy` detects the block by its begin-marker only and does not rewrite
existing content. Already-deployed `$PROFILE`s keep the old line until the block
is removed (`just clean`) and re-deployed. My local `$PROFILE` was already
hand-patched to match, so no drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)