### PR TITLE
feat(mise): add cloudflare cf, resend, stripe dev CLIs

### DIFF
--- a/.devcontainer/features/dotfiles-tools/install.sh
+++ b/.devcontainer/features/dotfiles-tools/install.sh
@@ -254,6 +254,9 @@ node = "24.15.0"
 "npm:@anthropic-ai/claude-code" = { version = "2.1.143", npm_args = "--ignore-scripts=false" }
 "npm:@github/copilot" = "1.0.48"
 "npm:@earendil-works/pi-coding-agent" = "0.75.3"
+"npm:cf" = "0.0.6"
+"npm:resend-cli" = "2.3.0"
+"npm:@stripe/cli" = "0.0.1"
 EOF
 echo "[dotfiles-tools] pre-installing mise.toml tools at build time (MISE_DATA_DIR=/opt/mise, system config /etc/mise/config.toml)"
 (

--- a/config/mise/config.toml
+++ b/config/mise/config.toml
@@ -51,6 +51,16 @@ prek = "latest"
 "npm:@github/copilot" = "latest"
 "npm:@earendil-works/pi-coding-agent" = "latest"
 
+# Cloud-service dev CLIs (npm-distributed). Declared "latest" like the
+# AI CLIs above; the minimum_release_age="7d" quarantine below makes
+# that resolve to the newest release at least 7 days old. Concrete pins
+# for these live in the repo mise.toml (ADR 0006). Explicit `npm:`
+# backend avoids registry-alias ambiguity.
+#   cf -> Cloudflare CLI, resend-cli -> Resend, @stripe/cli -> Stripe
+"npm:cf" = "latest"
+"npm:resend-cli" = "latest"
+"npm:@stripe/cli" = "latest"
+
 [settings]
 # Disable asdf-style .python-version / .nvmrc auto-detection so only
 # mise.toml / .tool-versions drive tool resolution.

--- a/mise.toml
+++ b/mise.toml
@@ -41,6 +41,18 @@ node = "24.15.0"
 "npm:@github/copilot" = "1.0.48"
 "npm:@earendil-works/pi-coding-agent" = "0.75.3"
 
+# Cloud-service dev CLIs (npm-distributed). Explicit `npm:` backend to
+# avoid any mise registry-alias ambiguity. Concrete pins per ADR 0006
+# (no `latest` in this file); bump by hand like the tools above. Each
+# was the newest release at least 7 days old when pinned.
+#   cf          -> Cloudflare CLI (blog.cloudflare.com cf local explorer)
+#   resend-cli  -> Resend CLI (resend.com/docs/cli)
+#   @stripe/cli -> Stripe CLI (docs.stripe.com, npm install method;
+#                  the legacy `stripe-cli` package is deprecated)
+"npm:cf" = "0.0.6"
+"npm:resend-cli" = "2.3.0"
+"npm:@stripe/cli" = "0.0.1"
+
 # `~/.npmrc` may set `min-release-age=7` (7-day quarantine, mirrors
 # uv's `exclude-newer = "7 days"`). That blocks `mise install` of
 # brand-new npm-backed tools (e.g. vp). Override only for mise-driven


### PR DESCRIPTION
npm 配布の cloud-service CLI を 3本 toolchain に追加 (依頼: cf local explorer / resend-cli / stripe npm install)。各々 7日以上経過の最新版を採用。

| tool | pin | 出典 |
|---|---|---|
| `npm:cf` | 0.0.6 | Cloudflare CLI (blog.cloudflare.com cf local explorer) |
| `npm:resend-cli` | 2.3.0 | resend.com/docs/cli |
| `npm:@stripe/cli` | 0.0.1 | docs.stripe.com npm method (旧 `stripe-cli` は deprecated → `@stripe/cli`) |

- repo `mise.toml`: 具体 pin (ADR 0006 が `latest` 禁止)。`.devcontainer/.../install.sh` の `/etc/mise/config.toml` heredoc にも同期 (`test_system_mise_config_matches_workspace_mise_toml` が全ツール一致を強制)
- global `config/mise/config.toml`: AI CLI と同様 `latest` 宣言 (minimum_release_age=7d が cooldown 解決)
- 明示 `npm:` backend で mise registry-alias 曖昧さ回避

### 検証
- `mise install` で 3本とも導入確認 (7日隔離通過)
- `tests/test_mise_pin_consistency.py` 8 passed