### PR TITLE
feat(mise): make AI CLIs/prek global and provision them on deploy

### DIFF
--- a/config/mise/config.toml
+++ b/config/mise/config.toml
@@ -23,10 +23,33 @@ gradle = "latest"
 python = "latest"
 vp = "latest"
 markdownlint-cli2 = "latest"
+# prek — pre-commit runner. Project-pinned in the repo mise.toml for
+# the devcontainer build, but declared here too so it resolves on the
+# Mac host outside the dotfiles dir (ADR 0023 is activate-only with no
+# shims PATH, so a repo-only tool is invisible elsewhere).
+prek = "latest"
 # portless (local-dev HTTPS proxy). De-orphaned from the retired
 # pnpm-global subsystem (ADR 0017): declare it here so `mise ls` shows
 # a config source instead of an untracked orphan.
 "npm:portless" = "0.13.0"
+
+# AI agent CLIs. Project-pinned in the repo mise.toml so Coder
+# workspaces boot with them ready; declared here at "latest" so they
+# also resolve globally on the Mac host (ADR 0023 activate-only: a
+# repo-only tool is only on PATH inside the dotfiles dir). The global
+# minimum_release_age="7d" quarantine below still applies, so these
+# track the newest release that is at least 7 days old. Authenticate
+# on first use (`codex login`, `claude /login`, `gemini auth`,
+# `copilot auth`, `pi auth`).
+"npm:@openai/codex" = "latest"
+"npm:@google/gemini-cli" = "latest"
+# claude-code hardlinks its native binary in a postinstall (install.cjs);
+# mise's npm backend defaults to --ignore-scripts=true, which would leave
+# the stub and break `claude` at runtime. npm_args re-enables scripts for
+# this one tool (npm honors the last --ignore-scripts flag).
+"npm:@anthropic-ai/claude-code" = { version = "latest", npm_args = "--ignore-scripts=false" }
+"npm:@github/copilot" = "latest"
+"npm:@earendil-works/pi-coding-agent" = "latest"
 
 [settings]
 # Disable asdf-style .python-version / .nvmrc auto-detection so only

--- a/justfile
+++ b/justfile
@@ -124,6 +124,16 @@ deploy:
     cp ~/dotfiles/dump/gitignore-global ~/.config/git/ignore
     mkdir -p ~/.config/mise
     ln -sf ~/dotfiles/config/mise/config.toml ~/.config/mise/config.toml
+    if command -v mise >/dev/null 2>&1; then
+        echo "==> Provisioning global mise tools (best-effort)..."
+        # cwd=/ so only the global ~/.config/mise/config.toml resolves; a
+        # HOME-level ~/mise.toml / ~/.tool-versions must NOT widen the set.
+        # Best-effort: never abort the symlink deploy on a transient network
+        # or registry failure (resolving "latest" needs an online lookup).
+        mise -C / install || echo "==> WARN: global mise tool install incomplete; re-run 'mise -C / install' (needs network for 'latest')"
+    else
+        echo "==> mise not on PATH; skipping global tool install (install mise, then run 'mise -C / install')"
+    fi
     echo "==> Installing plugins..."
     if command -v sheldon >/dev/null 2>&1; then
         sheldon lock

--- a/tests/test_just_sandbox.py
+++ b/tests/test_just_sandbox.py
@@ -296,6 +296,27 @@ SCRIPT_INSTALL_RERUN = textwrap.dedent(
 ).strip()
 
 
+# A `mise` wrapper that records every invocation and no-ops the
+# `install` subcommand. `just deploy` now provisions the host-global
+# toolchain via `mise -C / install` (cwd=/ so only the global config
+# resolves; see justfile). Without this stub the deploy sandbox tests
+# would try to install the entire global config (rust/java/AI CLIs/...)
+# inside the throwaway container. The wrapper logs argv to
+# /tmp/mise-calls.log so a test can assert the HOME-independent
+# `-C / install` wiring, and delegates every non-install call
+# (e.g. `mise x -- sheldon lock`) to the real mise at /usr/bin/mise.
+_MISE_RECORD_STUB = (
+    "mkdir -p /tmp/stubs && "
+    "printf '%s\\n' "
+    "'#!/bin/sh' "
+    "'echo \"$@\" >> /tmp/mise-calls.log' "
+    '\'for a in "$@"; do [ "$a" = install ] && exit 0; done\' '
+    "'exec /usr/bin/mise \"$@\"' "
+    "> /tmp/stubs/mise && chmod +x /tmp/stubs/mise && "
+    "export PATH=/tmp/stubs:$PATH && "
+)
+
+
 def _case_id(params):
     # Prefer the explicit human-friendly name (first param)
     if isinstance(params, (list, tuple)) and params:
@@ -338,7 +359,10 @@ def _case_id(params):
         ),
         pytest.param(
             "deploy_and_clean_link",
-            "rm -f ~/.zshrc && just deploy && test -L ~/.zshrc && readlink ~/.zshrc | grep '/root/dotfiles/.zshrc' && just clean && test ! -e ~/.zshrc",
+            # `_MISE_RECORD_STUB` no-ops `just deploy`'s `mise -C / install`
+            # so this case stays a fast symlink check (see stub comment).
+            _MISE_RECORD_STUB
+            + "rm -f ~/.zshrc && just deploy && test -L ~/.zshrc && readlink ~/.zshrc | grep '/root/dotfiles/.zshrc' && just clean && test ! -e ~/.zshrc",
             0,
             "",
             "",
@@ -347,7 +371,8 @@ def _case_id(params):
         ),
         pytest.param(
             "deploy_idempotent",
-            "rm -f ~/.zshrc && just deploy && just deploy && test -L ~/.zshrc && readlink ~/.zshrc | grep '/root/dotfiles/.zshrc' && just clean && test ! -e ~/.zshrc",
+            _MISE_RECORD_STUB
+            + "rm -f ~/.zshrc && just deploy && just deploy && test -L ~/.zshrc && readlink ~/.zshrc | grep '/root/dotfiles/.zshrc' && just clean && test ! -e ~/.zshrc",
             0,
             "",
             "",
@@ -938,6 +963,57 @@ def test_just_install_runs_mise_install(docker_image):
     )
     combined = result.stdout + result.stderr
     assert "mise install" in combined
