### PR TITLE
chore: bump mise tool pins + OpenTofu to 7-day-cooldown latest

### DIFF
--- a/.devcontainer/features/dotfiles-tools/install.sh
+++ b/.devcontainer/features/dotfiles-tools/install.sh
@@ -89,7 +89,7 @@ apt-get update -y
 apt-get install -y --no-install-recommends mise
 
 # ---- uv (Python package manager) ------------------------------------
-UV_VERSION="0.11.14"
+UV_VERSION="0.11.17"
 case "$ARCH" in
   x86_64)  UV_TARGET="x86_64-unknown-linux-gnu" ;;
   aarch64) UV_TARGET="aarch64-unknown-linux-gnu" ;;
@@ -243,17 +243,17 @@ cat > /etc/mise/config.toml <<'EOF'
 [tools]
 just = "1.51.0"
 markdownlint-cli2 = "0.22.1"
-prek = "0.4.0"
-uv = "0.11.14"
-vp = "0.1.21"
-node = "24.15.0"
-"npm:@openai/codex" = "0.131.0"
-"npm:@google/gemini-cli" = "0.42.0"
+prek = "0.4.3"
+uv = "0.11.17"
+vp = "0.1.23"
+node = "24.16.0"
+"npm:@openai/codex" = "0.135.0"
+"npm:@google/gemini-cli" = "0.44.1"
 # npm_args re-enables postinstall (mise defaults to --ignore-scripts=true)
 # so claude-code's native binary is linked, not left as a stub. See mise.toml.
-"npm:@anthropic-ai/claude-code" = { version = "2.1.143", npm_args = "--ignore-scripts=false" }
-"npm:@github/copilot" = "1.0.48"
-"npm:@earendil-works/pi-coding-agent" = "0.75.3"
+"npm:@anthropic-ai/claude-code" = { version = "2.1.158", npm_args = "--ignore-scripts=false" }
+"npm:@github/copilot" = "1.0.56"
+"npm:@earendil-works/pi-coding-agent" = "0.78.0"
 EOF
 echo "[dotfiles-tools] pre-installing mise.toml tools at build time (MISE_DATA_DIR=/opt/mise, system config /etc/mise/config.toml)"
 (

--- a/.github/workflows/iac-test.yaml
+++ b/.github/workflows/iac-test.yaml
@@ -38,7 +38,7 @@ jobs:
 
       - uses: opentofu/setup-opentofu@847eaa4afeb791b06daa46e8eafa8b1b68d7cfb4 # v2.0.1
         with:
-          tofu_version: 1.11.6
+          tofu_version: 1.12.1
 
       - name: tofu test
         working-directory: exe/coder/templates/dotfiles-devcontainer

--- a/mise.toml
+++ b/mise.toml
@@ -7,11 +7,11 @@
 # constants in .devcontainer/features/dotfiles-tools/install.sh.
 just = "1.51.0"
 markdownlint-cli2 = "0.22.1"
-prek = "0.4.0"
-uv = "0.11.14"
+prek = "0.4.3"
+uv = "0.11.17"
 # `vp` is the mise registry alias for npm:vite-plus (NOT the
 # unrelated `vp` npm package). Pin to vite-plus's actual version.
-vp = "0.1.21"
+vp = "0.1.23"
 
 # Node runtime. The npm-backed AI CLIs below have a `#!/usr/bin/env
 # node` shebang that needs node on PATH at *runtime*, not just at
@@ -19,17 +19,17 @@ vp = "0.1.21"
 # `ghcr.io/devcontainers/features/node:1` feature in devcontainer.json
 # does install node into /usr/local/bin, but on Coder workspaces the
 # `/home/<user>:/root` volume mount can mask the symlink chain. Pin
-# node here so /opt/mise/installs/node/24.15.0/bin/node lives outside
+# node here so /opt/mise/installs/node/24.16.0/bin/node lives outside
 # the volume-mount path; mise's shim in /opt/mise/shims wins PATH
 # resolution against any bind-mount issue.
-node = "24.15.0"
+node = "24.16.0"
 
 # AI agent CLIs. Installed at build time so the Coder workspace
 # boots with them ready on PATH; operators authenticate them on
 # first use (`codex login`, `claude /login`, `gemini auth`,
 # `copilot auth`, `pi auth`). Source: 2026-05 latest stable.
-"npm:@openai/codex" = "0.131.0"
-"npm:@google/gemini-cli" = "0.42.0"
+"npm:@openai/codex" = "0.135.0"
+"npm:@google/gemini-cli" = "0.44.1"
 # claude-code ships its ~248MB native binary as per-platform npm
 # optionalDependencies that a postinstall (install.cjs) hardlinks over a
 # stub. mise's npm backend installs with --ignore-scripts=true by default,
@@ -37,9 +37,9 @@ node = "24.15.0"
 # stub — `claude` then errors at runtime with "native binary not installed".
 # npm_args re-enables scripts for this one tool (npm honors the last
 # --ignore-scripts flag, so this overrides mise's default).
-"npm:@anthropic-ai/claude-code" = { version = "2.1.143", npm_args = "--ignore-scripts=false" }
-"npm:@github/copilot" = "1.0.48"
-"npm:@earendil-works/pi-coding-agent" = "0.75.3"
+"npm:@anthropic-ai/claude-code" = { version = "2.1.158", npm_args = "--ignore-scripts=false" }
+"npm:@github/copilot" = "1.0.56"
+"npm:@earendil-works/pi-coding-agent" = "0.78.0"
 
 # `~/.npmrc` may set `min-release-age=7` (7-day quarantine, mirrors
 # uv's `exclude-newer = "7 days"`). That blocks `mise install` of


### PR DESCRIPTION
リポの 7日 cooldown 規約 (npm min-release-age=7 / uv exclude-newer=7days) に沿い、2026-05-31 以前リリースの最新 stable へ手 pin を bump。

### mise tool pins (mise.toml + install.sh heredoc 同期, ADR 0006)
- uv 0.11.14 → 0.11.17
- prek 0.4.0 → 0.4.3
- node 24.15.0 → 24.16.0 (LTS)
- @openai/codex 0.131.0 → 0.135.0
- @google/gemini-cli 0.42.0 → 0.44.1
- @anthropic-ai/claude-code 2.1.143 → **2.1.158** (2.1.159 は当日まだ7日未満で npm 隔離対象)
- @github/copilot 1.0.48 → 1.0.56
- @earendil-works/pi-coding-agent 0.75.3 → 0.78.0
- vp (vite-plus) 0.1.21 → 0.1.23
- just / markdownlint-cli2 / sheldon: 既に cooldown 内最新で据置

### CI
- OpenTofu CLI 1.11.6 → 1.12.1 (iac-test.yaml)

### 検証
- `tests/test_mise_pin_consistency.py` 8 passed
- `tofu test` (Coder template) 6 passed @ OpenTofu 1.12.1
- prek pre-commit (ruff/shellcheck/fmt/lint) 通過