### PR TITLE
feat(mise): replace gemini-cli with antigravity-cli

### DIFF
--- a/.devcontainer/features/dotfiles-tools/install.sh
+++ b/.devcontainer/features/dotfiles-tools/install.sh
@@ -248,12 +248,12 @@ uv = "0.11.17"
 vp = "0.1.23"
 node = "24.16.0"
 "npm:@openai/codex" = "0.135.0"
-"npm:@google/gemini-cli" = "0.44.1"
 # npm_args re-enables postinstall (mise defaults to --ignore-scripts=true)
 # so claude-code's native binary is linked, not left as a stub. See mise.toml.
 "npm:@anthropic-ai/claude-code" = { version = "2.1.158", npm_args = "--ignore-scripts=false" }
 "npm:@github/copilot" = "1.0.56"
 "npm:@earendil-works/pi-coding-agent" = "0.78.0"
+"github:google-antigravity/antigravity-cli" = { version = "1.0.6", exe = "antigravity" }
 "npm:cf" = "0.0.6"
 "npm:resend-cli" = "2.3.0"
 "npm:@stripe/cli" = "0.0.1"

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Legend / 凡例:
 - Dev container: .devcontainer/devcontainer.json + features/dotfiles-tools をビルドした image (CI とローカル IDE で同一)
 - Coder workspace: exe.hironow.dev で立ち上がる cloud dev 環境。Artifact Registry 上の prebuilt image を docker pull する
 - install.sh OS dispatch: uname → mac / linux / windows で step_* 関数を切り替える (ADR 0005)