+
+
+@pytest.mark.deploy
+def test_deploy_provisions_global_mise(docker_image):
+    """`just deploy` provisions the host-global mise toolchain.
+
+    The recipe runs `mise -C / install` (cwd=/ so only the global
+    config resolves, never a HOME-level project config). We stub
+    `mise` to record argv and no-op the install, then assert the
+    HOME-independent `-C / install` wiring fired and the symlink
+    deploy still happened.
+    """
+    result = run_in_sandbox(
+        docker_image,
+        _MISE_RECORD_STUB + "rm -f /tmp/mise-calls.log ~/.zshrc && just deploy && "
+        "grep -q -- '-C / install' /tmp/mise-calls.log && "
+        "test -L ~/.zshrc",
+    )
+    assert result.returncode == 0, (
+        f"deploy global-mise provisioning wiring failed:\n"
+        f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    )
+
+
+@pytest.mark.deploy
+def test_deploy_mise_install_is_global_scoped(docker_image):
+    """Guard the `-C /` scope choice: the deploy provisioning command
+    must resolve ONLY the global config, never a HOME-level project
+    config (`~/mise.toml` / `~/.tool-versions`).
+
+    Plant a sentinel `~/mise.toml`; from cwd=$HOME mise sees it (HOME
+    is in scope), but from cwd=/ it must not (HOME is not an ancestor
+    of /), while the global config still loads. This locks the
+    assumption behind `mise -C / install` so a future "simplification"
+    back to `-C "$HOME"` (which would leak HOME-local configs) is
+    caught.
+    """
+    result = run_in_sandbox(
+        docker_image,
+        'printf \'[tools]\\n"npm:cowsay" = "latest"\\n\' > ~/mise.toml && '
+        "mise trust ~/mise.toml >/dev/null 2>&1; "
+        # cwd=$HOME sees the planted config (sanity that planting worked):
+        'mise -C "$HOME" config 2>&1 | grep -q cowsay && '
+        # cwd=/ must NOT see it, yet must still load the global config:
+        "! mise -C / config 2>&1 | grep -q cowsay && "
+        "mise -C / config 2>&1 | grep -qw uv",
+    )
+    assert result.returncode == 0, (
+        f"global-scope guard failed:\n"
+        f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

AI エージェント CLI 群と `prek` を host 全体で使えるようにし、新規マシンが `just deploy` でそれらを provision できるようにする2つの関連変更。

### 1. AI CLI + prek を global mise config にミラー (`chore`)
`config/mise/config.toml` に `prek` と npm AI CLI (`codex` / `gemini-cli` / `claude-code` / `copilot` / `pi-coding-agent`) を `"latest"` で宣言。ADR 0023 は activate-only (no shims) なので、repo `mise.toml` だけに pin されたツール (devcontainer / Coder workspace 用、ADR 0006) は dotfiles ディレクトリ外の host では PATH に出ない。`claude-code` は `npm_args="--ignore-scripts=false"` を維持し native-binary postinstall を走らせる。

### 2. `just deploy` で global toolchain を provision (`feat`)
`just deploy` が global config を symlink した直後に `mise -C / install` を実行する。

- **`-C /` (cwd=/)** は global `~/.config/mise/config.toml` だけを解決する。HOME-level の `~/mise.toml` / `~/.tool-versions` は set を広げられない (HOME は `/` の祖先でない) = **運用前提でなく構造的に enforced**。
- **Best-effort**: 一過性の network / registry 失敗時は symlink deploy を中断せず `WARN` + remedy を出す (deploy は routine refresh 兼用で、`"latest"` 解決は online lookup が要る)。

## Why
新規マシン / `$HOME` で開いた新 terminal では repo-only ツールが PATH に無かった。本変更で host-global 化し、`just deploy` 一発で provision できるようにする。

## 変更しないもの
repo `mise.toml` は意図的に未変更。二層は設計上 parallel (ADR 0006): repo `mise.toml` = devcontainer/Coder workspace 用に焼く pinned 版、global config = host の "latest"。pin は `tests/test_mise_pin_consistency.py` が今も強制しており、除去できるものは無い。

## Tests
- `just ci` green (ruff / shellcheck / markdownlint / meta-semgrep / `semgrep --test` 27/27 / tofu test)。
- Full sandbox suite green: `90 passed`。
- 新規 deploy カバレッジ:
  - `test_deploy_provisions_global_mise` — deploy で `-C / install` wiring が発火することを assert (recording `mise` stub が install を no-op 化)。
  - `test_deploy_mise_install_is_global_scoped` — `-C /` が植えた `~/mise.toml` を除外しつつ global config はロードすることを guard。
- 既存 `Deploy: basic` / `Deploy: idempotent` は stub を足して高速な symlink チェックのまま維持。

## Review
`codex` でプランを2周レビュー。`-C "$HOME"` → `-C /` への hardening (global-only を運用前提でなく enforced 化) はそのレビュー指摘由来。