### PR TITLE
feat(zshrc): add ant (Anthropic CLI) zsh completion

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -257,6 +257,17 @@ alias dbtf="$HOME/.local/bin/dbt"
 # CF CLI completions
 [[ -f "$HOME/.config/cf/completions/_cf.zsh" ]] && source "$HOME/.config/cf/completions/_cf.zsh"
 
+# ant (Anthropic CLI) completion — cached, regenerated only when missing
+if _cmd_exists ant; then
+    _ant_comp_cache="${XDG_CACHE_HOME:-$HOME/.cache}/zsh/ant_completion.zsh"
+    if [[ ! -f "$_ant_comp_cache" || ! -s "$_ant_comp_cache" ]]; then
+        mkdir -p "${_ant_comp_cache:h}"
+        ant @completion zsh > "$_ant_comp_cache"
+    fi
+    source "$_ant_comp_cache"
+    unset _ant_comp_cache
+fi
+
 # Antigravity CLI (installs into ~/.local/bin, already on PATH via line ~119;
 # use the dedup helper so a re-run of the installer cannot double-register it)
 path_prepend "$HOME/.local/bin"


### PR DESCRIPTION
## 背景

Anthropic CLI (`ant`) quickstart のチェックで判明: **install は対応済み**
（`dump/Brewfile` の `cask "anthropics/tap/ant"`、v1.10.0 が `/opt/homebrew/bin/ant`）
だが **shell completion だけ未対応**だった。auth は実行時（`ant auth login`）なので
repo 管理対象外。

## 対応

`.zshrc` に `ant @completion zsh` を追加。repo 既存の kubectl/fzf completion と同じ
**キャッシュ方式**（`${XDG_CACHE_HOME:-$HOME/.cache}/zsh/ant_completion.zsh` に
生成、無い時だけ再生成、compinit 後に source）。`_cmd_exists ant` ガード付きなので
ant 未インストールの shell では no-op。

## 検証

- clean login（`env -i ... zsh -lic`）で:
    - キャッシュ生成（56行）を確認
    - `(( $+functions[__ant_zsh_autocomplete] ))` = completion 関数ロード済みを確認
    - source エラー無し
- `just ci` ✅

配置は CF CLI completions の直後（compinit 後・既存 completion 群の近く）。