### PR TITLE
chore(deps): bump claude-code pin 2.1.158 -> 2.1.159

### DIFF
--- a/.devcontainer/features/dotfiles-tools/install.sh
+++ b/.devcontainer/features/dotfiles-tools/install.sh
@@ -250,7 +250,7 @@ node = "24.16.0"
 "npm:@openai/codex" = "0.135.0"
 # npm_args re-enables postinstall (mise defaults to --ignore-scripts=true)
 # so claude-code's native binary is linked, not left as a stub. See mise.toml.
-"npm:@anthropic-ai/claude-code" = { version = "2.1.158", npm_args = "--ignore-scripts=false" }
+"npm:@anthropic-ai/claude-code" = { version = "2.1.159", npm_args = "--ignore-scripts=false" }
 "npm:@github/copilot" = "1.0.56"
 "npm:@earendil-works/pi-coding-agent" = "0.78.0"
 "github:google-antigravity/antigravity-cli" = { version = "1.0.6", exe = "antigravity" }

--- a/mise.toml
+++ b/mise.toml
@@ -36,7 +36,7 @@ node = "24.16.0"
 # stub — `claude` then errors at runtime with "native binary not installed".
 # npm_args re-enables scripts for this one tool (npm honors the last
 # --ignore-scripts flag, so this overrides mise's default).
-"npm:@anthropic-ai/claude-code" = { version = "2.1.158", npm_args = "--ignore-scripts=false" }
+"npm:@anthropic-ai/claude-code" = { version = "2.1.159", npm_args = "--ignore-scripts=false" }
 "npm:@github/copilot" = "1.0.56"
 "npm:@earendil-works/pi-coding-agent" = "0.78.0"
 


### PR DESCRIPTION
## 背景

`just doctor` の PATH 重複調査中に判明: mise が管理する claude-code が
**2.1.158**（2026-05-30 公開）で止まっており、native installer
（`~/.local/bin/claude`）は **2.1.168** まで自動更新していた。`which claude`
は mise 側（2.1.158）に解決するため、古い版が動いていた。

## 対応と cooldown の制約

repo の npm quarantine（`min-release-age=7` ≒ uv の `exclude-newer = "7 days"`、
mise.toml に明記）が **公開7日未満の install をブロック**する。実時刻
2026-06-08 時点で 7日以上経過した最新は **2.1.159**（2026-05-31 公開、約8日）。
2.1.160 以降はまだ quarantine 窓内で install 不可。

→ policy 上限の **2.1.159** に bump（mise 所有を維持。native は同系列で shadowed のまま無害）。

## 同期

- `mise.toml`（host SoT）
- `.devcontainer/features/dotfiles-tools/install.sh`（sandbox heredoc）

mise-pin house style に従い両方を同値に。`config/mise/config.toml` は
house style 通り `latest` 据え置き。

## 検証

- `mise install npm:@anthropic-ai/claude-code@2.1.159` ✅（quarantine 通過）→
  `which claude` = mise 2.1.159 / `claude --version` = 2.1.159 を確認
- `uvx pytest tests/test_mise_pin_consistency.py` ✅ 8 passed
- `just ci` ✅

## 補足

native 2.1.168 が quarantine を抜けたら次回さらに bump 可能。`just doctor` の
claude 重複フラグ自体は mise/native 併存ゆえ残る（同系列なので無害・情報用）。