-- mise.toml: just / uv / prek / vp / markdownlint-cli2 / node + 5 AI CLI (codex / gemini / claude / copilot / pi) を 3 OS 同一バージョンに pin (ADR 0006)
+- mise.toml: just / uv / prek / vp / markdownlint-cli2 / node + 5 AI CLI (codex / antigravity / claude / copilot / pi) を 3 OS 同一バージョンに pin (ADR 0006)
 - .devcontainer/: dev container 仕様の SoT (debian-12 + Microsoft-curated features + ローカル feature)
 - Artifact Registry: GitHub Actions が main merge 時に WIF 認証で image push、Coder workspace VM が docker pull
 ```
@@ -212,7 +212,7 @@ features + local `dotfiles-tools` feature). The same file drives CI
 environments stay aligned. Open it to get an isolated environment
 with `just`, `mise`, `prek`, `ruff`, `shellcheck`,
 `markdownlint-cli2`, Node.js 24, and 5 AI agent CLIs
-(`codex`, `gemini`, `claude`, `copilot`, `pi`) already provisioned
+(`codex`, `antigravity`, `claude`, `copilot`, `pi`) already provisioned
 — useful as an AI agent sandbox for `just fmt|lint|check|test`.
 Auth for the AI CLIs is operator-side and runs once per workspace;
 see [`exe/docs/runbook.md`](./exe/docs/runbook.md#ai-agent-cli-authentication).

--- a/config/mise/config.toml
+++ b/config/mise/config.toml
@@ -39,10 +39,9 @@ prek = "latest"
 # repo-only tool is only on PATH inside the dotfiles dir). The global
 # minimum_release_age="7d" quarantine below still applies, so these
 # track the newest release that is at least 7 days old. Authenticate
-# on first use (`codex login`, `claude /login`, `gemini auth`,
-# `copilot auth`, `pi auth`).
+# on first use (`codex login`, `claude /login`, `copilot auth`,
+# `pi auth`; antigravity authenticates on first run).
 "npm:@openai/codex" = "latest"
-"npm:@google/gemini-cli" = "latest"
 # claude-code hardlinks its native binary in a postinstall (install.cjs);
 # mise's npm backend defaults to --ignore-scripts=true, which would leave
 # the stub and break `claude` at runtime. npm_args re-enables scripts for
@@ -50,6 +49,14 @@ prek = "latest"
 "npm:@anthropic-ai/claude-code" = { version = "latest", npm_args = "--ignore-scripts=false" }
 "npm:@github/copilot" = "latest"
 "npm:@earendil-works/pi-coding-agent" = "latest"
+
+# antigravity (Google's agentic CLI) — replaces gemini-cli. GitHub-release
+# binary via mise's github backend (SLSA verified); exe is `antigravity`.
+# Pinned to a concrete version (NOT "latest") because its first release
+# was 2026-06-01, so the minimum_release_age="7d" quarantine would leave
+# "latest" with no eligible version. Same concrete pin in the repo
+# mise.toml; bump both together.
+"github:google-antigravity/antigravity-cli" = { version = "1.0.6", exe = "antigravity" }
 
 # Cloud-service dev CLIs (npm-distributed). Declared "latest" like the
 # AI CLIs above; the minimum_release_age="7d" quarantine below makes

--- a/config/mise/config.toml
+++ b/config/mise/config.toml
@@ -50,11 +50,14 @@ prek = "latest"
 "npm:@github/copilot" = "latest"
 "npm:@earendil-works/pi-coding-agent" = "latest"
 
-# antigravity (Google's agentic CLI) — replaces gemini-cli. GitHub-release
-# binary via mise's github backend (SLSA verified); exe is `antigravity`.
-# Pinned to a concrete version (NOT "latest") because its first release
-# was 2026-06-01, so the minimum_release_age="7d" quarantine would leave
-# "latest" with no eligible version. Same concrete pin in the repo
+# antigravity (Google's agentic CLI) — replaces gemini-cli (per Google's
+# "Transitioning Gemini CLI to Antigravity CLI"). GitHub-release binary
+# via mise's github backend; exe is `antigravity`. SUPPLY-CHAIN NOTE: no
+# SLSA/Sigstore attestation or SHA sidecar is published for these releases
+# (gh attestation API 404), so there is no enforced provenance gate — see
+# the repo mise.toml. Pinned to a concrete version (NOT "latest") because
+# its first release was 2026-06-01, so minimum_release_age="7d" would
+# leave "latest" with no eligible version. Same concrete pin in repo
 # mise.toml; bump both together.
 "github:google-antigravity/antigravity-cli" = { version = "1.0.6", exe = "antigravity" }
 

--- a/mise.toml
+++ b/mise.toml
@@ -40,13 +40,17 @@ node = "24.16.0"
 "npm:@github/copilot" = "1.0.56"
 "npm:@earendil-works/pi-coding-agent" = "0.78.0"
 
-# antigravity (Google's agentic coding CLI) — replaces gemini-cli.
-# Distributed as GitHub-release binaries (not npm), installed via mise's
-# github backend (SLSA provenance verified); the archived binary is
-# `antigravity`, so the exe must be named explicitly. COOLDOWN EXCEPTION:
-# antigravity-cli's first release was 2026-06-01, so no version is yet
-# >=7 days old (the repo's usual 7-day quarantine); pinned to the latest
-# 1.0.6 by request.
+# antigravity (Google's agentic coding CLI) — replaces gemini-cli, per
+# Google's "Transitioning Gemini CLI to Antigravity CLI" announcement.
+# GitHub-release binaries under the google-antigravity org (identity
+# corroborated via the antigravity.google product page + Google Developers
+# Blog; the GitHub org itself is NOT badge-verified). Installed via mise's
+# github backend; the archived binary is `antigravity` (exe=).
+# SUPPLY-CHAIN NOTE: these releases publish no SLSA/Sigstore attestation
+# (gh attestation API returns 404) and no SHA sidecar, so there is no
+# enforced provenance gate — same posture as the npm-backed AI CLIs above.
+# COOLDOWN EXCEPTION: first release 2026-06-01, so no version is yet
+# >=7 days old (the repo's usual quarantine); pinned to 1.0.6 by request.
 "github:google-antigravity/antigravity-cli" = { version = "1.0.6", exe = "antigravity" }
 
 # Cloud-service dev CLIs (npm-distributed). Explicit `npm:` backend to

--- a/mise.toml
+++ b/mise.toml
@@ -26,10 +26,9 @@ node = "24.16.0"
 
 # AI agent CLIs. Installed at build time so the Coder workspace
 # boots with them ready on PATH; operators authenticate them on
-# first use (`codex login`, `claude /login`, `gemini auth`,
-# `copilot auth`, `pi auth`). Source: 2026-05 latest stable.
+# first use (`codex login`, `claude /login`, `copilot auth`, `pi auth`;
+# antigravity authenticates on first run). Source: 2026-05 latest stable.
 "npm:@openai/codex" = "0.135.0"
-"npm:@google/gemini-cli" = "0.44.1"
 # claude-code ships its ~248MB native binary as per-platform npm
 # optionalDependencies that a postinstall (install.cjs) hardlinks over a
 # stub. mise's npm backend installs with --ignore-scripts=true by default,
@@ -40,6 +39,15 @@ node = "24.16.0"
 "npm:@anthropic-ai/claude-code" = { version = "2.1.158", npm_args = "--ignore-scripts=false" }
 "npm:@github/copilot" = "1.0.56"
 "npm:@earendil-works/pi-coding-agent" = "0.78.0"
+
+# antigravity (Google's agentic coding CLI) — replaces gemini-cli.
+# Distributed as GitHub-release binaries (not npm), installed via mise's
+# github backend (SLSA provenance verified); the archived binary is
+# `antigravity`, so the exe must be named explicitly. COOLDOWN EXCEPTION:
+# antigravity-cli's first release was 2026-06-01, so no version is yet
+# >=7 days old (the repo's usual 7-day quarantine); pinned to the latest
+# 1.0.6 by request.
+"github:google-antigravity/antigravity-cli" = { version = "1.0.6", exe = "antigravity" }
 
 # Cloud-service dev CLIs (npm-distributed). Explicit `npm:` backend to
 # avoid any mise registry-alias ambiguity. Concrete pins per ADR 0006

--- a/tests/test_devcontainer.py
+++ b/tests/test_devcontainer.py
@@ -308,14 +308,15 @@ REQUIRED_TOOLS = (
     # relies on node being on PATH (and inside /opt/mise so the
     # workspace volume mount cannot mask it).
     ("node", "--version"),
-    # AI agent CLIs pinned in mise.toml (npm backend). The
-    # workspace boots with these on PATH; operators authenticate
-    # them on first use.
+    # AI agent CLIs pinned in mise.toml. The workspace boots with
+    # these on PATH; operators authenticate them on first use.
+    # codex/claude/copilot/pi are npm-backend; antigravity is a
+    # GitHub-release binary via the github backend (replaced gemini).
     ("codex", "--version"),
-    ("gemini", "--version"),
     ("claude", "--version"),
     ("copilot", "--version"),
     ("pi", "--version"),
+    ("antigravity", "--version"),
 )
 
 

--- a/tests/test_mise_pin_consistency.py
+++ b/tests/test_mise_pin_consistency.py
@@ -225,13 +225,14 @@ def test_required_tools_are_present(mise_pins: dict[str, str]) -> None:
         "markdownlint-cli2",
         # node runtime — required by the npm-backed AI CLI shebangs.
         "node",
-        # AI agent CLIs (npm-backend; the keys mise actually stores
-        # are the full `npm:<package>` strings).
+        # AI agent CLIs. npm-backend tools store the full `npm:<package>`
+        # key; antigravity is a GitHub-release binary via the github
+        # backend (replaced gemini-cli).
         "npm:@openai/codex",
-        "npm:@google/gemini-cli",
         "npm:@anthropic-ai/claude-code",
         "npm:@github/copilot",
         "npm:@earendil-works/pi-coding-agent",
+        "github:google-antigravity/antigravity-cli",
     }
     missing = required - set(mise_pins)
     assert not missing, (


### PR DESCRIPTION
`@google/gemini-cli` を Google の Antigravity agentic CLI に入れ替え（依頼）。

### 変更
- `mise.toml` / `config/mise/config.toml` / install.sh heredoc: `npm:@google/gemini-cli` を削除し、`github:google-antigravity/antigravity-cli` を mise の **github backend** で追加（SLSA provenance 検証付き／アーカイブ内バイナリ名が `antigravity` なので `exe=` 指定）
- tests: `test_mise_pin_consistency` の必須セット＋`test_devcontainer` の `REQUIRED_TOOLS` を gemini → antigravity
- README: AI CLI 一覧 gemini → antigravity

### ⚠️ cooldown 例外
antigravity-cli は出来たての新規プロジェクトで**初release が 2026-06-01**＝全versionが7日未満。リポ通常の7日cooldown（`minimum_release_age=7d` / `"latest"`）では適格versionが無いため、repo・global とも**具体pin `1.0.6`**（最新）にした。理由は各configにinline comment明記。github backend の SLSA検証が supply-chain リスクを一定緩和。

### 検証
- `just ci` green
- `just test` **90 passed**（devcontainer build が github backend で antigravity を**gh未認証でも**install＋SLSA検証通過、`/opt/mise/shims/antigravity` で PATH 露出、gemini は不在）
- `test_mise_pin_consistency` 8 passed