### PR TITLE
chore: bump telemetry + emulator Docker dev-stack (cross-major, smoke-tested)

### DIFF
--- a/emulator/compose.yaml
+++ b/emulator/compose.yaml
@@ -235,7 +235,7 @@ services:
 
   # MLflow Tracking Server + UI
   mlflow:
-    image: ghcr.io/mlflow/mlflow:v3.5.1
+    image: ghcr.io/mlflow/mlflow:v3.12.0
     container_name: mlflow-server
     profiles:
       - ml
@@ -339,7 +339,7 @@ services:
       - cli  # Only run when explicitly requested
   # Elasticsearch
   elasticsearch:
-    image: elasticsearch:9.3.0
+    image: elasticsearch:9.4.2
     container_name: elasticsearch-emulator
     profiles:
       - search

--- a/emulator/firebase/Dockerfile
+++ b/emulator/firebase/Dockerfile
@@ -1,14 +1,18 @@
-FROM node:24-slim
+FROM node:24-trixie-slim
 
-# Install Java and other dependencies (required for Firebase emulators)
-RUN apt-get update && apt-get install -y \
-    openjdk-17-jre-headless \
+# Install Java and other dependencies (required for Firebase emulators).
+# firebase-tools >=14 requires a JDK >= 21. node:24-trixie-slim is Debian
+# 13 (trixie), whose main repo ships openjdk-21 directly -- Debian 12
+# (bookworm) only has openjdk-17 and bookworm-backports carries no
+# openjdk-21, so the trixie base avoids any extra apt source.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    openjdk-21-jre-headless \
     curl \
     netcat-openbsd \
     && rm -rf /var/lib/apt/lists/*
 
 # Install Firebase CLI with specific version for stability
-RUN npm install -g firebase-tools@13.0.2 && \
+RUN npm install -g firebase-tools@15.19.0 && \
     firebase --version
 
 WORKDIR /firebase
@@ -30,5 +34,7 @@ EXPOSE 9099 8080 9399 9199 9299 9499 4000
 HEALTHCHECK --interval=30s --timeout=10s --start-period=60s --retries=3 \
   CMD curl -f http://localhost:4000 || exit 1
 
-# Default command (can be overridden by docker-compose)
-CMD ["firebase", "emulators:start", "--host", "0.0.0.0"]
+# Default command (can be overridden by docker-compose). firebase-tools
+# 15 removed the `--host` flag; the emulator host binding (0.0.0.0) now
+# comes from firebase.json's per-emulator `host` fields.
+CMD ["firebase", "emulators:start"]

--- a/telemetry/compose.yaml
+++ b/telemetry/compose.yaml
@@ -1,7 +1,7 @@
 services:
   # OpenTelemetry Collector
   otel-collector:
-    image: otel/opentelemetry-collector-contrib:0.144.0
+    image: otel/opentelemetry-collector-contrib:0.153.0
     command: ["--config=/etc/otel-collector-config.yaml"]
     volumes:
       - ./config/otel/otel-collector-config.yaml:/etc/otel-collector-config.yaml
@@ -16,20 +16,14 @@ services:
       - tempo
       - prometheus
 
-  # Tempo init service (handles volume permissions)
-  tempo-init:
-    image: grafana/tempo:2.9.0
-    user: root
-    entrypoint:
-      - "chown"
-      - "10001:10001"
-      - "/var/tempo"
-    volumes:
-      - tempo-data:/var/tempo
-
-  # Tempo for traces
+  # Tempo for traces. Tempo 3.0's image is distroless (no shell/chown),
+  # and 3.0 provisions its own data dir on a fresh named volume as uid
+  # 10001, so the previous `tempo-init` chown sidecar is both impossible
+  # and unnecessary — removed. Migration note: a root-owned `tempo-data`
+  # volume left over from Tempo 2.x must be recreated
+  # (`docker volume rm telemetry_tempo-data`) before the first 3.0 start.
   tempo:
-    image: grafana/tempo:2.9.0
+    image: grafana/tempo:3.0.0
     command: [ "-config.file=/etc/tempo.yaml" ]
     volumes:
       - ./config/tempo/tempo-config.yaml:/etc/tempo.yaml
@@ -37,13 +31,10 @@ services:
     ports:
       - "127.0.0.1:3200:3200"   # tempo
       - "127.0.0.1:14268:14268" # jaeger ingest
-    depends_on:
-      tempo-init:
-        condition: service_completed_successfully
 
   # Prometheus for metrics
   prometheus:
-    image: prom/prometheus:v3.9.1
+    image: prom/prometheus:v3.12.0
     command:
       - '--config.file=/etc/prometheus/prometheus.yml'
       - '--storage.tsdb.path=/prometheus'
@@ -59,7 +50,7 @@ services:
 
   # Loki for logs (uses /tmp/loki internally, no external volume needed)
   loki:
-    image: grafana/loki:3.5.0
+    image: grafana/loki:3.7.2
     command: -config.file=/etc/loki/loki-config.yaml
     volumes:
       - ./config/loki/loki-config.yaml:/etc/loki/loki-config.yaml
@@ -68,7 +59,7 @@ services:
 
   # Grafana
   grafana:
-    image: grafana/grafana:12.3.1
+    image: grafana/grafana:13.0.1
     environment:
       - GF_SECURITY_ADMIN_USER=admin
       - GF_SECURITY_ADMIN_PASSWORD=admin

--- a/telemetry/config/otel/otel-collector-config.yaml
+++ b/telemetry/config/otel/otel-collector-config.yaml
@@ -45,9 +45,14 @@ processors:
   batch:
 
 extensions:
+  # Collector >=0.110 defaults extension endpoints to localhost (security
+  # hardening). compose.yaml maps 13133/55679 to the host, so bind these
+  # to 0.0.0.0 explicitly to keep them reachable from the host as before.
   health_check:
+    endpoint: 0.0.0.0:13133
   pprof:
   zpages:
+    endpoint: 0.0.0.0:55679
 
 service:
   extensions: [health_check, pprof, zpages]

--- a/telemetry/config/tempo/tempo-config.yaml
+++ b/telemetry/config/tempo/tempo-config.yaml
@@ -10,13 +10,11 @@ distributor:
         http:
           endpoint: 0.0.0.0:4318
 
-ingester:
-  max_block_duration: 5m
-
-compactor:
-  compaction:
-    block_retention: 48h
-
+# Tempo 3.0 (monolithic) removed the top-level `ingester:` and
+# `compactor:` blocks; the built-in live-store now handles block
+# building/flushing and retention. The previous tuning
+# (ingester.max_block_duration=5m, compactor block_retention=48h) maps
+# to live-store defaults, which are fine for this local dev stack.
 storage:
   trace:
     backend: local


### PR DESCRIPTION
`telemetry/` + `emulator/` の dev-stack image を 7日 cooldown 内最新へ (cross-major 承認済)。CI 自動テスト対象外なので全て手動 smoke 済み。

### telemetry (`just tel-up` で5サービス全 healthy: HTTP 200)
- otel-collector-contrib 0.144.0 → 0.153.0
- **tempo 2.9.0 → 3.0.0** (major)
- prometheus v3.9.1 → v3.12.0
- loki 3.5.0 → 3.7.2
- **grafana 12.3.1 → 13.0.1** (major)

**Tempo 3.0 migration** (commit 参照):
- config: top-level `ingester:`/`compactor:` 削除 (3.0 monolithic は live-store が内部処理)
- compose: `tempo-init` chown sidecar 撤去 (3.0 は distroless で chown 不可、fresh volume を uid 10001 で自前 provision)。⚠️ 既存 root-owned `tempo-data` volume は要 recreate
- otel 0.153: health_check/zpages endpoint を 0.0.0.0 明示 (>=0.110 は localhost 既定で host mapping が死ぬ)

### emulator
- mlflow v3.5.1 → v3.12.0 (smoke: /health 200)
- elasticsearch 9.3.0 → 9.4.2 (smoke: :9200 200)
- **firebase-tools 13.0.2 → 15.19.0** (build smoke: container healthy, "All emulators ready")
  - base node:24-slim(bookworm) → **node:24-trixie-slim** (firebase-tools>=14 は JDK21 必須、bookworm main/backports に openjdk-21 無し → trixie main から導入。Temurin 外部 repo 不要)
  - CMD から削除済み `--host` を除去 (firebase.json が per-emulator host:0.0.0.0 を設定済み)
  - eventarc init 失敗は v13 でも起きる既存事象 (回帰なし)

### 検証
- `just ci` (meta-semgrep 0 / semgrep --test 27/27 / portless in sync / tofu test 6) 通過
- 全 image registry tag 存在確認 + 起動/health smoke