### PR TITLE
chore(emulator): make uv 7-day cooldown repo-authoritative (keep P7D)

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -9,12 +9,15 @@
 # fast. This mirrors the repo's uv `exclude-newer = "7 days"` / npm
 # `min-release-age=7` quarantine.
 #
-# NOTE on the uv ecosystem (emulator/): uv.lock pins `exclude-newer-span = P7D`.
-# A Dependabot uv PR regenerates the lock under that 7-day span, so a brand-new
-# release (<7 days) won't resolve. For a security fix that needs a fresh version,
-# bump it with `uv lock --upgrade-package <pkg> --exclude-newer <now>` and
-# restore the `exclude-newer-span = "P7D"` line in the same change (see PR #149,
-# aiohttp 3.14.0 / starlette 1.2.1).
+# NOTE on the uv ecosystem: the 7-day cooldown is set authoritatively in the uv
+# project's pyproject.toml (`[tool.uv] exclude-newer = "7 days"`, e.g.
+# emulator/pyproject.toml), NOT just in a personal global uv config. That way
+# Dependabot's uv updater reads it, reproduces `exclude-newer-span = "P7D"` in
+# uv.lock (instead of silently dropping it), and only proposes releases >=7 days
+# old. A security fix that needs a fresher release overrides once with
+# `uv lock --upgrade-package <pkg> --exclude-newer "$(date -u +%FT%TZ)"`; a later
+# conservative `uv lock` keeps the already-pinned version (see PR #149: aiohttp
+# 3.14.0 / starlette 1.2.1).
 #
 # Ecosystems in this repo:
 #   github-actions -> .github/workflows/*.yaml (SHA-pinned actions)

--- a/emulator/pyproject.toml
+++ b/emulator/pyproject.toml
@@ -32,3 +32,15 @@ markers = [
 timeout = 180
 # Timeout method: 'thread' is more compatible with async tests
 timeout_method = "thread"
+
+[tool.uv]
+# Supply-chain quarantine: only resolve distributions that have been public for
+# at least 7 days. This is repo-authoritative (not just a personal global uv
+# config), so EVERY `uv lock` -- local, CI, and Dependabot's uv updater --
+# reproduces `exclude-newer-span = "P7D"` in uv.lock instead of silently
+# dropping it. Mirrors the npm `min-release-age=7` quarantine. uv serializes the
+# relative "7 days" value to the lock's `exclude-newer-span = "P7D"`.
+# Security fixes that need a <7-day-old release override this once with
+# `uv lock --upgrade-package <pkg> --exclude-newer "$(date -u +%FT%TZ)"`; a plain
+# `uv lock` afterwards is conservative and keeps the already-locked version.
+exclude-newer = "7 days"


### PR DESCRIPTION
## 問題
emulator/uv.lock の `exclude-newer-span = "P7D"`（7日 supply-chain cooldown）は **個人の global uv 設定**（`~/.config/uv/uv.toml` の `exclude-newer = "7 days"`）由来だった。Dependabot の uv updater は global 設定を持たないため、lock 再生成時に **span を黙って落とす**（PR #151 で発覚）。

## 修正
`emulator/pyproject.toml` に `[tool.uv] exclude-newer = "7 days"` を追加して **repo-authoritative** に。これで local / CI / **Dependabot** の全 `uv lock` が pyproject を読んで `exclude-newer-span = "P7D"` を再生成し、Dependabot は **7日以上経過版のみ**提案するようになる。

## 検証
global を隔離（`XDG_CONFIG_HOME` を空に＝Dependabot/CI 相当）して `uv lock`:
- **span=P7D を維持** ✓
- 既存の **aiohttp 3.14.0 / starlette 1.2.1**(security pin) も温存（保守的lockは既存版をdowngradeしない）✓
- `uv sync --all-extras --frozen` / `uv lock --check` とも現lockに対して pass（lock無変更）
- `just ci` pass

## 補足
- `emulator/uv.lock` は無変更（設定のみ追加）
- tools/rttm/uv.lock は現状 span 無し、root は deps 空。希望あれば同 `[tool.uv]` 設定を別途展開