### PR TITLE
docs(wow): add fact-checked Next '26 streaming reference notes

### DIFF
--- a/docs/wow/01-pubsub-ai-inference-smt/README.md
+++ b/docs/wow/01-pubsub-ai-inference-smt/README.md
@@ -1,0 +1,195 @@
+# Pub/Sub AI Inference SMT（GA）
+
+Pub/Sub のメッセージが流れる途中で、**外部サービスを挟まずに直接モデル推論を呼び、結果を
+メッセージに付与する** 機能。SMT = Single Message Transform（単一メッセージ変換）。
+
+- Launch stage: **GA（一般提供）**
+- 公式: <https://docs.cloud.google.com/pubsub/docs/smts/ai-inference-smt>
+- SMT 全体像: <https://docs.cloud.google.com/pubsub/docs/smts/smts-overview>
+
+## ファクトチェック
+
+- 記事の「Pub/Sub ストリーミング内での直接モデル呼び出し」「Gemini Enterprise Agent
+  Platform 対応」「NLP / 不正検知 / セマンティック検索」は **公式の use case と一致**（公式は
+  real-time enrichment / simplified AI pipelines / reduced latency / enhanced flow control を挙げる）。
+- 記事の **GA 表記は正しい**（公式ブログ "Streaming AI news from Next '26" で GA と明記）。
+- 「Gemini Enterprise Agent Platform」は **Vertex AI のリブランド**。IAM ロール・API は
+  旧称（`Vertex AI ...` / `aiplatform.*`）のままなので注意。
+
+## SMT は 2 種類ある
+
+| 種類 | 用途 | 公式 |
+|---|---|---|
+| **AI Inference** | Agent Platform のモデルに推論させ、結果をメッセージへ付与 | [ai-inference-smt](https://docs.cloud.google.com/pubsub/docs/smts/ai-inference-smt) |
+| **JavaScript UDF** | 任意の JS 関数で変換 / フィルタ（`null` を返すと drop） | [udfs-overview](https://docs.cloud.google.com/pubsub/docs/smts/udfs-overview) |
+
+両者は **チェーン可能**。典型は「UDF でモデル入力形式に整形 → AI Inference → UDF で後処理」。
+
+## Topic SMT と Subscription SMT
+
+- **Topic SMT**: Pub/Sub が保存する **前** に実行。結果は **全 subscriber で共有**。
+- **Subscription SMT**: 配信 **直前** に実行。結果は **その subscription のみ**。
+
+```text
+Topic SMT  (runs once before storage; result shared by ALL subscribers)
+
+  publisher --> [ Topic + SMT ] --> stored --> sub A --> subscriber A
+                                       |
+                                       +-------> sub B --> subscriber B
+
+Subscription SMT  (runs per subscription, just before delivery)
+
+  publisher --> [ Topic ] --> sub A + SMT  --> subscriber A
+                    |
+                    +--------> sub B (no SMT) --> subscriber B
+```
+
+Legend / 凡例:
+
+- Topic SMT: トピック側変換（保存前に 1 回、全 subscriber が共有）
+- Subscription SMT: サブスクリプション側変換（配信直前、その sub だけに適用）
+- stored: Pub/Sub 内部ストレージへ保存
+- sub: subscription（購読）
+- subscriber: 購読アプリ
+
+## 実装：最小手順（gcloud）
+
+### 1. 変換定義ファイル（YAML）
+
+```yaml
+# ai-smt.yaml
+- aiInference:
+    endpoint: projects/PROJECT_ID/locations/LOCATION/publishers/google/models/gemini-2.5-flash
+    unstructuredInference: {
+        parameters: {
+            "max_tokens": 25000
+        }
+    }
+```
+
+- `endpoint` の形式:
+    - Model Garden（MaaS）モデル:
+      `projects/PROJECT/locations/LOCATION/publishers/PUBLISHER/models/MODEL_NAME`
+    - 自前デプロイモデル: `projects/PROJECT/locations/LOCATION/endpoints/ENDPOINT`
+- `unstructuredInference.parameters` は各メッセージにマージされるモデルパラメータ（任意）。
+- `service_account_email` も指定可（任意。未指定なら Pub/Sub service agent を使用）。
+
+### 2. topic / subscription を作成して試す
+
+```bash
+# topic を作成
+gcloud pubsub topics create TOPIC_ID
+
+# AI Inference SMT 付き subscription を作成（推論は最長 60s なので ack-deadline を伸ばす）
+gcloud pubsub subscriptions create TOPIC_ID-sub \
+  --ack-deadline=600 \
+  --topic TOPIC_ID \
+  --message-transforms-file ai-smt.yaml
+
+# Chat Completions API 形式のプロンプトを publish
+gcloud pubsub topics publish TOPIC_ID --message=$'{
+  "model":"google/gemini-2.5-flash","messages":[{
+    "role": "user",
+    "content": "Explain how AI works in a few words"
+    }]
+  }'
+
+# 推論結果が付与されたメッセージを pull
+gcloud pubsub subscriptions pull TOPIC_ID-sub
+```
+
+Topic に付ける場合は `gcloud pubsub topics create TOPIC_ID --message-transforms-file ai-smt.yaml`。
+
+## 入出力フォーマット
+
+- **入力**: メッセージ data は **モデルへ送る JSON 文字列**。SMT が `parameters` をマージして
+  送信。Pub/Sub は入力を検証しないので、形式の正しさは利用者責任。
+- **出力**: 成功すると元メッセージを次の形にラップする。
+
+```json
+{
+  "original_message": { ORIGINAL_MESSAGE },
+  "model_output": { INFERENCE_RESULT }
+}
+```
+
+## 呼び出される API（モデル種別ごと）
+
+| モデル | 呼ばれる API |
+|---|---|
+| 自前デプロイ（全種） | `rawPredict` |
+| Gemini foundational（例 `gemini-3.0-pro`） | Chat Completions API |
+| その他 Gemini（例 embeddings） | `rawPredict` |
+| Anthropic / Mistral / AI21 | `rawPredict` |
+| その他 MaaS | Chat Completions API |
+
+互換 MaaS モデルは Gemini 2.0/2.5/3 系、Claude（Sonnet/Opus/Haiku 4 系）、Llama 3.3/4、
+Mistral、DeepSeek、Qwen3、GPT-OSS、各種 embedding 等。一部（一部 embedding-2 / Veo / Lyria /
+最新 thinking 系など）は **非対応**。最新の対応・非対応表は公式ページを参照。
+
+## IAM
+
+- 操作者: `roles/pubsub.editor`（topic/subscription 作成権限）。
+- 推論呼び出し用 service account に Agent Platform エンドポイントへの権限:
+    - 権限: `aiplatform.endpoints.get` / `aiplatform.endpoints.predict`
+    - 付与ロール: Pub/Sub service agent を使うなら **Vertex AI Service Agent**、独自 SA なら
+      **Vertex AI User**。
+
+## フロー制御（記事の「不正検知」等で効く）
+
+エンドポイント過負荷を避けるため、Pub/Sub がレイテンシ・quota に応じて **リクエストレートを
+自動調整** する（unary pull API 利用時は非対応）。バックプレッシャーを自前で組まなくてよい。
+
+> **用語注意（ファクトチェック）**: 元記事の「Elastic Inference Queue」は **公式ドキュメントに
+> 該当用語がない**。製品 / 機能名ではなく、ここで説明した **フロー制御（レート自動調整）** を
+> セッションスライドで言い換えた表現とみられる。実装上「Elastic Inference Queue」という設定や
+> API は存在しないため、固有名として探さないこと。
+
+## 制約・落とし穴
+
+- 1 つの topic / subscription につき **AI Inference SMT は 1 個** まで。
+- **private endpoint 非対応**（自前モデルは public な Agent Platform endpoint に置く）。
+- **global endpoint** は Gemini foundation model のみ。他は regional endpoint 必須。
+- **クライアント側バッチングなし**（1 メッセージ = 1 推論リクエスト）。非同期バッチ推論も不可。
+- 推論は **60 秒以内**。超えると配信タイムアウト → リトライ、最終的に dead-letter topic 行き。
+  **subscription SMT を使うときは dead-letter topic の設定を推奨**。
+- 最終メッセージサイズ（元 + 推論出力）は Pub/Sub のメッセージサイズ上限内に収める必要あり。
+- **リージョン制約**: topic SMT はエンドポイントのリージョンが topic の message storage policy
+  内であること。export subscription（BigQuery / Cloud Storage）に付ける場合は宛先リソースの
+  リージョンと一致が必要。pull は locational endpoint 推奨。
+
+## エラーハンドリング
+
+- **Topic SMT のエラー**: publish 全体が失敗し、publisher にエラーが返る（バッチ内 1 件でも
+  失敗すると **バッチ全体が失敗**）。
+- **Subscription SMT のエラー**: dead-letter topic に転送可能。
+- 監視: `topic/message_transform_latencies`（status / filtered ラベル）、`topic/byte_cost`
+  （`operation_type` / `response_code`）。
+
+## 公式サンプル実装（2026-06 確認）
+
+- Python サンプル群（`pubsub_v1` クライアント。SMT は `MessageTransform` /
+  `JavaScriptUDF` 型を使う）:
+  [`GoogleCloudPlatform/python-docs-samples` → `pubsub/cloud-client`](https://github.com/GoogleCloudPlatform/python-docs-samples/tree/main/pubsub/cloud-client)
+- SMT 検証・テスト手順（topic / subscription 作成前に validate）:
+  [create-topic-smt](https://docs.cloud.google.com/pubsub/docs/smts/create-topic-smt) /
+  [create-subscription-smt](https://docs.cloud.google.com/pubsub/docs/smts/create-subscription-smt)
+- E2E デモで AI Inference SMT ではなく **UDF SMT** を payload 整形に使う実例:
+  [`devrel-demos` → `data-analytics/event_driven_agents_demo` の `setup/`](https://github.com/GoogleCloudPlatform/devrel-demos/tree/main/data-analytics/event_driven_agents_demo)
+  （詳細は [03-bigquery-continuous-queries-stateful/](../03-bigquery-continuous-queries-stateful/README.md)）
+
+## 関連リンク
+
+- AI Inference SMT: <https://docs.cloud.google.com/pubsub/docs/smts/ai-inference-smt>
+  （本ドキュメントは 2026-06 時点の公式版に基づく）
+- SMT 概要 / 発表ブログ:
+  <https://docs.cloud.google.com/pubsub/docs/smts/smts-overview> /
+  <https://cloud.google.com/blog/products/data-analytics/pub-sub-single-message-transforms>
+- topic に SMT を付ける: <https://docs.cloud.google.com/pubsub/docs/smts/create-topic-smt>
+- subscription に SMT を付ける:
+  <https://docs.cloud.google.com/pubsub/docs/smts/create-subscription-smt>
+- topic / subscription どちらに付けるか:
+  <https://docs.cloud.google.com/pubsub/docs/smts/choose-smts>
+- Pub/Sub リリースノート: <https://docs.cloud.google.com/pubsub/docs/release-notes>
+- 解説記事（Medium / Google Cloud Community）:
+  <https://medium.com/google-cloud/deep-dive-into-google-cloud-pub-sub-single-message-transforms-and-ai-inference-baa920d8103a>

--- a/docs/wow/02-pubsub-bigtable-subscriptions/README.md
+++ b/docs/wow/02-pubsub-bigtable-subscriptions/README.md
@@ -1,0 +1,164 @@
+# Pub/Sub Bigtable Subscriptions（Preview）
+
+Pub/Sub のメッセージを **subscriber クライアントを書かずに、そのまま Bigtable テーブルへ
+書き込む** export subscription の一種。記事の「カスタム ETL 不要」「サブミリ秒サービング向け」
+はこれを指す。
+
+- Launch stage: **Preview**（Pre-GA。`gcloud beta` 系コマンド）
+- 概要: <https://docs.cloud.google.com/pubsub/docs/bigtable-subscriptions>
+- 作成手順: <https://docs.cloud.google.com/pubsub/docs/create-bigtable-subscription>
+
+## ファクトチェック
+
+- 記事の「Pub/Sub から Bigtable への直接書き込み」「カスタム ETL 不要」「リアルタイム
+  サービング向け」は **公式と一致**。
+- 記事の **Preview 表記は正しい**（公式ページに Pre-GA バナーあり）。
+- 「サブミリ秒レイテンシ」は **Bigtable の読み取りサービング特性** を指した表現。書き込み
+  経路自体は at-least-once で、重複排除はしない点に注意（後述）。
+
+## 位置づけ（いつ使うか）
+
+- メッセージを **追加処理なし or 軽い SMT 変換だけ** で Bigtable に入れたい → **Bigtable
+  subscription**。
+- 複雑な変換が必要 → **Dataflow + pull subscription** を推奨（公式が明記）。
+
+> **用語注意（ファクトチェック）**: 元記事のアーキ図に出てくる「Bigtable のマテリアライズド
+> ビュー」は、この **Bigtable Subscriptions とは別の機能**。後者は raw メッセージを Bigtable に
+> 直接書き込む export subscription だが、前者は
+> [Bigtable continuous materialized views](https://docs.cloud.google.com/bigtable/docs/continuous-materialized-views)
+> という **SQL 定義の背景集約ビュー**（着信データを増分集約し、update / delete も伝播、
+> eventually consistent）である。両者とも実在するが役割が異なるので混同しないこと。
+
+## 前提条件
+
+- 書き込み先 Bigtable テーブルが **既に存在** すること。
+- テーブルに **`data` という column family が必須**。
+- メタデータも書くなら **`pubsub_metadata` column family** も用意（任意）。
+
+## 実装：エンドツーエンド例（gcloud）
+
+```bash
+# 1. Bigtable インスタンス
+gcloud bigtable instances create my-instance --display-name="My instance" \
+  --cluster-config=id=my-cluster-1,zone=ZONE,nodes=1
+
+# 2. data column family つきテーブル
+gcloud bigtable instances tables create table-1 \
+  --instance=my-instance \
+  --column-families=data
+
+# 3. topic
+gcloud pubsub topics create topic-1
+
+# 4. Bigtable subscription（Preview = beta）
+gcloud beta pubsub subscriptions create bigtable-sub \
+  --topic=topic-1 \
+  --bigtable-table=projects/PROJECT_ID/instances/my-instance/tables/table-1
+
+# 5. publish
+gcloud pubsub topics publish topic-1 --message='{"name":"Alice"}'
+```
+
+Bigtable Studio の query editor で確認:
+
+```sql
+SELECT _key, JSON_VALUE(CAST(data[''] AS STRING), '$.name') AS name FROM table-1;
+```
+
+### 主なフラグ
+
+- `--bigtable-write-metadata`: メッセージメタデータを `pubsub_metadata` family に書く。
+- `--bigtable-app-profile-id=APP_PROFILE`: 使用する app profile。**single-cluster routing
+  必須**。未指定ならデフォルト app profile。
+- `--bigtable-service-account-email`: 書き込み用 SA。未指定なら Pub/Sub service agent。
+
+## 書き込みレイアウト
+
+- **メッセージ data**: `data` family の **空文字列（`""`）column qualifier** に **`BYTES`
+  型** で 1 セル。cell timestamp = メッセージの **publish time**。
+- **row key**: `projects/PROJECT_NUMBER/subscriptions/SUBSCRIPTION_ID#SALT_PREFIX#MESSAGE_ID`
+  （subscription ID + salt prefix + message ID の連結）。salt prefix がホットスポットを散らす。
+- **メタデータ**（`--bigtable-write-metadata` 時、`pubsub_metadata` family）:
+
+| Column | 値 | 型 |
+|---|---|---|
+| `subscription_name` | subscription 名 | String |
+| `message_id` | メッセージ ID | String |
+| `attributes` | メッセージ属性の JSON | String |
+
+```text
+Bigtable table : 1 message = 1 row
+
+ row key = projects/<PROJECT_NUMBER>/subscriptions/<SUB_ID>#<SALT>#<MESSAGE_ID>
+   |
+   +-- column family "data"                +-- column family "pubsub_metadata" (optional)
+   |     qualifier ""  = <message BYTES>   |     subscription_name = <String>
+   |     cell ts       = publish time      |     message_id        = <String>
+   |                                       |     attributes        = <JSON String>
+   v                                       v
+ (always written)                        (only with --bigtable-write-metadata)
+```
+
+Legend / 凡例:
+
+- row key: 行キー（subscription ID + salt prefix + message ID の連結。salt がホットスポット分散）
+- column family "data": メッセージ本体を入れる必須ファミリ
+- qualifier "": 空文字列のカラム修飾子（ここに本体 1 セル）
+- message BYTES: 本体は BYTES 型で格納
+- cell ts: セルのタイムスタンプ（= メッセージの publish time）
+- column family "pubsub_metadata": メタデータ用ファミリ（`--bigtable-write-metadata` 指定時のみ）
+
+## SMT との併用
+
+Bigtable subscription は **SMT と組み合わせ可能**。軽い整形（PII マスク、フィールド削除、AI
+Inference によるラベル付与など）を SMT で済ませてから Bigtable に materialize できる。記事の
+「ベクトル埋め込みを Bigtable に取得してセマンティック検索」は、AI Inference SMT（embedding
+モデル）→ Bigtable subscription の組み合わせで実現できる構図。
+
+## 配信セマンティクスと失敗処理
+
+- **at-least-once**。厳密な重複排除が要るなら、Bigtable 側で downstream 重複処理を入れるか、
+  Dataflow の exactly-once 処理を使う。
+- 書き込み失敗時はメッセージを nack → 再送。一定回数失敗かつ **dead-letter topic** 設定済みなら
+  そこへ転送。DLT メッセージには失敗理由が属性
+  `CloudPubSubDeadLetterSourceDeliveryErrorMessage` で付く。
+- Pub/Sub が Bigtable に書けない間は push backoff 類似のバックオフがかかる。
+
+## IAM
+
+- Pub/Sub service agent（`service-PROJECT_NUMBER@gcp-sa-pubsub.iam.gserviceaccount.com`）に
+  **Bigtable User（`roles/bigtable.user`）** を付与（プロジェクト or インスタンス単位）。
+- よりきめ細かくするなら user-managed SA を指定（`--bigtable-service-account-email`）。その SA に
+  Bigtable User、Pub/Sub service account に `iam.serviceAccounts.getAccessToken`、作成者に
+  `iam.serviceAccounts.actAs` が必要。
+
+## 制約・落とし穴
+
+- **テーブルと `data` family は事前作成必須**（subscription が勝手に作らない）。
+- app profile は **single-cluster routing** に限定。
+- リージョン / quota: Bigtable subscriber スループットにリージョン単位の quota あり。
+- 厳密な順序保証・重複排除は提供しない（at-least-once）。
+- トラブルシュート:
+  <https://docs.cloud.google.com/pubsub/docs/troubleshoot-bigtable-subscriptions>
+
+## サンプル実装（2026-06 確認）
+
+Bigtable subscription は **subscriber コードを書かない**（gcloud / Console で完結する）のが
+売りなので、専用の「アプリ実装」サンプルは無く、公式の作成手順がそのままサンプルになる。
+パブリッシュ側や周辺操作の Python サンプルは以下。
+
+- 公式 E2E 手順（gcloud。本ドキュメントの実装例の出典）:
+  <https://docs.cloud.google.com/pubsub/docs/create-bigtable-subscription>
+- Pub/Sub Python サンプル群:
+  [`GoogleCloudPlatform/python-docs-samples` → `pubsub/cloud-client`](https://github.com/GoogleCloudPlatform/python-docs-samples/tree/main/pubsub/cloud-client)
+  / [`GoogleCloudPlatform/cloud-pubsub-samples-python`](https://github.com/GoogleCloudPlatform/cloud-pubsub-samples-python)
+- 参考（**コミュニティ・非公式**。Cloud Functions 経由の Pub/Sub→Bigtable。subscription
+  機能登場前の手法）:
+  [`krapes/pubsub_bigtable`](https://github.com/krapes/pubsub_bigtable)
+
+## 関連リンク
+
+- Bigtable subscriptions: <https://docs.cloud.google.com/pubsub/docs/bigtable-subscriptions>
+- 作成手順: <https://docs.cloud.google.com/pubsub/docs/create-bigtable-subscription>
+- subscription タイプの選び方: <https://docs.cloud.google.com/pubsub/docs/subscriber>
+- Bigtable 概要: <https://docs.cloud.google.com/bigtable/docs/overview>

--- a/docs/wow/03-bigquery-continuous-queries-stateful/README.md
+++ b/docs/wow/03-bigquery-continuous-queries-stateful/README.md
@@ -1,0 +1,220 @@
+# BigQuery Continuous Queries — Stateful Data Processing（Preview）
+
+**常駐し続ける SQL** で、BigQuery に着信したデータをリアルタイム処理し、結果を BigQuery
+テーブル / Pub/Sub / Bigtable / Spanner に書き出す。記事の目玉は、その中の **stateful 処理
+（JOIN・集約・タンブリングウィンドウ）が Preview で使えるようになった** 点。
+
+- Continuous queries 自体: 既存機能
+- **Stateful operations（JOIN / aggregations / windowing）: Preview**
+- 概要: <https://docs.cloud.google.com/bigquery/docs/continuous-queries-introduction>
+- 実装例: <https://docs.cloud.google.com/bigquery/docs/continuous-queries>
+
+## ファクトチェック
+
+- 記事の「集約関数・タンブリングウィンドウ・JOIN 処理対応」「30 分平均の計算」「異なる
+  ストリーム間のイベント相関」「AI.GENERATE_TEXT 等の生成 AI 直接統合」「Bigtable / Spanner /
+  Pub/Sub へのリバース ETL」は **すべて公式と一致**。
+- 記事の **Preview 表記は正しい**（stateful operations セクションに Pre-GA バナーあり。
+  フィードバック窓口 `bq-continuous-queries-feedback@google.com`）。
+
+## 何が "stateful" なのか
+
+- **stateless 関数**: 各行を独立処理（変換・JSON 操作・生成 AI 呼び出しなど）。
+- **stateful 操作**: 複数行 / 時間区間にまたがる状態を保持して正確な結果を出す。Preview で
+  使えるのは以下:
+    - [JOINs](https://docs.cloud.google.com/bigquery/docs/continuous-query-joins)
+      — 異なるストリームのイベントを相関
+    - [Aggregations / windowing](https://docs.cloud.google.com/bigquery/docs/window-aggregations)
+      — `TUMBLE`（タンブリングウィンドウ）で「5 分ごと」「30 分平均」等を算出
+
+```text
+stateless : 1 row in -> 1 row out (no memory across rows)
+
+  row1 -> out1     row2 -> out2     row3 -> out3
+
+stateful : TUMBLE keeps state per fixed, non-overlapping window
+
+  time -->  e1  e2       e3   e4        e5   e6 e7        e8
+          |-------------|-------------|-------------|-------------|
+          |  window 1   |  window 2   |  window 3   |  window 4   |  TUMBLE(5 min)
+          |-------------|-------------|-------------|-------------|
+                |             |             |             |
+                v             v             v             v
+             agg(w1)       agg(w2)       agg(w3)       agg(w4)       COUNT / AVG / JOIN
+```
+
+Legend / 凡例:
+
+- stateless: 各行を独立処理（行をまたぐ状態を持たない）
+- stateful: 行 / 時間区間にまたがる状態を保持する処理
+- time: 時間軸
+- e1..e8: 着信イベント（行）
+- window N: タンブリングウィンドウ（固定長・非重複の区間）
+- TUMBLE(5 min): 5 分ごとに区切る関数
+- agg(wN): そのウィンドウの集約結果（COUNT / AVG / JOIN など）
+
+## 入力データソース
+
+continuous query が処理できるのは標準 BigQuery テーブルへの着信（Storage Write API /
+`tabledata.insertAll` / batch load / `INSERT` DML / Pub/Sub BigQuery subscription /
+Dataflow → BigQuery / Datastream append-only など）。
+
+時間起点の制御には変更履歴 TVF を使う:
+
+- `APPENDS(TABLE ..., start_timestamp)` — 指定時刻以降の追加行を処理
+- `CHANGES(...)` — 追加 + 変更を処理（**stateful 操作とは併用不可**、Pub/Sub export 時のみ）
+
+## 実装例
+
+### 例 1: フィルタ + 変換して別テーブルへ（stateless）
+
+```sql
+INSERT INTO `myproject.real_time_taxi_streaming.transformed_taxirides`
+SELECT
+  timestamp, meter_reading, ride_status, passenger_count,
+  ST_Distance(
+    ST_GeogPoint(pickup_longitude, pickup_latitude),
+    ST_GeogPoint(dropoff_longitude, dropoff_latitude)) AS euclidean_trip_distance,
+  SAFE_DIVIDE(meter_reading, passenger_count) AS cost_per_passenger
+FROM APPENDS(
+  TABLE `myproject.real_time_taxi_streaming.taxirides`,
+  CURRENT_TIMESTAMP() - INTERVAL 10 MINUTE)
+WHERE ride_status = 'dropoff';
+```
+
+### 例 2: 生成 AI を呼んで Pub/Sub へ export（リアルタイム生成）
+
+```sql
+EXPORT DATA OPTIONS (
+  format = 'CLOUD_PUBSUB',
+  uri = 'https://pubsub.googleapis.com/projects/myproject/topics/taxi-real-time-rides') AS (
+  SELECT
+    TO_JSON_STRING(STRUCT(ride_id, timestamp, latitude, longitude, prompt, result)) AS message
+  FROM AI.GENERATE_TEXT(
+    MODEL `myproject.real_time_taxi_streaming.taxi_ml_generate_model`,
+    (
+      SELECT timestamp, ride_id, latitude, longitude,
+        CONCAT('Generate an ad based on the current latitude of ',
+               latitude, ' and longitude of ', longitude) AS prompt
+      FROM APPENDS(
+        TABLE `myproject.real_time_taxi_streaming.taxirides`,
+        CURRENT_TIMESTAMP() - INTERVAL 10 MINUTE)
+      WHERE ride_status = 'enroute'
+    ),
+    STRUCT(50 AS max_output_tokens, 1.0 AS temperature, 40 AS top_k, 1.0 AS top_p)) AS ml_output
+);
+```
+
+### 例 3: JOIN + タンブリングウィンドウ集計（stateful、Preview の目玉）
+
+```sql
+INSERT INTO `real_time_taxi_streaming.neighborhood_taxi_health`
+WITH potential_matches AS (
+  SELECT
+    requests._CHANGE_TIMESTAMP AS bq_changed_ts,
+    requests.geohash, requests.latitude, requests.longitude,
+    ST_DISTANCE(
+      ST_GEOGPOINT(requests.longitude, requests.latitude),
+      ST_GEOGPOINT(taxis.longitude, taxis.latitude)) AS distance_in_meters
+  FROM APPENDS(TABLE `real_time_taxi_streaming.ride_requests`,
+              CURRENT_TIMESTAMP() - INTERVAL 10 MINUTE) AS requests
+  INNER JOIN APPENDS(TABLE `real_time_taxi_streaming.taxirides`,
+              CURRENT_TIMESTAMP() - INTERVAL 10 MINUTE) AS taxis
+    ON requests.geohash = taxis.geohash
+  WHERE taxis.ride_status = 'available'
+    AND taxis._CHANGE_TIMESTAMP
+        BETWEEN (requests._CHANGE_TIMESTAMP - INTERVAL 5 MINUTE) AND requests._CHANGE_TIMESTAMP
+)
+SELECT
+  window_end, geohash,
+  COUNT(*) AS taxi_demand_volume,
+  ROUND(AVG(distance_in_meters), 2) AS avg_proximity_meters,
+  ROUND(MIN(distance_in_meters), 2) AS min_proximity_meters,
+  ROUND(MAX(distance_in_meters), 2) AS max_proximity_meters,
+  ROUND(STDDEV(distance_in_meters), 2) AS proximity_stddev
+FROM TUMBLE(TABLE potential_matches, "bq_changed_ts", INTERVAL 5 MINUTE)
+GROUP BY window_end, geohash;
+```
+
+## 使える AI / ML 関数
+
+- 生成 AI: `AI.GENERATE` / `AI.GENERATE_TEXT`（BigQuery ML remote model 経由で Agent
+  Platform モデルを呼ぶ）
+- AI API: `ML.UNDERSTAND_TEXT` / `ML.TRANSLATE`（Cloud AI API の remote model）
+- 前処理: `ML.NORMALIZER`
+- remote model 作成:
+  <https://docs.cloud.google.com/bigquery/docs/reference/standard-sql/bigqueryml-syntax-create-remote-model>
+
+## 出力先（リバース ETL）
+
+`EXPORT DATA` で **Pub/Sub / Bigtable / Spanner** に書き出せる（それ以外の宛先は不可）。分析
+結果を低レイテンシのサービング系（Bigtable / Spanner）へ書き戻す reverse ETL が代表用途。
+
+## 制約・落とし穴（重要）
+
+- **実行時間上限**: ユーザーアカウント実行は **最大 2 日**、サービスアカウント実行は **最大
+  150 日**。到達するとジョブは失敗・停止する → 本番は SA 実行が前提。
+- **watermark lag 48 時間** を超えると **ジョブ失敗**。`APPENDS` / `CHANGES` で停止時点から
+  再開する設計にしておく。
+- **実行中の SQL 変更不可**（止めて作り直す）。data canvas からは実行不可。
+- stateful はサポート対象の JOIN / 集約 / windowing のみ。`PIVOT` / `UNPIVOT` /
+  `TABLESAMPLE` / set 演算 / `SELECT DISTINCT` / `EXISTS` 子問い合わせ / 再帰 CTE / UDF /
+  window function call / DDL / `INSERT` 以外の DML などは **不可**。
+- データソース非対応: external table / information schema / Iceberg managed table /
+  wildcard table / CDC upsert / materialized view / 一部 view。
+- column-level / row-level security 非対応。
+- リージョン: Bigtable / Spanner / Pub/Sub locational endpoint への export は、クエリ元
+  BigQuery dataset と **同一リージョン境界** 内のリソースのみ（Pub/Sub global endpoint は例外）。
+- `CHANGES` は stateful 操作と併用不可。
+
+## エージェント連携（記事の "考えるデータ" の核）
+
+- **autonomous agent triggering**: live stream の複雑イベントを検知して agentic pipeline を
+  トリガー。
+- **autonomous agent monitoring**: ADK の
+  [BigQuery agent analytics plugin](https://adk.dev/integrations/bigquery-agent-analytics/)
+  でエージェントの trace / tool 使用 / ログを BigQuery にストリームして可観測性を確保。
+
+## 公式サンプル実装 / codelab（2026-06 実在確認済み）
+
+### 目玉: イベント駆動データエージェント（CQ stateful + Pub/Sub SMT + ADK の E2E）
+
+「Impossible Travel」異常を stateful continuous query で検知 → Pub/Sub（SMT で payload 整形）
+→ Vertex AI Agent Engine 上の ADK エージェント（Gemini 2.5 Flash + `BigQueryToolset` +
+`google_search`）が `FALSE_POSITIVE` / `ESCALATION_NEEDED` を判定、という **3 機能横断の
+完成デモ**。所要 60 分・想定コスト $2 未満。
+
+- 公式 codelab（Next '26）:
+  <https://codelabs.developers.google.com/next26/bigquery-adk-event-driven-agents>
+- 公式ブログ:
+  [Building Event-Driven Data Agents with BigQuery, Pub/Sub, and ADK](https://cloud.google.com/blog/topics/developers-practitioners/building-event-driven-data-agents-with-bigquery-pubsub-and-adk)
+- GitHub: [`GoogleCloudPlatform/devrel-demos` → `data-analytics/event_driven_agents_demo`](https://github.com/GoogleCloudPlatform/devrel-demos/tree/main/data-analytics/event_driven_agents_demo)
+  （2026-06-08 にファイル構成を実在確認）
+    - `setup/continuous_query.sql` — stateful CQ 定義（取引 × 顧客プロファイルの JOIN）
+    - `setup/transform.yaml` + `setup/pubsub_to_adk_transform.js` — Pub/Sub SMT（JavaScript
+      UDF）。BigQuery export の payload を unwrap・normalize して Agent Engine の envelope へ整形
+    - `setup/setup_env.sh` / `load_historical_data.py` / `customer_profiles.csv` — 環境構築・履歴データ
+    - `agent/adk_agent_app/agent.py` + `tools.py` — ADK エージェント（`gemini-2.5-flash` 既定 +
+      `BigQueryToolset` + `google_search`）。`agent_runner.py` / `deploy_agent_script.py` で Agent Engine へ
+    - `simulator/generate_events.py` — 合成トランザクション生成
+
+### ADK × BigQuery のツール / 評価 / 可観測性
+
+- ADK の BigQuery ツール: <https://google.github.io/adk-docs/tools/google-cloud/bigquery/>
+- codelab（ADK + GenAI Eval で BigQuery エージェントを構築・評価）:
+  <https://codelabs.developers.google.com/bigquery-adk-eval>
+- BigQuery Agent Analytics:
+  [公式ブログ](https://cloud.google.com/blog/products/data-analytics/introducing-bigquery-agent-analytics)
+  / [codelab](https://codelabs.developers.google.com/adk-bigquery-agent-analytics-plugin)
+- 参考（コミュニティ / 非公式・stateful CQ + ADK の Telco 監視事例）:
+  [Stream processing with BigQuery STATEFUL continuous queries and ADK agents](https://medium.com/google-cloud/stream-processing-with-bigquery-stateful-continuous-queries-and-adk-agents-for-telco-network-97a3e6973c8e)
+
+## 関連リンク
+
+- 概要: <https://docs.cloud.google.com/bigquery/docs/continuous-queries-introduction>
+- 実装: <https://docs.cloud.google.com/bigquery/docs/continuous-queries>
+- JOINs: <https://docs.cloud.google.com/bigquery/docs/continuous-query-joins>
+- windowing: <https://docs.cloud.google.com/bigquery/docs/window-aggregations>
+- Pub/Sub へ export: <https://docs.cloud.google.com/bigquery/docs/export-to-pubsub>
+- Bigtable へ export: <https://docs.cloud.google.com/bigquery/docs/export-to-bigtable>
+- Spanner へ export（reverse ETL）: <https://docs.cloud.google.com/bigquery/docs/export-to-spanner>

--- a/docs/wow/04-dataflow-streaming-agents/README.md
+++ b/docs/wow/04-dataflow-streaming-agents/README.md
@@ -1,0 +1,190 @@
+# Dataflow Streaming Agents（記事の "In-stream Agents"）
+
+記事が「Dataflow — In-stream Agents によるカスタム AI 実行」と書いた機能の **実体**。Dataflow
+（= Apache Beam のマネージドランナー）パイプラインの中に、**ADK（Agent Development Kit）で
+書いたエージェントを 1 ノードとして組み込み**、高スループットなストリームに対して数百の
+エージェントセッションを並列実行する。
+
+## ファクトチェック（最重要）
+
+- **"In-stream Agents" は正式な製品名ではない。** 記事の意訳であり、公式 SKU / 機能名では
+  ない。公式（Google Cloud Blog "Streaming AI news from Next '26"）の表現は
+  **"event-driven autonomous agents in Dataflow"** / 「agentic logic を Dataflow パイプラインの
+  first-class citizen として扱う」。
+- **実装の実体は次の 3 つの組み合わせ**:
+    1. Apache Beam の **`RunInference`** トランスフォーム（GA、Beam 2.40.0+）
+    2. 新しいモデルハンドラ **`ADKAgentModelHandler`**（`apache_beam.ml.inference.agent_development_kit`）
+    3. **ADK（Agent Development Kit）** で定義したエージェント
+- 記事の「複数データソース統合（Spanner / AlloyDB / BigQuery / GCS / Kafka）」は **正確**。
+  これは Beam の I/O コネクタと enrichment 変換で実現する従来からの強み。
+- `ADKAgentModelHandler` クラスは **Apache Beam の current pydoc に実在を確認済み**:
+  <https://beam.apache.org/releases/pydoc/current/apache_beam.ml.inference.agent_development_kit.html>
+
+## なぜ Dataflow にエージェントを載せるのか
+
+- **スケーラビリティ**: 高速イベントを上流（Dataflow）で前処理・集約し、数百のエージェント
+  セッションを並列実行。エージェント側は重い I/O やバッチングを意識しなくてよい。
+- **"action-ready" コンテキスト**: Dataflow が複雑なデータ充実化（enrichment / join / 整形）を
+  済ませ、エージェントには「すぐ行動に移せる」入力だけ渡す。
+- **統一エンジン**: Dataflow は batch / streaming / agentic AI を 1 つのサーバーレスエンジンで
+  扱う、という位置づけになった。
+
+## `ADKAgentModelHandler` の仕様（pydoc 実機確認）
+
+`apache_beam.ml.inference.agent_development_kit.ADKAgentModelHandler`
+
+コンストラクタ引数:
+
+- `agent`: ADK の `Agent` インスタンス、または **ゼロ引数の callable**（シリアライズ不可能な
+  状態を持つエージェントは lambda でラップして遅延生成する）
+- `app_name`: ADK アプリ名（デフォルト `'beam_inference'`）
+- `session_service_factory`: `BaseSessionService` を返す callable（任意）
+- `min_batch_size` / `max_batch_size` / `max_batch_duration_secs` / `max_batch_weight`:
+  バッチ制御（任意）
+- `element_size_fn`: 要素サイズを返す関数（任意）
+
+主なメソッド:
+
+- `load_model()`: ワーカー上で ADK `Runner` を初期化
+- `run_inference()`: バッチの各要素に対しエージェントを実行
+- `get_metrics_namespace()`: メトリクス名前空間
+
+基底 / 戻り値: `ModelHandler` / `PredictionResult`。
+
+## 実装：検証済み最小例（Apache Beam ソース由来）
+
+以下は Apache Beam ソースの docstring に載っている **検証済みの最小例**（2026-06 時点、
+`sdks/python/apache_beam/ml/inference/agent_development_kit.py`）。`LlmAgent` をそのまま
+`ADKAgentModelHandler` に渡し、`RunInference` で実行する。
+
+```python
+import apache_beam as beam
+from apache_beam.ml.inference.base import RunInference
+from apache_beam.ml.inference.agent_development_kit import ADKAgentModelHandler
+from google.adk.agents import LlmAgent
+
+agent = LlmAgent(
+    name="my_agent",
+    model="gemini-2.0-flash",
+    instruction="You are a helpful assistant.",
+)
+
+with beam.Pipeline() as p:
+    results = (
+        p
+        | beam.Create(["What is the capital of France?"])
+        | RunInference(ADKAgentModelHandler(agent=agent))
+    )
+```
+
+- **stateful なマルチターン会話**: `RunInference(..., inference_args={"session_id": ...})` で
+  `session_id` を渡すと、同じ `session_id` の要素が会話履歴を共有する（test
+  `test_shared_session_id_from_inference_args` で実証）。
+- エージェントがシリアライズ不可能な状態を持つ場合は、`agent` に **ゼロ引数 callable**
+  （lambda）を渡してワーカー上で遅延生成する。
+
+### ストリーミングへの応用（Pub/Sub 入力）
+
+上記の `beam.Create(...)` を Pub/Sub 読み取りに差し替え、前段で enrichment するのが
+ストリーミング構成。Dataflow ランナーで実行する。
+
+```python
+with beam.Pipeline(options=pipeline_options) as p:
+    (
+        p
+        | "Read"  >> beam.io.ReadFromPubSub(subscription="projects/.../subscriptions/...")
+        | "Prep"  >> beam.Map(to_action_ready_context)   # Dataflow 側で enrichment
+        | "Agent" >> RunInference(ADKAgentModelHandler(agent=agent))
+        | "Sink"  >> beam.Map(dispatch_action)           # 結果を下流へ
+    )
+```
+
+## パイプライン像
+
+```text
+ Pub/Sub / Kafka --> Dataflow --> [ enrichment ] --> RunInference(ADKAgentModelHandler) --> action
+   (events)          (Beam)        Spanner/AlloyDB/      ADK agent (gemini)                 Pub/Sub
+                                   BigQuery/GCS lookup                                      / DB update
+```
+
+Legend / 凡例:
+
+- events: 着信イベント（Pub/Sub / Kafka）
+- enrichment: 文脈付与（外部データソース参照による充実化）
+- RunInference(ADKAgentModelHandler): エージェント実行ノード
+- ADK agent: ADK 定義のエージェント（Gemini 等）
+- action: エージェントの決定（下流アクション・DB 更新・通知など）
+
+## 関連機能: Dataflow Unified Embeddings Sinks
+
+記事本文では薄いが、同じ Next '26 発表の一部。ストリーム内で埋め込みを生成し、**Cloud
+Spanner（新ベクトル検索）/ AlloyDB** に materialize する sink。エージェント RAG の long-term
+memory を最新化し続ける用途。
+
+- `MLTransform`（Beam 2.53.0+）で Vertex AI / Hugging Face の埋め込みを生成、または `Gemma` 等を
+  ローカル推論。
+- 参考: [Deploying EmbeddingGemma at scale with Dataflow](https://developers.googleblog.com/en/deploying-embeddinggemma-at-scale-with-dataflow/)
+
+## Dataflow ML の基礎（前提知識）
+
+- `RunInference`（Beam 2.40.0+）: モデル設定を `ModelHandler` に渡すだけで推論を組み込める。
+  PyTorch / scikit-learn / TensorFlow / ONNX / TensorRT / Vertex AI endpoint / **ADK** 等の
+  ハンドラがある。複数モデルの keyed handler、自動モデルリフレッシュ（side input）にも対応。
+- `MLTransform`（Beam 2.53.0+）: 前処理を 1 クラスに集約。
+- GPU/TPU 対応（H100 / TPU v5e・v5p・v6e、GPU autoscaling、right fitting）。
+- batch / streaming 両対応。
+
+## 開発リポジトリ / SDK / サンプル実装（2026-06 実在確認済み）
+
+### Apache Beam（`ADKAgentModelHandler` 本体）
+
+- リポジトリ: <https://github.com/apache/beam>（製品サイト <https://beam.apache.org/>）
+- **ソース実体**（GitHub API で 200 確認）:
+    - 本体: [`sdks/python/apache_beam/ml/inference/agent_development_kit.py`](https://github.com/apache/beam/blob/master/sdks/python/apache_beam/ml/inference/agent_development_kit.py)
+    - テスト（使い方の実例。`test_string_input_returns_prediction_result` /
+      `test_batch_of_strings` / `test_shared_session_id_from_inference_args`）:
+      [`sdks/python/apache_beam/ml/inference/agent_development_kit_test.py`](https://github.com/apache/beam/blob/master/sdks/python/apache_beam/ml/inference/agent_development_kit_test.py)
+- `RunInference` 全般のサンプル集:
+  [`sdks/python/apache_beam/examples/inference`](https://github.com/apache/beam/tree/master/sdks/python/apache_beam/examples/inference)
+- pydoc: <https://beam.apache.org/releases/pydoc/current/apache_beam.ml.inference.agent_development_kit.html>
+- Beam ML / LLM ガイド: <https://beam.apache.org/documentation/ml/large-language-modeling/>
+
+### ADK（Agent Development Kit）
+
+- ドキュメント: <https://google.github.io/adk-docs/>
+- Python: <https://github.com/google/adk-python> / Go: <https://github.com/google/adk-go>
+- サンプル集: <https://github.com/google/adk-samples>
+- Google サービス統合一覧: <https://adk.dev/integrations/?topic=google>
+
+### Dataflow ML（RunInference / remote inference）
+
+- Dataflow ML ドキュメント: <https://docs.cloud.google.com/dataflow/docs/machine-learning>
+- サンプル一覧（Colab 手順あり）:
+  <https://docs.cloud.google.com/dataflow/docs/machine-learning/ml-about>
+- remote inference notebook（Vertex AI / 外部エンドポイント呼び出し）:
+  <https://docs.cloud.google.com/dataflow/docs/notebooks/custom_remote_inference>
+- codelab（Beam + Dataflow でリアルタイム AI/ML 評価）:
+  <https://codelabs.developers.google.com/beam-ai-evaluation-pipeline>
+
+### エンドツーエンド・デモ（CQ + Pub/Sub SMT + ADK の 3 機能横断）
+
+- 公式 codelab（Next '26）:
+  <https://codelabs.developers.google.com/next26/bigquery-adk-event-driven-agents>
+- GitHub: [`GoogleCloudPlatform/devrel-demos` → `data-analytics/event_driven_agents_demo`](https://github.com/GoogleCloudPlatform/devrel-demos/tree/main/data-analytics/event_driven_agents_demo)
+  （`agent/` `setup/` `simulator/` 構成。実在確認済み）。詳細は
+  [03-bigquery-continuous-queries-stateful/](../03-bigquery-continuous-queries-stateful/README.md) を参照。
+
+## 制約・注意
+
+- `ADKAgentModelHandler` は新しい API。Preview 相当として扱い、引数・挙動は最新版で確認する。
+- エージェントがシリアライズ不可能な状態を持つ場合は **callable（lambda）でラップ** して
+  ワーカー上で遅延生成する（pydoc の指示）。
+- 1 イベント = 1 エージェント実行が基本。スループットは `max_batch_size` 等とワーカー数で調整。
+- LLM 呼び出しは外部 quota / レイテンシに律速される。Dataflow の autoscaling と合わせて設計する。
+
+## 関連リンク
+
+- 公式ブログ（Next '26 総括、Dataflow agentic の一次情報）:
+  <https://cloud.google.com/blog/products/data-analytics/streaming-ai-news-from-next26>
+- Apache Beam RunInference: <https://beam.apache.org/documentation/ml/about-ml/>
+- Dataflow（製品トップ）: <https://cloud.google.com/products/dataflow>

--- a/docs/wow/README.md
+++ b/docs/wow/README.md
@@ -1,0 +1,164 @@
+# What's New in Streaming (Google Cloud Next '26) — ファクトチェック済みノート
+
+このディレクトリは、KDDI アイレットの記事
+[Google Cloud Next '26: ストリーミング基盤の最新アップデート (iret.media/194869)](https://iret.media/194869)
+の内容を **一次情報（cloud.google.com 公式ドキュメント・Google Cloud Blog・Apache Beam
+pydoc）と突き合わせて裏取りし**、「実際にどう実装で使えるのか」まで踏み込んでまとめた
+技術ノートである。
+
+- 元記事: 田村直樹（KDDI アイレット / Google Cloud Partner Top Engineer 2025 & 2026）
+  による Next '26 セッション **"What's new in streaming: Real-time data for agentic AI"**
+  のレポート（公開日 2026-04-24）。
+- 元セッション:
+  [What's new in streaming: Real-time data for agentic AI (Next '26, Las Vegas)](https://www.googlecloudevents.com/next-vegas/session/3912220/what's-new-in-streaming-real-time-data-for-agentic-ai)
+- 公式総括ブログ:
+  [Streaming AI news from Next '26 (Google Cloud Blog, 2026-05-19)](https://cloud.google.com/blog/products/data-analytics/streaming-ai-news-from-next26)
+
+## TL;DR — テーマ
+
+ストリーミング基盤の位置づけが「データを **運ぶ** パイプライン（data transfer pipeline）」
+から「エージェント向けに **意味づけ・推論する** インテリジェンスパイプライン（intelligence
+pipeline for agents）」へ移った、というのが Next '26 の主張。記事のキャッチコピー
+「流れるデータを、考えるデータへ」はこの転換を指しており、**公式ブログの内容と整合する**。
+
+## ファクトチェック結果サマリ
+
+記事が挙げた 4 つの目玉は **すべて実在の機能** であり、launch stage の記述も公式と一致する。
+1 点だけ用語の注意が要る（下表 ★）。
+
+| # | 記事の記述 | 公式での正式名称 / 実体 | Launch stage | 判定 |
+|---|---|---|---|---|
+| 1 | Pub/Sub AI Inference SMT | AI Inference [Single Message Transform](https://docs.cloud.google.com/pubsub/docs/smts/ai-inference-smt) | **GA** | ✅ 正確 |
+| 2 | Pub/Sub Bigtable Subscriptions | [Bigtable subscription](https://docs.cloud.google.com/pubsub/docs/bigtable-subscriptions)（export subscription の一種） | **Preview** | ✅ 正確 |
+| 3 | BigQuery Continuous Query — Stateful Data Processing | [continuous queries](https://docs.cloud.google.com/bigquery/docs/continuous-queries) の stateful operations（JOIN / 集約 / windowing） | **Preview** | ✅ 正確 |
+| 4 | Dataflow — In-stream Agents | ★ Dataflow + `RunInference` + [`ADKAgentModelHandler`](https://beam.apache.org/releases/pydoc/current/apache_beam.ml.inference.agent_development_kit.html) + ADK | GA（RunInference は GA。ADKAgentModelHandler は Beam 同梱） | ⚠️ 機能は実在。ただし "In-stream Agents" は **正式な製品名ではなく記事の意訳** |
+
+### ★ 用語の注意（重要）
+
+記載ごとの判定は [fact-check.md](fact-check.md) に分離した。要注意は以下の 4 点。
+
+- **「In-stream Agents」は SKU / 製品名ではない。** 公式は "event-driven autonomous
+  agents in Dataflow" や「agentic logic を Dataflow パイプラインの first-class node として
+  扱う」と表現する。実装の実体は **Apache Beam の `RunInference` トランスフォーム + 新しい
+  `ADKAgentModelHandler` モデルハンドラ + [ADK (Agent Development Kit)](https://google.github.io/adk-docs/)**
+  の組み合わせ。詳細は [04-dataflow-streaming-agents/](04-dataflow-streaming-agents/README.md)。
+- **「Elastic Inference Queue」は公式用語ではない。** 公式ドキュメントに該当する製品 / 機能名は
+  存在せず、AI Inference SMT の **フロー制御機能**（エンドポイント過負荷を避けるための
+  レート自動調整）をスライドで言い換えた表現とみられる。詳細は
+  [01-pubsub-ai-inference-smt/](01-pubsub-ai-inference-smt/README.md)。
+- **「Gemini Enterprise Agent Platform」= Vertex AI のリブランド。** Next '26 前後で
+  Vertex AI が "Agent Platform" / "Gemini Enterprise Agent Platform" に改称された。公式
+  docs も "Agent Platform (previously Vertex AI)" と併記する。ただし **IAM ロール名
+  （`Vertex AI Service Agent` / `Vertex AI User`）や API（`aiplatform.endpoints.predict`）
+  は旧称のまま** なので、実装時は両方の名前が混在する点に注意。
+- **「Bigtable のマテリアライズドビュー」は Bigtable Subscriptions とは別機能。**
+  記事のアーキ図に出てくる Bigtable materialized view は実在する
+  [Bigtable continuous materialized views](https://docs.cloud.google.com/bigtable/docs/continuous-materialized-views)
+  （SQL 定義の背景集約ビュー）であり、目玉の **Bigtable Subscriptions（raw メッセージの
+  直接書き込み）とは別物**。混同しないこと。
+
+## ドキュメント構成
+
+- [fact-check.md](fact-check.md)
+  — 記事の **記載ごと** の判定（✅ / ⚠️ / ℹ️ / ❓）の詳細表
+
+実装手順・gcloud / SQL / Beam コード・制約・公式リンク・開発リポジトリは機能ごとのフォルダに
+分割した（各フォルダの本体は `README.md`）。
+
+1. [01-pubsub-ai-inference-smt/](01-pubsub-ai-inference-smt/README.md)
+   — Pub/Sub の中で直接モデルを呼ぶ（GA）
+2. [02-pubsub-bigtable-subscriptions/](02-pubsub-bigtable-subscriptions/README.md)
+   — コード不要で Pub/Sub → Bigtable に materialize（Preview）
+3. [03-bigquery-continuous-queries-stateful/](03-bigquery-continuous-queries-stateful/README.md)
+   — 常駐 SQL で JOIN / windowing / 生成 AI（Preview）
+4. [04-dataflow-streaming-agents/](04-dataflow-streaming-agents/README.md)
+   — Dataflow に ADK エージェントを組み込む（= 記事の "In-stream Agents"）
+
+## 記事が触れていない関連発表（公式ブログより補足）
+
+記事は 4 機能に絞っているが、同じセッション / ブログでは以下も発表されている。エージェントから
+ストリーミング基盤を「使う」側の話なので、実装の全体像として押さえておくと良い。
+
+- **Model Context Protocol (MCP) support（GA）** — エージェントがフルマネージドな MCP
+  エンドポイント経由で各サービスを操作できる。
+    - Pub/Sub: <https://docs.cloud.google.com/pubsub/docs/use-pubsub-mcp>
+    - Bigtable: <https://docs.cloud.google.com/bigtable/docs/use-bigtable-mcp>
+    - BigQuery: <https://docs.cloud.google.com/bigquery/docs/use-bigquery-mcp>
+    - Managed Service for Apache Kafka:
+      <https://docs.cloud.google.com/managed-service-for-apache-kafka/docs/use-managed-service-for-apache-kafka-mcp>
+- **ADK integration（GA）** — ADK エージェントが Pub/Sub / Bigtable / BigQuery 等の
+  リアルタイムデータに pre-built integration で接続:
+  <https://adk.dev/integrations/?topic=google>
+- **Dataflow unified embeddings sinks** — ストリーム内で埋め込み生成し、Cloud Spanner
+  （新ベクトル検索）/ AlloyDB に materialize（エージェント RAG の long-term memory 用途）。
+  参考: [Deploying EmbeddingGemma at scale with Dataflow](https://developers.googleblog.com/en/deploying-embeddinggemma-at-scale-with-dataflow/)
+
+## アーキテクチャ全体像
+
+```text
+                 +---------------------------+
+   publishers -> |  Pub/Sub (topic)          |
+                 |   + AI Inference SMT (GA)  |--enriched msg--+
+                 +---------------------------+                 |
+                      |                  |                     v
+        Bigtable sub  |                  | BigQuery sub   +-----------+
+        (Preview)     v                  v                |  Dataflow |
+                 +----------+      +-------------+         | RunInfer. |
+                 | Bigtable |      |  BigQuery   |         | + ADK     |
+                 | (serving)|      | continuous  |         | agent     |
+                 +----------+      | query (CQ)  |         +-----------+
+                      ^            | stateful(PV)|              |
+                      |            +-------------+              v
+                      +--reverse ETL--+   |   +--> Pub/Sub / Spanner / Bigtable
+                                          v
+                                  AI.GENERATE_TEXT etc.
+```
+
+Legend / 凡例:
+
+- publishers: パブリッシャー（イベント発行元）
+- AI Inference SMT: Pub/Sub 内でモデル推論を付与する変換（GA）
+- enriched msg: 推論結果を付与済みのメッセージ
+- Bigtable sub (Preview): Bigtable サブスクリプション（プレビュー）
+- BigQuery sub: BigQuery サブスクリプション
+- continuous query (CQ) stateful (PV): 常駐クエリの stateful 処理（プレビュー）
+- reverse ETL: 分析結果を低レイテンシ配信系へ書き戻す処理
+- RunInference + ADK agent: Dataflow にエージェントを組み込むノード
+- serving: アプリへの低レイテンシ配信
+
+## サンプル実装 / codelab（2026-06 実在確認済み）
+
+各機能の詳細サンプルは機能別ドキュメントの「サンプル実装」節に記載。**最初に触るなら** 以下の
+2 つが効率的。
+
+- **3 機能横断 E2E デモ**（BigQuery stateful CQ + Pub/Sub SMT + ADK エージェント）:
+  公式 codelab
+  [Build an Event-Driven Data Agent with BigQuery and ADK](https://codelabs.developers.google.com/next26/bigquery-adk-event-driven-agents)
+  / GitHub
+  [`GoogleCloudPlatform/devrel-demos` → `data-analytics/event_driven_agents_demo`](https://github.com/GoogleCloudPlatform/devrel-demos/tree/main/data-analytics/event_driven_agents_demo)
+- **Dataflow にエージェントを載せる最小例**: Apache Beam の `ADKAgentModelHandler` 本体 +
+  テスト
+  [`sdks/python/apache_beam/ml/inference/agent_development_kit.py`](https://github.com/apache/beam/blob/master/sdks/python/apache_beam/ml/inference/agent_development_kit.py)
+  / [`..._test.py`](https://github.com/apache/beam/blob/master/sdks/python/apache_beam/ml/inference/agent_development_kit_test.py)
+
+> GitHub のパス・codelab・docs はいずれも 2026-06-08 に GitHub API / 実フェッチで到達確認済み。
+
+## 一次情報リンク集
+
+- Pub/Sub SMT 概要: <https://docs.cloud.google.com/pubsub/docs/smts/smts-overview>
+- AI Inference SMT: <https://docs.cloud.google.com/pubsub/docs/smts/ai-inference-smt>
+- JavaScript UDF SMT: <https://docs.cloud.google.com/pubsub/docs/smts/udfs-overview>
+- Bigtable subscriptions: <https://docs.cloud.google.com/pubsub/docs/bigtable-subscriptions>
+- Bigtable subscription 作成: <https://docs.cloud.google.com/pubsub/docs/create-bigtable-subscription>
+- Continuous queries 概要: <https://docs.cloud.google.com/bigquery/docs/continuous-queries-introduction>
+- Continuous queries 実装: <https://docs.cloud.google.com/bigquery/docs/continuous-queries>
+- Dataflow ML: <https://docs.cloud.google.com/dataflow/docs/machine-learning>
+- Apache Beam RunInference: <https://beam.apache.org/documentation/ml/about-ml/>
+- `ADKAgentModelHandler` pydoc:
+  <https://beam.apache.org/releases/pydoc/current/apache_beam.ml.inference.agent_development_kit.html>
+- ADK ドキュメント: <https://google.github.io/adk-docs/>
+- 公式ブログ（Next '26 総括）:
+  <https://cloud.google.com/blog/products/data-analytics/streaming-ai-news-from-next26>
+
+> 検証日: 2026-06-08 時点の公式ドキュメントに基づく。Preview 機能は仕様が変わりうるため、
+> 実装前に必ず各公式ページの最新版を確認すること。

--- a/docs/wow/fact-check.md
+++ b/docs/wow/fact-check.md
@@ -1,0 +1,126 @@
+# ファクトチェック詳細（記載ごとの判定）
+
+[iret.media/194869](https://iret.media/194869) が述べている **個々の記載** を、一次情報
+（cloud.google.com 公式ドキュメント・Google Cloud Blog・Apache Beam pydoc）と一文ずつ
+突き合わせた結果。総括は [README.md](README.md) を、各機能の実装詳細は各機能ドキュメントを参照。
+
+> 検証日: 2026-06-08 時点の公式ドキュメントに基づく。
+
+## 判定記号
+
+- ✅ **正確** — 公式と一致
+- ⚠️ **要注意** — 不正確、または誤解を招く（製品名でないものを製品名扱い等）
+- ℹ️ **補足必要** — 誤りではないが、文脈・但し書きの追加が要る
+- ❓ **検証対象外** — 記事メタ情報など、一次情報で裏取りできない / する意味が薄い
+
+## 結論
+
+記事の事実精度は **高い**。4 機能の正式名称・launch stage（GA / GA / Preview / Preview）は
+すべて公式と一致し、ユースケースも概ね正確。**要注意は用語まわりの 3 点のみ**（下記 ⚠️ / ℹ️）。
+
+## 著者・セッション情報
+
+| 記載 | 判定 | 一次情報との照合 |
+|---|---|---|
+| セッション名「What's New in Streaming」 | ℹ️ | 公式の正式名は **"What's new in streaming: Real-time data for agentic AI"**。記事は短縮形。実体は同一 |
+| 田村直樹 / Partner Top Engineer 2025 & 2026 / 2026-04-24 公開 | ❓ | 記事メタ情報ゆえ検証対象外。Partner Top Engineer は実在の Google Cloud プログラム |
+
+## 全体アーキテクチャ
+
+| 記載 | 判定 | 照合 |
+|---|---|---|
+| Raw Events → Pub/Sub → AI Inference SMT →（BigQuery CQ / Bigtable）→ MCP 経由でエージェント | ✅ | 公式ブログの構図と一致。**MCP support は GA**（Pub/Sub / Bigtable / BigQuery / Kafka）確認済 |
+| 「Bigtable のマテリアライズドビュー」 | ℹ️ | [Bigtable continuous materialized views](https://docs.cloud.google.com/bigtable/docs/continuous-materialized-views) は実在機能。ただし **目玉の Bigtable Subscriptions とは別の Bigtable 機能**（subscriptions は raw メッセージ書き込み、materialized view は SQL 定義の背景集約ビュー） |
+| エージェント 3 条件（リアルタイムシグナル / セマンティックメモリ / 低レイテンシ） | ✅ | セッションの editorial framing。ブログの論旨と整合 |
+
+## ① Pub/Sub AI Inference SMT
+
+| 記載 | 判定 | 照合 |
+|---|---|---|
+| 正式名称 Single Message Transforms（SMT） | ✅ | 公式と一致（厳密には単数 "Transform" が正準） |
+| Launch stage: **GA** | ✅ | 公式ブログ "Streaming AI news from Next '26" で GA 明記 |
+| ストリーミングパス内で直接モデル呼び出し / 間にサービス不要 | ✅ | 公式の "reduced latency" / "simplified AI pipelines" と一致 |
+| 対応: Agent Platform 上のモデル / Model Garden / カスタム | ✅ | self-deployed + MaaS で一致 |
+| 「Gemini Enterprise Agent Platform（このイベントで GA）」 | ℹ️ | **= Vertex AI のリブランド**。IAM ロール（`Vertex AI User`）と API（`aiplatform.endpoints.predict`）は **旧称のまま残る** 点に注意 |
+| フロー制御を Pub/Sub 側で統合管理、過負荷を心配せず済む | ✅ | 公式 "enhanced flow control"（レート自動調整）と一致 |
+| ユースケース: NLP（embedding / 分類）、予測（不正検知 / センチメント） | ✅ | 公式 use case（enrichment / classification / sentiment / embedding）と一致 |
+| 「Elastic Inference Queue」 | ⚠️ | **公式ドキュメントに該当用語なし**。AI Inference SMT のフロー制御機能をスライドで言い換えたものとみられる。製品 / 機能名として扱うと誤り |
+
+## ② Pub/Sub Bigtable Subscriptions
+
+| 記載 | 判定 | 照合 |
+|---|---|---|
+| 正式名称 / Launch stage: **Preview** | ✅ | 公式に Pre-GA バナー。`gcloud beta` 系コマンド |
+| Bigtable へ直接書き込む新しいサブスクリプションタイプ | ✅ | export subscription の一種で一致 |
+| 「カスタム ETL も Dataflow も不要」 | ✅ | 一致（複雑変換時は Dataflow 推奨、という但し書きは公式にあり） |
+| スケーリング / エラー / フロー制御を Pub/Sub が全管理 | ✅ | 一致。ただし **配信は at-least-once**（重複排除なし）という前提が記事では省略 |
+| 「BigQuery・Cloud Storage に続く 3 つ目のネイティブ書き込み先」 | ✅ | export subscription の系譜として正確 |
+| サブミリ秒サービング向け | ✅ | Bigtable の読み取りサービング特性として妥当 |
+
+## ③ BigQuery Continuous Query / Stateful Data Processing
+
+| 記載 | 判定 | 照合 |
+|---|---|---|
+| 「BigQuery は実はストリーミング処理エンジンでもある」 | ✅ | continuous queries で正確 |
+| CQ の 4 ユースケース分類（分析 / 生成 AI / reverse ETL / Agentic） | ✅ | 公式 use case と整合（セッションの分類軸） |
+| 正式名称 Stateful Data Processing / Launch stage: **Preview** | ✅ | 公式 stateful operations は Preview（フィードバック窓口 `bq-continuous-queries-feedback@google.com`） |
+| 従来はステートレス（1 件ずつ独立処理）だった | ✅ | 公式の説明と一致 |
+| 集約（SUM / AVG / APPROX_COUNT_DISTINCT）/ タンブリングウィンドウ / ストリーム間 INNER JOIN | ✅ | `TUMBLE`・JOIN・集約すべて公式で確認 |
+| Updates / Deletes 処理（CHANGES TVF 経由で Pub/Sub シンクへ） | ✅ | 正確。ただし **CHANGES は stateful 操作とは併用不可・Pub/Sub export 時のみ** という制約あり |
+| 「Flink / Spark Structured Streaming の領域に SQL だけで入れる」 | ✅ | editorial だが JOIN + windowing 追加で妥当な評価 |
+
+## ④ Dataflow
+
+| 記載 | 判定 | 照合 |
+|---|---|---|
+| SMT / CQ で処理しきれない複雑ケースに対応 / プログラマティック制御 | ✅ | 公式ポジショニングと一致 |
+| 統合データソース: Spanner / AlloyDB / BigQuery / GCS / Pub/Sub / Kafka | ✅ | Beam I/O コネクタで正確 |
+| 「In-stream Agents というエージェントがカスタム AI モデルをパイプライン内で直接実行」 | ⚠️ | **「In-stream Agents」は正式な製品 / 機能名ではない**。実体は Apache Beam の `RunInference` + 新ハンドラ `ADKAgentModelHandler` + ADK。公式表現は "event-driven autonomous agents in Dataflow"。「エージェントがモデルを実行」も主客が逆気味で、正しくは「パイプラインが ADK エージェントをノードとして実行」 |
+| 使い分け（1 msg 推論 → SMT / SQL 集約・結合 → CQ / 複数ソース・カスタム → Dataflow） | ✅ | 公式の選択指針と一致 |
+
+## 要注意点まとめ
+
+1. ⚠️ **「In-stream Agents」** — 正式名称ではない。実体は ADK エージェントを
+   `RunInference` + `ADKAgentModelHandler` で実行する構成（詳細:
+   [04-dataflow-streaming-agents/](04-dataflow-streaming-agents/README.md)）。
+2. ⚠️ **「Elastic Inference Queue」** — 公式用語ではない。AI Inference SMT のフロー制御機能の
+   言い換え（詳細: [01-pubsub-ai-inference-smt/](01-pubsub-ai-inference-smt/README.md)）。
+3. ℹ️ **「Gemini Enterprise Agent Platform」** — Vertex AI のリブランド。IAM / API は旧称が残存。
+
+軽微な省略（誤りではない）:
+
+- Bigtable Subscriptions の at-least-once（重複排除なし）配信。
+- CHANGES TVF と stateful 操作の併用不可制約。
+
+## ドキュメント記載の自己検証（2026-06-08）
+
+記事だけでなく、本 docs に **後から追加した実装コード・ファイルパス・サンプル・図** も
+primary source に当て直した結果。
+
+| 検証対象 | 方法 | 結果 |
+|---|---|---|
+| `ADKAgentModelHandler` 最小例（[04](04-dataflow-streaming-agents/README.md)）| beam ソース `agent_development_kit.py` の docstring と逐語照合 | ✅ import / `gemini-2.0-flash` / `beam.Create([...])` / `RunInference(...)` 完全一致 |
+| `ADKAgentModelHandler.__init__` 署名（`max_batch_weight` 含む）| 同ソース `def __init__` 照合 | ✅ 一致（`max_batch_weight` も実在） |
+| beam の `.py` / `_test.py` パス | GitHub API HTTP ステータス | ✅ 両方 200 |
+| `devrel-demos` の SMT 配置（`setup/transform.yaml`）| GitHub API で実ファイル確認 | ✅ `setup/` が正（repo 自身の README 散文は `agent/` と誤記） |
+| デモ agent のモデル / ツール | `agent/adk_agent_app/agent.py` 照合 | ✅ `gemini-2.5-flash` 既定 + `BigQueryToolset` + `google_search` |
+| Bigtable 書き込みレイアウト図（[02](02-pubsub-bigtable-subscriptions/README.md)）| 公式 docs で行構造を確認 | ✅ metadata は **同一行**（同一 row key）に `pubsub_metadata` family |
+| ASCII 図 5 枚 | text-fence 内を byte 単位スキャン | ✅ 多バイト文字ゼロ（規約準拠）+ 各図に日本語 legend |
+
+修正した記載:
+
+- ⚠️→修正: [01](01-pubsub-ai-inference-smt/README.md) の「docs 最終更新 2026-05-14」は二次
+  ソースの paraphrase で primary 未確認 → 「2026-06 時点の公式版に基づく」に軟化。
+
+## 判定の根拠（一次情報）
+
+- AI Inference SMT: <https://docs.cloud.google.com/pubsub/docs/smts/ai-inference-smt>
+- SMT 概要: <https://docs.cloud.google.com/pubsub/docs/smts/smts-overview>
+- Bigtable subscriptions: <https://docs.cloud.google.com/pubsub/docs/bigtable-subscriptions>
+- Bigtable continuous materialized views:
+  <https://docs.cloud.google.com/bigtable/docs/continuous-materialized-views>
+- BigQuery continuous queries: <https://docs.cloud.google.com/bigquery/docs/continuous-queries-introduction>
+- `ADKAgentModelHandler` pydoc:
+  <https://beam.apache.org/releases/pydoc/current/apache_beam.ml.inference.agent_development_kit.html>
+- 公式ブログ（Next '26 総括）:
+  <https://cloud.google.com/blog/products/data-analytics/streaming-ai-news-from-next26>


### PR DESCRIPTION
## What

`docs/wow/` に **Google Cloud Next '26「What's New in Streaming」** のファクトチェック済み技術ノートを追加する。元記事は [iret.media/194869](https://iret.media/194869)。記事の各記載を **一次情報**（cloud.google.com 公式 docs / Google Cloud Blog / Apache Beam pydoc・ソース）に当て直し、実装で使える粒度まで掘り下げた。

## 構成（機能ごとにフォルダ、データフロー順）

| | doc | launch stage |
|---|---|---|
| 01 | Pub/Sub AI Inference SMT | GA |
| 02 | Pub/Sub Bigtable Subscriptions | Preview |
| 03 | BigQuery continuous queries — stateful processing | Preview |
| 04 | Dataflow streaming agents (`RunInference` + `ADKAgentModelHandler`) | GA 相当 |

- `README.md` — 索引 + 総括 + 用語注意 + アーキ全体図 + 目玉サンプル
- `fact-check.md` — 記載ごとの判定（✅/⚠️/ℹ️/❓）+ **ドキュメント記載の自己検証表**

## ファクトチェックの要点

- 記事の 4 機能・launch stage・ユースケースは **おおむね公式と一致**。
- 用語の注意 3 点を明記:
  - 「In-stream Agents」は正式名でなく記事の意訳（実体 = `RunInference` + `ADKAgentModelHandler` + ADK）
  - 「Elastic Inference Queue」は公式用語でない（AI Inference SMT のフロー制御の言い換え）
  - 「Gemini Enterprise Agent Platform」= Vertex AI のリブランド（IAM/API は旧称が残存）

## 検証（2026-06-08）

- 実装コードは Apache Beam ソース `agent_development_kit.py` の docstring と **逐語一致**を確認。
- サンプル repo / ファイルパス（apache/beam, GoogleCloudPlatform/devrel-demos）を **GitHub API / 生ソースで実在確認**。
- ASCII 図 5 枚はすべて **単角 ASCII のみ + 日本語 legend**（CLAUDE.md 規約準拠、byte 単位スキャン済み）。
- `markdownlint-cli2` **0 error**、内部リンク **BROKEN ゼロ**、commit は GPG 署名済み。

## Notes

- 追加は `docs/wow/` のみ（純粋な documentation = `docs` type / structural）。コード・設定への影響なし。