### PR TITLE
fix(zshrc): use path_prepend for antigravity/grok installer PATH entries

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -227,8 +227,8 @@ if _cmd_exists fzf; then
     unset _fzf_cache
 fi
 
-# Added by Antigravity
-export PATH="$HOME/.antigravity/antigravity/bin:$PATH"
+# Added by Antigravity (dedup so a re-source / installer re-run cannot double it)
+path_prepend "$HOME/.antigravity/antigravity/bin"
 
 
 # Vite+ bin (https://viteplus.dev)
@@ -272,7 +272,7 @@ if _cmd_exists mise; then
 fi
 
 # >>> grok installer >>>
-export PATH="$HOME/.grok/bin:$PATH"
+path_prepend "$HOME/.grok/bin"
 fpath=(~/.grok/completions/zsh $fpath)
 autoload -Uz compinit && compinit -C
 # <<< grok installer <<<


### PR DESCRIPTION
## 背景

PR #155 で `~/.local/bin` の二重登録（Antigravity installer の無条件 prepend）を
修正したが、`.zshrc` には同種の無条件行があと2つ残っていた:

- `# Added by Antigravity` → `export PATH="$HOME/.antigravity/antigravity/bin:$PATH"`
- grok installer ブロック内 → `export PATH="$HOME/.grok/bin:$PATH"`

これらは fresh login では1回しか効かないため `just doctor` の 180件爆発には
寄与しなかったが、**再 source（`relogin` / `source ~/.zshrc`）で二重登録**する
（`~/.local/bin` と同じバグクラス）。

## 対応

両方を dedup-safe な `path_prepend` helper に置換。解決先バイナリは不変。

## 検証

- `env -i ... zsh -lic 'source ~/.zshrc; ...'`（login + 追加 source = relogin 2回相当）で
  `.antigravity/antigravity/bin` / `.grok/bin` / `.local/bin` が **各1回ずつ** を確認
- 残る生 `export PATH=...:$PATH` は dbt の `if [[ ... ]]` ガード内の1行のみ（二重化しない）
- `just ci` ✅

## 補足

grok 側は installer の sentinel ブロック（`>>> grok installer >>>`）内なので、
grok の再インストール時に書き戻される可能性がある（その時は再度 path_prepend 化）。