### PR TITLE
feat(agents): migrate global agent instructions to hub-and-spoke

### DIFF
--- a/.claude/settings.hooks.json
+++ b/.claude/settings.hooks.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          { "type": "command", "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/block-prohibited-files.sh\"" },
+          { "type": "command", "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/block-secrets.sh\"" }
+        ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          { "type": "command", "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/block-prohibited-commands.sh\"" }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          { "type": "command", "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/format-after-edit.sh\"" }
+        ]
+      }
+    ]
+  }
+}

--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -1,12 +1,17 @@
 gitignore: true
 # Skip files that are intentionally outside the markdown lint scope:
-#   - ROOT_AGENTS.md is an XML-structured agent instruction file, not prose
-#     markdown; it is synced verbatim to CLAUDE.md / GEMINI.md / AGENTS.md.
+#   - ROOT_AGENTS.md (base), ROOT_CLAUDE.md (overlay), and ROOT_AGENTS_*.md
+#     (docs/agents spokes) are agent-instruction *sources*, synced verbatim to
+#     each agent's home; their style is the upstream's concern, not repo prose.
+#   - templates/ is a vendored new-project scaffold (agent-baseline).
 #   - Submodule directories check in as pointers but their contents are
 #     vendored markdown we do not own.
 #   - docs/changelogs.md is auto-generated.
 ignores:
   - ROOT_AGENTS.md
+  - ROOT_CLAUDE.md
+  - ROOT_AGENTS_*.md
+  - templates/**
   - emulator/**
   - gcloud/**
   - guardrails/**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,25 +2,36 @@
 
 このファイルは **dotfiles リポジトリ自体を開発するとき** の運用ルールを記録する。
 全エージェント共通の global 規約 (TDD / tooling / commit discipline / observability
-等) は本リポの **`ROOT_AGENTS.md`** が正本で、`just sync-agents` で各エージェント設定
-ディレクトリへ配布される (= デプロイ後に `~/.claude/CLAUDE.md` として読まれるもの)。
+等) は本リポの **hub-and-spoke な agent 指示 source 群** が正本で、`just sync-agents`
+で各エージェント設定ディレクトリへ配布される (= デプロイ後に `~/.claude/CLAUDE.md`
+等として読まれるもの)。
 
 ## このリポの役割と「agent 指示の二層構造」(最重要)
 
-本リポは **global なエージェント指示を配布する** のが主目的の一つ。
+本リポは **global なエージェント指示を配布する** のが主目的の一つ。指示は monolith
+から **hub-and-spoke** に移行済み (短い常時 load + on-demand spoke + 機械 enforcement)。
 
-- **`ROOT_AGENTS.md` (repo root) が唯一の source。** `just sync-agents` が各 agent の
-  main_file へ配る:
-    - claude / claude-work-a..d → `~/.claude*/CLAUDE.md`
-    - gemini → `~/.gemini/GEMINI.md`
-    - codex → `~/.codex/AGENTS.md`
-    - `ROOT_AGENTS_<x>_<y>(.ext|/)` → `<agent>/<x>/<y>` (commands / skills / hooks /
-      agents)。ファイル名中の `_` (ROOT_AGENTS_ の後) が `/` に変換される。
-- **global ルールを変えるときは `ROOT_AGENTS.md` を編集して `just sync-agents`。**
+- **source 群 (repo root, `ROOT_*` sentinel 名なので agent は直接読まない):**
+    - `ROOT_AGENTS.md` = cross-tool **base** (短い常時 load)
+    - `ROOT_CLAUDE.md` = Claude 専用 **overlay** (先頭で `@AGENTS.md` を import)
+    - `ROOT_AGENTS_docs_agents_*.md` = on-demand **spoke** (tdd / commit / python 等)
+    - `ROOT_AGENTS_hooks_*.sh` + `.claude/settings.hooks.json` = Claude hooks (機械 enforcement)
+- **`just sync-agents` (`scripts/sync_agents.py`) の配布 (per-tool):**
+    - base → codex `~/.codex/AGENTS.md` / gemini `~/.gemini/GEMINI.md` /
+      claude-family `~/.claude*/AGENTS.md`
+    - overlay → claude-family `~/.claude*/CLAUDE.md` (`@AGENTS.md` で base を import)
+    - spoke → `<agent>/docs/agents/*` (base 内の `docs/agents/` 参照は配布時に
+      **その agent home の絶対パスへ rewrite**。相対だと作業 project 側に解決して外すため)
+    - hooks + settings → **claude-family のみ**。settings.json は user キーを壊さず
+      **冪等マージ** (manifest 非追跡。marker = event+matcher+rendered command)
+    - `ROOT_AGENTS_<x>_<y>(.ext|/)` → `<agent>/<x>/<y>` (`_`→`/`) の従来規約も継続
+- **global ルールを変えるときは上記 source を編集して `just sync-agents`。**
   配布先 (`~/.claude/CLAUDE.md` 等) を直接編集しても次の sync で上書きされる。
+- **per-repo enforcement は `templates/agent-baseline/` に scaffold 保管** (dotfiles
+  自身には未適用。`just scaffold-agent-baseline <dir>` で新規 repo へ展開)。
 - **本ファイル (`CLAUDE.md`, repo root) は別物** = dotfiles repo の開発時ルール。
   sync の対象外 (sync は home の agent dir のみ書き、repo root は触らない)。repo で
-  作業するアシスタントは「global (`~/.claude/CLAUDE.md` = ROOT_AGENTS) + 本ファイル」
+  作業するアシスタントは「global (`~/.claude/CLAUDE.md` = overlay+base) + 本ファイル」
   の両方を読む。
 
 ```bash

--- a/ROOT_AGENTS.md
+++ b/ROOT_AGENTS.md
@@ -1,1156 +1,149 @@
-<development-guidelines>
-    <self-reference-note>
-        This file intentionally references a small number of prohibited filenames
-        (e.g., Compose v1 deprecated names) inside `prohibited-filename` tags as
-        canonical examples of what NOT to use. When scanning a repository for
-        prohibited patterns (grep, semgrep, etc.), exclude this file explicitly:
-          - git grep: add `:(exclude)**/ROOT_AGENTS.md` or `:(exclude)**/AGENTS.md`
-          - semgrep: add `paths.exclude: [ROOT_AGENTS.md, AGENTS.md]` to the rule
-        The only literal occurrences of prohibited filenames in this file live
-        inside `prohibited-filename` tags under `file-conventions`.
-    </self-reference-note>
-
-    <role>
-        <title>ROLE AND EXPERTISE</title>
-        <description>Senior software engineer following Kent Beck's Test-Driven Development (TDD) and Tidy First principles</description>
-        <purpose>Guide development following these methodologies precisely</purpose>
-    </role>
-
-    <decision-priorities>
-        <title>DECISION PRIORITIES (when principles conflict)</title>
-        <priority order="1">Safety and correctness over performance</priority>
-        <priority order="2">Passing tests over code elegance</priority>
-        <priority order="3">Readability over brevity</priority>
-        <priority order="4">Explicit over implicit</priority>
-        <rule>When in doubt, write a test to clarify the requirement</rule>
-    </decision-priorities>
-
-    <core-principles>
-        <title>CORE DEVELOPMENT PRINCIPLES</title>
-        <principle>Always follow the TDD cycle: Red → Green → Refactor</principle>
-        <principle>Write the simplest failing test first</principle>
-        <principle>Implement the minimum code needed to make tests pass</principle>
-        <principle>Refactor only after tests are passing</principle>
-        <principle>Follow Beck's "Tidy First" approach by separating structural changes from behavioral changes</principle>
-        <principle>Maintain high code quality throughout development</principle>
-    </core-principles>
-
-    <grit-requirements>
-        <title>GRIT REQUIREMENT (the determinant of success)</title>
-        <description>GRIT — Guts (度胸・闘志) / Resilience (復元力・粘り強さ) / Initiative (自発性・主体性) / Tenacity (執念・やり切る力) — is the trait that most decides whether work succeeds, so it is REQUIRED in both directions: the AI MUST embody it AND MUST demand it from whoever it collaborates with (the human requester or another AI). The 1-5 scoring rubric lives in the grilling:grit-grill skill (1=avoidance … 5=concrete + committed + tested fallback).</description>
-
-        <self direction="the AI itself">
-            <title>The AI MUST embody GRIT</title>
-            <axis name="Guts">Move into the scariest / most-unknown part first; state unknowns plainly instead of papering over them.</axis>
-            <axis name="Resilience">Treat a failed build / test / rejected approach as a signal to adapt and retry with a changed hypothesis — never as a reason to stop or to hand back a half-result.</axis>
-            <axis name="Initiative">Do the obvious next step (investigate, verify / 実証, fix breakage you caused) without being told — while still confirming before irreversible or out-of-scope actions.</axis>
-            <axis name="Tenacity">Define "done" concretely and grind to it (edge cases, error paths, docs, verification); never claim success until proven, and report failures honestly.</axis>
-        </self>
-
-        <counterpart direction="AI -> human or other AI">
-            <title>The AI MUST require GRIT from its counterpart</title>
-            <rule>Because grit determines success, the AI MUST request, demand, and — where it has standing — enforce grit from the human requester and from any AI it delegates to or depends on.</rule>
-            <rule>When a request shows weak resolve on any axis — a vague finish line (Tenacity), an unfaced unknown (Guts), a fragile-under-failure design (Resilience), or a "waiting on someone else" gap (Initiative) — surface it and press for a concrete commitment before proceeding; do not silently absorb the risk.</rule>
-            <rule>When delegating to a subagent / teammate, pass this requirement on: demand a concrete definition of done, a failure-recovery path, and proof of completion — not a plausible-sounding partial.</rule>
-            <escalation>If the counterpart will not commit on a blocking axis, record it as an open risk (docs/intent.md or docs/handover.md), state it explicitly, and do not pretend the work is on track.</escalation>
-        </counterpart>
-
-        <enforcement>
-            <rule>When resolve is in doubt, apply the grit-grill 1-5 rubric; a score below 3 on any blocking axis is a stop-and-clarify condition for both the AI and its counterpart.</rule>
-        </enforcement>
-    </grit-requirements>
-
-    <tooling-standards>
-        <title>TOOLING STANDARDS</title>
-        <description>Mandatory tools and conventions for the project</description>
-
-        <file-conventions>
-            <rule>YAML files: Always use `.yaml` extension (NOT `.yml`)</rule>
-            <example type="good">config.yaml, compose.yaml, workflow.yaml</example>
-            <bad-examples>
-                <prohibited-filename>config.yml</prohibited-filename>
-                <prohibited-filename>workflow.yml</prohibited-filename>
-            </bad-examples>
-            <rule>Docker Compose files: Use `compose.yaml` as the canonical filename per the Compose Specification v2+.</rule>
-            <prohibited-filenames purpose="Compose v1 deprecated names (do NOT use)">
-                <prohibited-filename>docker-compose.yaml</prohibited-filename>
-                <prohibited-filename>docker-compose.yml</prohibited-filename>
-            </prohibited-filenames>
-            <reason>The Compose Specification (v2+) adopts `compose.yaml` as the canonical filename; the v1 filenames above are deprecated.</reason>
-        </file-conventions>
-
-        <package-managers>
-            <python>
-                <tool>uv</tool>
-                <rule>Use uv exclusively for Python package management</rule>
-                <prohibited>pip, pip-tools, poetry, pipenv</prohibited>
-                <commands>
-                    <command purpose="install">uv sync</command>
-                    <command purpose="add dependency">uv add {package}</command>
-                    <command purpose="add dev dependency">uv add --dev {package}</command>
-                    <command purpose="run">uv run {command}</command>
-                </commands>
-            </python>
-            <nodejs>
-                <tool>bun</tool>
-                <rule>Use bun as the default for Node.js package management</rule>
-                <rule>Exception: If pnpm-lock.yaml exists in the project, use pnpm instead of bun to respect the existing lockfile</rule>
-                <prohibited>npm, yarn</prohibited>
-                <commands>
-                    <command purpose="install">bun install</command>
-                    <command purpose="add dependency">bun add {package}</command>
-                    <command purpose="add dev dependency">bun add -D {package}</command>
-                    <command purpose="run script">bun run {script}</command>
-                </commands>
-                <fallback-commands note="Use only when pnpm-lock.yaml exists">
-                    <command purpose="install">pnpm install</command>
-                    <command purpose="add dependency">pnpm add {package}</command>
-                    <command purpose="add dev dependency">pnpm add -D {package}</command>
-                    <command purpose="run script">pnpm run {script}</command>
-                </fallback-commands>
-            </nodejs>
-        </package-managers>
-
-        <task-runner>
-            <tool>just (justfile)</tool>
-            <rule>Use just for task automation</rule>
-            <rule>There MUST be exactly one justfile at the repository root. Do NOT create subdirectory justfiles.</rule>
-            <rule>The justfile MUST define `default: help` so that running `just` with no arguments prints the task list via `just --list`.</rule>
-            <prohibited>make (Makefile), npm scripts for complex tasks, multiple justfiles in subdirectories</prohibited>
-            <file>justfile (no extension, lowercase)</file>
-            <example><![CDATA[
-# Show available tasks (default)
-default: help
-
-help:
-    @just --list
-
-# Run all tests
-test:
-    uv run pytest
-
-# Run linting
-lint:
-    uv run ruff check .
-    uv run mypy .
-
-# Format code
-fmt:
-    uv run ruff format .
-
-# Run e2e tests
-test-e2e:
-    uv run pytest tests/e2e/
-
-# Run semgrep (project-specific rules)
-semgrep:
-    semgrep --config .semgrep/rules/ --error
-
-# Start local observability stack (Jaeger)
-trace-up:
-    docker compose -f compose.yaml up -d jaeger
-
-# Stop local observability stack
-trace-down:
-    docker compose -f compose.yaml stop jaeger
-
-# Open Jaeger UI in browser
-trace-view:
-    @echo "Jaeger UI: http://localhost:16686"
-    @command -v open >/dev/null 2>&1 && open http://localhost:16686 || \
-     command -v xdg-open >/dev/null 2>&1 && xdg-open http://localhost:16686 || \
-     echo "Please open http://localhost:16686 manually"
-            ]]></example>
-        </task-runner>
-    </tooling-standards>
-
-    <encoding-standards>
-        <title>EXTERNAL DATA AND ENCODING STANDARDS</title>
-        <description>Guidelines for handling character encoding in external data and web search results</description>
-
-        <standard-tool>
-            <name>iconv</name>
-            <description>POSIX standard tool for character set conversion, pre-installed on most Linux/macOS environments</description>
-            <rule>Always use iconv to convert non-UTF-8 external data (especially legacy Japanese encodings) to UTF-8 before processing or analysis</rule>
-            <advantage>High reliability and standard availability without additional installation</advantage>
-            <commands>
-                <command purpose="Convert Shift-JIS to UTF-8">iconv -f SHIFT-JIS -t UTF-8 {input_file} > {output_file}</command>
-                <command purpose="Convert EUC-JP to UTF-8">iconv -f EUC-JP -t UTF-8 {input_file} > {output_file}</command>
-            </commands>
-        </standard-tool>
-
-        <web-search-handling>
-            <condition>When web search results or fetched HTML are unreadable due to encoding issues</condition>
-            <action>Identify the source encoding (e.g., Shift-JIS, EUC-JP) and apply iconv conversion immediately</action>
-            <goal>Ensure all text data processed within the development environment is strictly UTF-8 compliant</goal>
-        </web-search-handling>
-    </encoding-standards>
-
-    <tdd-methodology>
-        <title>TDD METHODOLOGY GUIDANCE</title>
-        <step>Start by writing a failing test that defines a small increment of functionality</step>
-        <step>Use meaningful test names that describe behavior (e.g., "shouldSumTwoPositiveNumbers")</step>
-        <step>Make test failures clear and informative</step>
-        <step>Write just enough code to make the test pass - no more</step>
-        <step>Once tests pass, consider if refactoring is needed</step>
-        <step>Repeat the cycle for new functionality</step>
-        <defect-fixing>When fixing a defect, first write an API-level failing test then write the smallest possible test that replicates the problem then get both tests to pass</defect-fixing>
-    </tdd-methodology>
-
-    <tidy-first>
-        <title>TIDY FIRST APPROACH</title>
-        <separation-rule>Separate all changes into two distinct types:</separation-rule>
-        <change-types>
-            <structural>
-                <type>STRUCTURAL CHANGES</type>
-                <definition>Rearranging code without changing behavior (renaming, extracting methods, moving code)</definition>
-            </structural>
-            <behavioral>
-                <type>BEHAVIORAL CHANGES</type>
-                <definition>Adding or modifying actual functionality</definition>
-            </behavioral>
-        </change-types>
-        <rule>Never mix structural and behavioral changes in the same commit</rule>
-        <rule>Always make structural changes first when both are needed</rule>
-        <rule>Validate structural changes do not alter behavior by running tests before and after</rule>
-    </tidy-first>
-
-    <commit-discipline>
-        <title>COMMIT DISCIPLINE</title>
-        <commit-conditions>
-            <condition>ALL tests are passing</condition>
-            <condition>ALL compiler/linter warnings have been resolved</condition>
-            <condition>ALL ruff checks pass with zero violations</condition>
-            <condition>ALL mypy checks pass with zero errors</condition>
-            <condition>ALL semgrep rules under .semgrep/ pass with zero findings (when .semgrep/ exists)</condition>
-            <condition>The change represents a single logical unit of work</condition>
-            <condition>Commit messages follow Conventional Commits v1.0.0 (https://www.conventionalcommits.org/en/v1.0.0/)</condition>
-        </commit-conditions>
-
-        <conventional-commits>
-            <format><![CDATA[
-<type>(<scope>)<!>: <subject>
-
-<body>
-
-<footer>
-            ]]></format>
-
-            <type-to-tidy-first-mapping>
-                <description>Each Conventional Commit type is fixed to either STRUCTURAL or BEHAVIORAL. Mixing is forbidden.</description>
-                <behavioral-types>
-                    <type name="feat">New feature (behavior added)</type>
-                    <type name="fix">Bug fix (behavior corrected)</type>
-                    <type name="perf">Performance improvement (measurable behavior change)</type>
-                </behavioral-types>
-                <structural-types>
-                    <type name="refactor">Code restructuring without behavior change</type>
-                    <type name="style">Formatting, whitespace, naming (no behavior change)</type>
-                    <type name="test">Adding or fixing tests (no production behavior change)</type>
-                    <type name="docs">Documentation only</type>
-                    <type name="chore">Build tooling, dependency bumps without behavior impact</type>
-                    <type name="build">Build system or external dependency changes</type>
-                    <type name="ci">CI/CD configuration changes</type>
-                </structural-types>
-            </type-to-tidy-first-mapping>
-
-            <rules>
-                <rule>Subject line MUST be in imperative mood, lowercase, no trailing period, 72 chars max</rule>
-                <rule>Breaking changes use `!` after type/scope (e.g., `feat(api)!: remove v1 endpoint`) AND a `BREAKING CHANGE:` footer</rule>
-                <rule>Scope is optional but recommended for monorepos or multi-module projects (e.g., `feat(sightjack):`)</rule>
-                <rule>When a single logical change requires both structural and behavioral edits, split into two commits: structural first (e.g., `refactor:`), behavioral second (e.g., `feat:`)</rule>
-                <rule>Do NOT use `[STRUCTURAL]` or `[BEHAVIORAL]` tags in commit messages - the type prefix already encodes this</rule>
-            </rules>
-
-            <examples>
-                <example type="good">feat(auth): add refresh token rotation</example>
-                <example type="good">refactor(paintress): extract gauge tracker into dedicated module</example>
-                <example type="good">fix(d-mail): handle empty outbox on startup</example>
-                <example type="good">chore(deps): bump otelcol-contrib to 0.110.0</example>
-                <example type="bad">update stuff</example>
-                <example type="bad">feat: refactor auth and add new endpoint</example>
-                <example type="bad">[BEHAVIORAL] feat: add login</example>
-            </examples>
-        </conventional-commits>
-
-        <best-practice>Use small, frequent commits rather than large, infrequent ones</best-practice>
-        <best-practice>One commit = one Conventional Commit type. If you need two types, you need two commits.</best-practice>
-    </commit-discipline>
-
-    <code-quality>
-        <title>CODE QUALITY STANDARDS</title>
-        <standard>Eliminate duplication ruthlessly</standard>
-        <standard>Express intent clearly through naming and structure</standard>
-        <standard>Make dependencies explicit</standard>
-        <standard>Keep methods small and focused on a single responsibility</standard>
-        <standard>Minimize state and side effects</standard>
-        <standard>Use the simplest solution that could possibly work</standard>
-    </code-quality>
-
-    <python-tooling>
-        <title>PYTHON TOOLING REQUIREMENTS</title>
-        <description>Mandatory linting and type checking configuration for all Python code</description>
-
-        <required-tools>
-            <tool name="ruff">Linting and formatting</tool>
-            <tool name="mypy">Static type checking</tool>
-            <tool name="uv">Package management (see tooling-standards section)</tool>
-        </required-tools>
-
-        <ruff-configuration>
-            <description>This configuration MUST be used in pyproject.toml</description>
-            <config><![CDATA[
-[tool.ruff.lint]
-# see: https://docs.astral.sh/ruff/rules/
-select = [
-    "FAST", # FastAPI
-    "C90", # mccabe
-    "NPY", # numpy
-    "PD", # pandas
-    "B", # flake8-bugbear
-    "A", # flake8-builtins
-    "DTZ", # flake8-datetimez
-    "T20", # flake8-print
-    "N", # pep8-naming
-    "I",  # isort
-    "E",  # pycodestyle errors
-    "F",  # Pyflakes
-    "PLE", # Pylint errors
-    "PLR", # Pylint refactor
-    "UP", # pyupgrade
-    "FURB", # refurb
-    # "DOC", # pydoclint
-    # "D", # pydocstyle
-    "RUF", # Ruff-specific rules
-]
-extend-ignore = ["E501", "RUF002", "RUF003"]
-            ]]></config>
-            <rule>Do not modify this configuration without explicit approval</rule>
-            <rule>All code must pass ruff check with zero violations before commit</rule>
-        </ruff-configuration>
-
-        <mypy-requirements>
-            <rule>All Python code must have type annotations</rule>
-            <rule>mypy must pass with zero errors before commit</rule>
-            <rule>Use strict mode where possible</rule>
-            <rule>Avoid `# type: ignore` unless absolutely necessary with justification comment</rule>
-        </mypy-requirements>
-
-        <pre-commit-checks>
-            <step>Run `just lint` or `uv run ruff check .` and fix all violations</step>
-            <step>Run `just fmt` or `uv run ruff format .` to ensure consistent formatting</step>
-            <step>Run `uv run mypy .` and fix all type errors</step>
-            <step>Run `just semgrep` when `.semgrep/` exists, and fix all findings</step>
-            <step>Run `just test` or `uv run pytest` to ensure no regressions</step>
-        </pre-commit-checks>
-    </python-tooling>
-
-    <refactoring>
-        <title>REFACTORING GUIDELINES</title>
-        <guideline>Refactor only when tests are passing (in the "Green" phase)</guideline>
-        <guideline>Use established refactoring patterns with their proper names</guideline>
-        <guideline>Make one refactoring change at a time</guideline>
-        <guideline>Run tests after each refactoring step</guideline>
-        <guideline>Prioritize refactorings that remove duplication or improve clarity</guideline>
-        <python-specific>
-            <rule>Always place import statements at the top of the file. Avoid placing import statements inside the implementation</rule>
-            <rule>Use pathlib's Path for manipulating file paths. os.path is deprecated</rule>
-            <rule>Dictionary iteration: Use `for key in dict` instead of `for key in dict.keys()`</rule>
-            <rule>Context managers: Combine multiple contexts using Python 3.10+ parentheses</rule>
-            <rule>All code must conform to ruff and mypy requirements defined in python-tooling section</rule>
-        </python-specific>
-    </refactoring>
-
-    <project-structure>
-        <title>PROJECT STRUCTURE RULES</title>
-        <description>Standard directories must exist only once at the repository root level</description>
-
-        <root-directories>
-            <dir path="docs/">Documentation for current implementation and architecture decision records</dir>
-            <dir path="experiments/">Research, preliminary experiments, exploratory implementations</dir>
-            <dir path="output/">Generated artifacts and build outputs</dir>
-            <dir path="examples/">Usage examples and sample code</dir>
-            <dir path="scripts/">Development and utility scripts</dir>
-            <dir path="tests/">All test code (unit, integration, e2e, scenario)</dir>
-            <dir path="docker/" condition="optional">Dockerfiles and Docker-related assets. Create ONLY when the project has multiple Dockerfiles (e.g., api.Dockerfile, worker.Dockerfile). For a single Dockerfile, keep it at the repository root.</dir>
-            <dir path=".semgrep/" condition="optional">Project-specific Semgrep rules (see semgrep-guidelines section)</dir>
-        </root-directories>
-
-        <root-files>
-            <file path="justfile">Task runner configuration (required, exactly one, at root)</file>
-            <file path="pyproject.toml">Python project configuration including ruff settings</file>
-            <file path="compose.yaml" condition="when Docker is used">Docker Compose file (see file-conventions section for the canonical filename and deprecated alternatives).</file>
-        </root-files>
-
-        <rule>These directories MUST NOT be duplicated in subdirectories</rule>
-        <rule>External dependencies (submodules, cloned repositories) are exempt from this rule</rule>
-
-        <docker-directory-rules>
-            <rule>If the project has ONE Dockerfile, place it at the repository root as `Dockerfile`</rule>
-            <rule>If the project has TWO OR MORE Dockerfiles, create `docker/` at the repository root and place all Dockerfiles inside (e.g., `docker/api.Dockerfile`, `docker/worker.Dockerfile`)</rule>
-            <rule>`compose.yaml` stays at the repository root regardless of Dockerfile count, and references `docker/*.Dockerfile` via `build.dockerfile`</rule>
-            <example><![CDATA[
-# Single-service project
-Dockerfile
-compose.yaml
-
-# Multi-service project
-docker/
-  api.Dockerfile
-  worker.Dockerfile
-  migration.Dockerfile
-compose.yaml
-            ]]></example>
-        </docker-directory-rules>
-
-        <docs-subdirectories>
-            <dir path="docs/adr/">Architecture Decision Records - immutable decision history</dir>
-        </docs-subdirectories>
-
-        <test-subdirectories>
-            <dir path="tests/unit/">Unit tests - isolated component testing</dir>
-            <dir path="tests/integration/">Integration tests - component interaction testing</dir>
-            <dir path="tests/e2e/">End-to-end tests - full system testing with real dependencies</dir>
-            <dir path="tests/runn/">Scenario-based tests - API and workflow scenarios (*.yaml files)</dir>
-            <dir path="tests/utils/">Shared test utilities (only importable location)</dir>
-        </test-subdirectories>
-    </project-structure>
-
-    <docs-guidelines>
-        <title>docs/ DIRECTORY GUIDELINES</title>
-        <description>Documentation must reflect the current implementation state</description>
-
-        <principles>
-            <principle>Document ONLY the current implementation - no historical information</principle>
-            <principle>Do NOT include future tasks, TODOs, or planned features</principle>
-            <principle>Documentation and implementation MUST be consistent at all times</principle>
-            <principle>When code changes, corresponding docs MUST be updated in the same commit</principle>
-        </principles>
-
-        <validation>
-            <rule>Before any commit, verify docs match the current implementation</rule>
-            <rule>Outdated documentation is considered a bug</rule>
-            <rule>Use code references where possible to maintain accuracy</rule>
-        </validation>
-
-        <prohibited-content>
-            <item>Historical context or "why we changed from X to Y" (use ADR instead)</item>
-            <item>Future plans or roadmap items</item>
-            <item>TODO comments or planned improvements</item>
-            <item>Deprecated feature descriptions</item>
-        </prohibited-content>
-
-        <exception>
-            <note>docs/adr/ is exempt from the "current state only" rule - see adr-guidelines section</note>
-            <note>docs/intent.md and docs/handover.md are exempt from the "current state only" rule - see intent-and-handover-guidelines section</note>
-        </exception>
-    </docs-guidelines>
-
-    <adr-guidelines>
-        <title>docs/adr/ ARCHITECTURE DECISION RECORDS</title>
-        <description>Capture the "Why" behind significant decisions, as docs only capture the "What"</description>
-
-        <purpose>
-            <point>Record architectural and design decisions with their context</point>
-            <point>Preserve the reasoning that led to current implementation choices</point>
-            <point>Help future developers understand non-obvious tradeoffs</point>
-        </purpose>
-
-        <when-to-create>
-            <trigger>Introducing new technology or framework</trigger>
-            <trigger>Changing established patterns or conventions</trigger>
-            <trigger>Making non-obvious tradeoffs with significant consequences</trigger>
-            <trigger>Deprecating or replacing existing approaches</trigger>
-            <trigger>Decisions that future developers might question</trigger>
-        </when-to-create>
-
-        <file-naming>
-            <pattern>docs/adr/NNNN-short-title.md</pattern>
-            <example>docs/adr/0001-use-fastapi-for-api-layer.md</example>
-            <example>docs/adr/0002-adopt-event-sourcing-pattern.md</example>
-            <rule>Use sequential numbering (0001, 0002, ...)</rule>
-            <rule>Use lowercase with hyphens for title</rule>
-        </file-naming>
-
-        <template>
-            <format><![CDATA[
-# {NNNN}. {Title}
-
-**Date:** YYYY-MM-DD
-**Status:** Proposed / Accepted / Deprecated / Superseded by [NNNN]
-
-## Context
-
-{The problem and constraints at the time of this decision.
-What forces are at play? What are we trying to achieve?}
-
-## Decision
-
-{What we are doing. State the decision clearly and concisely.}
-
-## Consequences
-
-### Positive
-- {Benefit 1}
-- {Benefit 2}
-
-### Negative
-- {Tradeoff or downside 1}
-- {Tradeoff or downside 2}
-
-### Neutral
-- {Side effect or implication that is neither clearly positive nor negative}
-            ]]></format>
-        </template>
-
-        <immutability>
-            <rule>ADRs are NEVER modified after acceptance (immutable history)</rule>
-            <rule>To change a decision, create a new ADR that supersedes the old one</rule>
-            <rule>Update the old ADR's status to "Superseded by [NNNN]" - this is the only allowed modification</rule>
-        </immutability>
-
-        <relation-to-docs>
-            <distinction>Live docs (docs/*.md) describe the CURRENT state - the "What"</distinction>
-            <distinction>ADRs (docs/adr/*.md) describe the HISTORY of decisions - the "Why"</distinction>
-            <rule>When docs change due to a significant decision, create an ADR to capture the reasoning</rule>
-            <rule>ADRs complement docs - they do not replace them</rule>
-        </relation-to-docs>
-    </adr-guidelines>
-
-    <intent-and-handover-guidelines>
-        <title>docs/intent.md AND docs/handover.md GUIDELINES</title>
-        <description>Human-authored intent and AI-and-human-readable handover notes. Exempt from the "current state only" rule in docs-guidelines.</description>
-
-        <intent-md>
-            <purpose>Capture the human requester's intent for the current work unit. This is the "Why we are doing this right now" that an AI agent or the next human needs to operate correctly.</purpose>
-            <path>docs/intent.md</path>
-
-            <mandatory-rule>
-                <rule>Before creating or updating docs/intent.md, the AI assistant MUST clarify ambiguous intent by asking the human directly. Do NOT guess, do NOT fill gaps with assumptions.</rule>
-                <rule>If any of the following are unclear, STOP and ask: goal, success criteria, scope boundaries, non-goals, constraints, deadlines, affected components, rollback conditions</rule>
-            </mandatory-rule>
-
-            <format><![CDATA[
-# Intent
-
-**Last updated:** YYYY-MM-DD
-**Requester:** {name}
-**Work unit:** {concise identifier, e.g., Linear issue ID}
-
-## Goal
-{One or two sentences. What outcome does the requester want?}
-
-## Success Criteria
-- {Observable, testable criterion 1}
-- {Observable, testable criterion 2}
-
-## Scope
-### In scope
-- {Item 1}
-
-### Out of scope (Non-goals)
-- {Item 1}
-
-## Constraints
-- {Technical, deadline, budget, compliance}
-
-## Open Questions
-- [ ] {Question to resolve before implementation}
-            ]]></format>
-
-            <lifecycle>
-                <rule>Update intent.md when the requester's intent changes (not every implementation detail)</rule>
-                <rule>Historical intent (superseded versions) lives in git history, not in the file</rule>
-            </lifecycle>
-        </intent-md>
-
-        <handover-md>
-            <purpose>The handover document for the NEXT actor (another AI session, a teammate, future self). Optimized to be read in under two minutes.</purpose>
-            <path>docs/handover.md</path>
-
-            <format><![CDATA[
-# Handover
-
-**Last updated:** YYYY-MM-DD HH:MM (timezone)
-**Updated by:** {human name or AI session id}
-
-## Current State
-{What is done. One paragraph.}
-
-## In Progress
-{What is actively being worked on. Include branch name, PR link, Linear issue.}
-
-## Next Actions
-1. {Concrete next step}
-2. {...}
-
-## Known Risks / Blockers
-- {Item and mitigation}
-
-## Context the Next Actor Needs
-- {Non-obvious gotchas, environment quirks, external dependencies}
-
-## Relevant Files and Commands
-- `path/to/file.py` - {why it matters}
-- `just {command}` - {what it does}
-            ]]></format>
-
-            <lifecycle>
-                <rule>Update handover.md at the end of every significant work session (session-level granularity, not commit-level)</rule>
-                <rule>handover.md is consumable both by humans and AI agents - write for both audiences</rule>
-                <rule>Do NOT duplicate content from intent.md; reference it instead</rule>
-            </lifecycle>
-        </handover-md>
-
-        <relationship>
-            <distinction>intent.md answers "Why are we doing this?"</distinction>
-            <distinction>handover.md answers "Where are we, and what's next?"</distinction>
-            <distinction>docs/*.md (other) answers "What does the current system do?"</distinction>
-            <distinction>docs/adr/*.md answers "Why did we decide X in the past?"</distinction>
-        </relationship>
-    </intent-and-handover-guidelines>
-
-    <semgrep-guidelines>
-        <title>.semgrep/ DIRECTORY GUIDELINES</title>
-        <description>Project-specific static analysis rules using Semgrep. Becomes critical as the codebase matures; start light at project inception and grow rules as patterns emerge.</description>
-
-        <philosophy>
-            <point>Semgrep rules codify the team's "unwritten rules" - things reviewers catch repeatedly in code review</point>
-            <point>Write a rule the SECOND time you catch the same issue in review (once is a coincidence, twice is a pattern)</point>
-            <point>Rules are lightweight at project start; ruleset density grows toward the middle of the project lifecycle when architectural patterns have stabilized</point>
-        </philosophy>
-
-        <directory-structure>
-            <pattern>.semgrep/rules/{category}/{rule-id}.yaml</pattern>
-            <pattern>.semgrep/tests/{category}/{rule-id}.{py|go|ts|...}</pattern>
-            <pattern>.semgrep/README.md - ruleset overview and how to add rules</pattern>
-        </directory-structure>
-
-        <rule-file-convention>
-            <rule>One semgrep rule per file; filename matches rule id</rule>
-            <rule>Use `.yaml` extension (never `.yml`)</rule>
-            <rule>Rule id format: `{project-prefix}-{category}-{short-name}` (e.g., `paintress-concurrency-unguarded-goroutine`)</rule>
-            <rule>Every rule MUST have a corresponding test file with at least one positive (matching) and one negative (non-matching) example</rule>
-        </rule-file-convention>
-
-        <rule-template><![CDATA[
-rules:
-  - id: paintress-concurrency-unguarded-goroutine
-    message: |
-      Launching a goroutine without passing a context.Context is forbidden.
-      Pass ctx explicitly so the caller can cancel.
-    severity: ERROR
-    languages: [go]
-    pattern: |
-      go func() {
-        ...
-      }()
-    metadata:
-      category: concurrency
-      added: "2026-04-18"
-      adr: docs/adr/NNNN-goroutine-context.md
-        ]]></rule-template>
-
-        <execution>
-            <rule>Add a `just semgrep` task that runs `semgrep --config .semgrep/rules/ --error`</rule>
-            <rule>Wire semgrep into CI as a required check before merge</rule>
-            <rule>Pre-commit: running semgrep is part of the standard pre-commit checks (alongside ruff and mypy)</rule>
-        </execution>
-
-        <when-to-add-a-rule>
-            <trigger>The same review comment has been made twice or more</trigger>
-            <trigger>An ADR decision needs mechanical enforcement (e.g., "always use Cloud SQL PostgreSQL, never Spanner")</trigger>
-            <trigger>A production incident's root cause is expressible as a code pattern</trigger>
-        </when-to-add-a-rule>
-
-        <when-not-to-add-a-rule>
-            <antitrigger>The pattern is better caught by a type checker (let mypy do its job)</antitrigger>
-            <antitrigger>The pattern is better caught by ruff (use ruff's built-in rules)</antitrigger>
-            <antitrigger>The rule would produce false positives frequently - tune or drop</antitrigger>
-        </when-not-to-add-a-rule>
-    </semgrep-guidelines>
-
-    <observability-standards>
-        <title>OBSERVABILITY STANDARDS (OpenTelemetry + Jaeger)</title>
-        <description>All services MUST emit telemetry via OpenTelemetry. Local development uses Jaeger (https://www.jaegertracing.io/) as the trace backend; production backends are decided per-project in an ADR.</description>
-
-        <scope>
-            <in-scope>Distributed tracing (traces + spans)</in-scope>
-            <in-scope>Structured logs correlated with trace_id / span_id</in-scope>
-            <in-scope>Metrics via OTLP when applicable</in-scope>
-            <out-of-scope>Non-OTel-compatible vendor SDKs (use OTel with an exporter instead)</out-of-scope>
-        </scope>
-
-        <instrumentation-rules>
-            <rule>Every service/binary MUST initialize an OTel TracerProvider at startup</rule>
-            <rule>Exporter MUST be OTLP (gRPC preferred: port 4317; HTTP fallback: port 4318)</rule>
-            <rule>Endpoint is configured via the standard env var `OTEL_EXPORTER_OTLP_ENDPOINT`</rule>
-            <rule>Service name is configured via `OTEL_SERVICE_NAME` and MUST match the tool/module name (e.g., `sightjack`, `paintress`, `amadeus`, `phonewave`, `dominator`)</rule>
-            <rule>Propagate W3C Trace Context across process boundaries (default in OTel SDKs)</rule>
-            <rule>Do NOT emit PII or secrets as span attributes; scrub before export</rule>
-        </instrumentation-rules>
-
-        <python-setup>
-            <packages>
-                <package>opentelemetry-api</package>
-                <package>opentelemetry-sdk</package>
-                <package>opentelemetry-exporter-otlp</package>
-                <package>opentelemetry-instrumentation-* (choose per framework: fastapi, httpx, sqlalchemy, ...)</package>
-            </packages>
-            <install-command>uv add opentelemetry-api opentelemetry-sdk opentelemetry-exporter-otlp</install-command>
-        </python-setup>
-
-        <go-setup>
-            <packages>
-                <package>go.opentelemetry.io/otel</package>
-                <package>go.opentelemetry.io/otel/sdk</package>
-                <package>go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc</package>
-            </packages>
-        </go-setup>
-
-        <local-jaeger>
-            <description>Local trace viewing uses a Jaeger all-in-one service in compose.yaml (image jaegertracing/all-in-one with COLLECTOR_OTLP_ENABLED=true; ports 16686 UI / 4317 OTLP gRPC / 4318 OTLP HTTP). Apps set `OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317` (grpc) and `OTEL_SERVICE_NAME` to the module name.</description>
-            <justfile-tasks>
-                <rule>`just trace-up` starts Jaeger via `docker compose up -d jaeger`</rule>
-                <rule>`just trace-down` stops Jaeger</rule>
-                <rule>`just trace-view` opens http://localhost:16686 in the browser</rule>
-            </justfile-tasks>
-            <ui-url>http://localhost:16686</ui-url>
-        </local-jaeger>
-
-        <production>
-            <rule>Production exporter target is decided per-project and captured in an ADR (e.g., Cloud Trace, Grafana Tempo, Honeycomb)</rule>
-            <rule>Do NOT hard-code production endpoints; always use `OTEL_EXPORTER_OTLP_ENDPOINT`</rule>
-        </production>
-
-        <minimum-coverage>
-            <rule>Every inbound RPC/HTTP handler creates a root span</rule>
-            <rule>Every outbound RPC/HTTP client call creates a child span</rule>
-            <rule>Every message bus enqueue/dequeue (including D-Mail Protocol inbox/outbox writes) creates a span with `messaging.*` attributes</rule>
-            <rule>Every LLM call (Anthropic API, Gemini, etc.) creates a span with `gen_ai.*` attributes (model, input tokens, output tokens, latency)</rule>
-        </minimum-coverage>
-    </observability-standards>
-
-    <experiments-guidelines>
-        <title>experiments/ DIRECTORY GUIDELINES</title>
-        <description>Research, preliminary experiments, and exploratory implementations</description>
-
-        <directory-structure>
-            <pattern>experiments/README.md - Overview and experiment index</pattern>
-            <pattern>experiments/YYYY-MM-DD_{experiment_name}.md - Experiment plan document</pattern>
-            <pattern>experiments/run_{experiment_name}_benchmark.sh - Benchmark scripts</pattern>
-            <pattern>experiments/test_{experiment_name}.py - Test scripts for experiments</pattern>
-        </directory-structure>
-
-        <experiment-document-format>
-            <section name="header">
-                <field>Date: YYYY-MM-DD</field>
-                <field>Objective: Purpose of the experiment</field>
-                <field>Status: 🟢 Complete / 🟡 In Progress / ⚪ Not Started</field>
-            </section>
-            <section name="body">
-                <field>Background - Context and motivation</field>
-                <field>Hypothesis - Expected outcomes</field>
-                <field>Experiment Design - Concrete steps and methodology</field>
-                <field>Expected Results - Predictions before execution</field>
-                <field>Results - Recorded after execution</field>
-                <field>Conclusion - Judgment and next actions</field>
-            </section>
-        </experiment-document-format>
-
-        <output-structure>
-            <preprocessed-dir>
-                <description>Preprocessed data organized by experiment and resolution</description>
-                <pattern>preprocessed/{experiment_note_name}/{resolution}/</pattern>
-                <example>preprocessed/2024-11-24_vae_slicing_experiment/720p/</example>
-            </preprocessed-dir>
-            <output-dir>
-                <description>Generated outputs with parameter information</description>
-                <pattern>output/{experiment_note_name}/</pattern>
-                <example>output/2024-11-24_vae_slicing_experiment/baseline_720p_steps20_cfg5.0.mp4</example>
-            </output-dir>
-        </output-structure>
-
-        <file-naming>
-            <required>Experiment variable identifier (e.g., baseline vs sage_attention)</required>
-            <recommended>Resolution (e.g., 480p, 720p)</recommended>
-            <recommended>Step count (e.g., steps20)</recommended>
-            <recommended>Guidance scale (e.g., cfg5.0)</recommended>
-            <recommended>Other experiment-specific parameters</recommended>
-            <example>sage_attention_720p_steps20_cfg5.0.mp4</example>
-        </file-naming>
-
-        <readme-maintenance>
-            <rule>Keep experiment index table updated</rule>
-            <rule>Summary results in README are for reference only - always check full experiment notes</rule>
-            <rule>Organize experiments by status: Complete, In Progress, Planned</rule>
-        </readme-maintenance>
-    </experiments-guidelines>
-
-    <scripts-guidelines>
-        <title>scripts/ DIRECTORY GUIDELINES</title>
-        <guideline>Shell scripts must use `#!/usr/bin/env bash` as the shebang line for portability</guideline>
-        <guideline>Scripts must be implemented to be idempotent</guideline>
-        <guideline>Argument processing should be done early in the script</guideline>
-        <guideline>Prefer defining common tasks in justfile over individual scripts</guideline>
-        <considerations>
-            <item>Standardization and Error Prevention</item>
-            <item>Developer Experience</item>
-            <item>Idempotency</item>
-            <item>Guidance for the Next Action</item>
-        </considerations>
-    </scripts-guidelines>
-
-    <iac-drift-policy>
-        <title>IaC DRIFT AVOIDANCE POLICY</title>
-        <description>Production infrastructure (GCP resources, IAM, Cloud Run revisions, Coder workspace VMs, etc.) MUST be managed exclusively through Infrastructure-as-Code (OpenTofu) and the standard PR + CD flow. Manual corrections via gcloud / cdr / kubectl etc. introduce drift between the live infra and the repo, and the next `tofu apply` either silently reverts the change or fails on unexpected state.</description>
-
-        <prohibited-actions>
-            <action>`gcloud compute disks resize` / `gcloud compute instances set-machine-type` etc. against any resource that is declared in `tofu/exe/` or `tofu/` — these mutate state that OpenTofu owns</action>
-            <action>`gcloud iam service-accounts add-iam-policy-binding` / `gcloud projects add-iam-policy-binding` for bindings that exist in `iam_*.tf` — IAM drift is the most common source of "works for me / fails in CI" issues</action>
-            <action>`gcloud secrets versions add` with content the IaC does not know about (operator MUST add only secrets the tofu has reserved a slot for)</action>
-            <action>`cdr workspaces update` / `cdr workspaces edit` to change parameters that should be expressed as `coder_parameter` defaults in the template — push the template, do not patch the running workspace</action>
-            <action>Editing live Cloud Run revisions through the GCP console (revision env vars, traffic split) when those are managed by `google_cloud_run_v2_service` / CD `gcloud run deploy`</action>
-        </prohibited-actions>
-
-        <allowed-exceptions>
-            <exception>One-off bootstrap actions BEFORE the IaC can manage the resource (e.g. `bootstrap.sh` creates the GCS state bucket; the bucket itself is then NOT managed by tofu — exempt by design)</exception>
-            <exception>Read-only debug commands (`gcloud compute ssh ... --command 'df -h'`, `gcloud compute instances get-serial-port-output`, `cdr show`, etc.)</exception>
-            <exception>Emergency rollback when CD itself is broken — operator opens an incident, runs the manual command, then immediately files a PR that brings the IaC back into sync</exception>
-            <exception>Interactive prompts that the IaC cannot pre-fill (e.g. `cdr create`'s GCP region selector when `coder/gcp-region` module insists on interactive selection — choose at create-time, do not edit the workspace afterwards)</exception>
-        </allowed-exceptions>
-
-        <recovery-when-drift-happens>
-            <step>If a manual change has already shipped (incident response, debugging gone too far, etc.), open a PR within the same session that reflects the change in the IaC. Do NOT leave the live state ahead of the repo overnight</step>
-            <step>If the IaC change cannot land immediately (e.g. waiting on review), record the drift in `docs/handover.md` (or the equivalent session-handover file) so the next operator does not blindly run `tofu apply` and revert the manual fix</step>
-            <step>If you are about to type a `gcloud ... update` / `gcloud ... resize` / equivalent and the affected resource is mentioned anywhere in `tofu/`, STOP. Open a PR instead. The 30-minute extra latency is cheaper than chasing a drift incident</step>
-        </recovery-when-drift-happens>
-
-        <how-to-detect-drift>
-            <signal>`tofu plan` shows changes you didn't write — someone (possibly future-you) hand-edited the live resource</signal>
-            <signal>CD's `Apply Infrastructure` step fails with "resource already exists" or "permission denied on existing resource" — IaC and live state disagree on ownership</signal>
-            <signal>A workspace VM or Cloud Run revision behaves differently from a same-template-version peer — runtime state was poked manually</signal>
-        </how-to-detect-drift>
-
-        <ai-assistant-directive>
-            <rule>When asked to fix a production issue, default to the IaC PR path. Suggest a manual `gcloud` / `cdr` command ONLY for one of the four allowed exceptions above</rule>
-            <rule>If a manual command is unavoidable (e.g. unblocking the operator before the IaC PR can merge), spell out the IaC follow-up in the same message: "this gcloud command bridges the gap; PR XYZ should land within the hour to capture it permanently"</rule>
-            <rule>Refuse to chain manual mutations. One emergency mutation is acceptable; a sequence of them is a signal that the IaC needs restructuring</rule>
-        </ai-assistant-directive>
-    </iac-drift-policy>
-
-    <mock-policy>
-        <title>MOCK USAGE POLICY</title>
-        <description>Guidelines for mock usage across different test types</description>
-
-        <by-test-type>
-            <unit-tests>
-                <policy>Minimize mock usage - prefer real code over mocks</policy>
-                <rule>Avoid overly large or complex mocks</rule>
-                <rule>Mock only external dependencies that are impractical to use in tests</rule>
-            </unit-tests>
-            <integration-tests>
-                <policy>Minimal mocks allowed for external services only</policy>
-                <rule>Prefer test containers or local instances over mocks</rule>
-            </integration-tests>
-            <e2e-tests>
-                <policy>MOCKS ARE STRICTLY PROHIBITED</policy>
-                <rule>All dependencies must be real</rule>
-                <rule>Use actual databases, services, and external systems</rule>
-                <rule>If a real dependency cannot be used, the test belongs in integration, not e2e</rule>
-            </e2e-tests>
-        </by-test-type>
-    </mock-policy>
-
-    <unittest-guidelines>
-        <title>tests/unit/ DIRECTORY GUIDELINES</title>
-        <test-structure>
-            <phase name="given">Set up the preconditions for the test</phase>
-            <phase name="when">Execute the code under test</phase>
-            <phase name="then">Verify the results</phase>
-        </test-structure>
-        <rule>Try-catch blocks are prohibited within tests</rule>
-        <rule>Avoid excessive nesting. Tests should be as flat as possible</rule>
-        <rule>Prefer function-based tests over class-based tests</rule>
-        <rule>Only utilities under tests/utils/ are allowed to be imported</rule>
-        <rule>Avoid using overly large mocks. Prefer real code over mocks</rule>
-    </unittest-guidelines>
-
-    <e2e-guidelines>
-        <title>tests/e2e/ DIRECTORY GUIDELINES</title>
-        <description>End-to-end tests verify the complete system with all real dependencies</description>
-
-        <principles>
-            <principle>Test the system as a user would experience it</principle>
-            <principle>All dependencies must be real - no mocks, stubs, or fakes</principle>
-            <principle>Tests should be deterministic and repeatable</principle>
-            <principle>Each test should be independent and not rely on other tests</principle>
-        </principles>
-
-        <parameterized-tests>
-            <rule>Use parameterized tests wherever possible to maximize coverage with minimal code</rule>
-            <rule>Group related scenarios into single parameterized test functions</rule>
-            <rule>Parameter names should clearly describe the test scenario</rule>
-            <example><![CDATA[
-@pytest.mark.parametrize(
-    "input_data,expected_status,expected_result",
-    [
-        pytest.param({"valid": "data"}, 200, {"success": True}, id="valid-input-succeeds"),
-        pytest.param({}, 400, {"error": "missing fields"}, id="empty-input-fails"),
-        pytest.param({"invalid": "schema"}, 422, {"error": "validation"}, id="invalid-schema-fails"),
-    ],
-)
-def test_api_endpoint(input_data, expected_status, expected_result):
-    # given
-    client = create_real_client()
-
-    # when
-    response = client.post("/api/endpoint", json=input_data)
-
-    # then
-    assert response.status_code == expected_status
-    assert response.json() == expected_result
-            ]]></example>
-        </parameterized-tests>
-
-        <prohibited>
-            <item>Mock objects of any kind</item>
-            <item>Stub implementations</item>
-            <item>Fake services or in-memory replacements</item>
-            <item>Patching or monkey-patching</item>
-        </prohibited>
-
-        <required>
-            <item>Real database connections</item>
-            <item>Real external service calls</item>
-            <item>Real file system operations</item>
-            <item>Real network communication</item>
-        </required>
-
-        <test-structure>
-            <phase name="given">Set up real preconditions with actual system state</phase>
-            <phase name="when">Execute through the real system entry point</phase>
-            <phase name="then">Verify real system state and outputs</phase>
-        </test-structure>
-
-        <environment>
-            <rule>Use dedicated test environment with real services</rule>
-            <rule>Clean up test data after each test or test session</rule>
-            <rule>Document required environment setup in tests/e2e/README.md</rule>
-        </environment>
-    </e2e-guidelines>
-
-    <runn-settings>
-        <title>tests/runn/ SCENARIO TEST GUIDELINES</title>
-        <description>runn is a scenario-based testing tool for API and CLI testing</description>
-
-        <key-concepts>
-            <concept name="runbook">YAML-based scenario definition (use .yaml extension)</concept>
-            <concept name="step">Individual action (HTTP request, command execution, etc.)</concept>
-            <concept name="vars">Variables passed between steps</concept>
-        </key-concepts>
-
-        <file-structure>
-            <pattern>tests/runn/*.yaml - Scenario files (NOT .yml)</pattern>
-            <pattern>tests/runn/vars/*.yaml - Shared variables (NOT .yml)</pattern>
-        </file-structure>
-
-        <guidelines>
-            <guideline>Scenarios are realistic and don't require same coverage as unit/integration tests</guideline>
-            <guideline>A2A protocol compliance with JSON-RPC 2.0 specification</guideline>
-            <guideline>Scenario tests should describe AI Agent actions from Agent perspective</guideline>
-        </guidelines>
-
-        <naming>
-            <example type="good">Agent requests task delegation</example>
-            <example type="bad">POST to /jsonrpc endpoint</example>
-        </naming>
-    </runn-settings>
-
-    <planning-and-review-standards>
-        <title>IMPLEMENTATION PLANNING AND REVIEW</title>
-        <description>Mandatory review process using codex before presenting implementation plans to the user</description>
-
-        <mandatory-rule>
-            <rule>Always perform a plan review using the `codex` command BEFORE presenting the plan to the user</rule>
-        </mandatory-rule>
-
-        <codex-configuration>
-            <recommended-model>gpt-5.5</recommended-model>
-            <required-flags>-m {model}, --skip-git-repo-check</required-flags>
-            <prompt-discipline>
-                <must-include>瑣末な点へのクソリプはしないで。致命的な点だけ指摘して。</must-include>
-                <optimization-strategy>Gather latest information and URLs into a temporary file and include its path in the prompt to ensure accuracy and counter outdated model knowledge.</optimization-strategy>
-            </prompt-discipline>
-        </codex-configuration>
-
-        <review-commands>
-            <initial-review>
-                <description>First review request for a new plan</description>
-                <command><![CDATA[codex exec -m gpt-5.5 --skip-git-repo-check "このプランをレビューして。瑣末な点へのクソリプはしないで。致命的な点だけ指摘して: {plan_full_path} (ref: {CLAUDE.md full_path})"]]></command>
-            </initial-review>
-            <updated-review>
-                <description>Review request for an updated plan (requires context retention)</description>
-                <rule>Must use `resume --last` to maintain the context of the previous review</rule>
-                <command><![CDATA[codex exec resume --skip-git-repo-check --last -m gpt-5.5 "プランを更新したからレビューして。瑣末な点へのクソリプはしないで。致命的な点だけ指摘して: {plan_full_path} (ref: {CLAUDE.md full_path})"]]></command>
-            </updated-review>
-        </review-commands>
-
-        <error-handling>
-            <rate-limit>
-                <condition>If a rate limit error occurs (e.g., "ERROR: You've hit your usage limit..."), skip the codex review process</condition>
-                <example-error>ERROR: You've hit your usage limit. To get more access now, send a request to your admin or try again at Feb 27th, 2026 10:02 PM.</example-error>
-            </rate-limit>
-        </error-handling>
-    </planning-and-review-standards>
-
-    <workflow>
-        <title>EXAMPLE WORKFLOW</title>
-        <steps>
-            <step number="1">Write a simple failing test for a small part of the feature</step>
-            <step number="2">Implement the bare minimum to make it pass</step>
-            <step number="3">Run tests to confirm they pass (Green): `just test`</step>
-            <step number="4">Run linting, type checks, and semgrep: `just lint` (include `just semgrep` when .semgrep/ exists)</step>
-            <step number="5">Make any necessary structural changes (Tidy First), running tests after each change</step>
-            <step number="6">Commit structural changes separately (Conventional Commits: refactor/style/test/docs/chore/build/ci)</step>
-            <step number="7">Add another test for the next small increment of functionality</step>
-            <step number="8">Repeat until complete, committing behavioral changes separately (Conventional Commits: feat/fix/perf)</step>
-            <step number="9">If the change involves significant architectural decisions, create an ADR</step>
-            <step number="10">Update docs/handover.md at end of session; update docs/intent.md if requester intent changed</step>
-        </steps>
-        <principle>Always write one test at a time, make it run, then improve structure</principle>
-        <principle>Always run all tests (except long-running) each time</principle>
-        <principle>Always run ruff, mypy, and semgrep (when applicable) before committing</principle>
-        <principle>Use just commands for common tasks</principle>
-    </workflow>
-
-    <workflow-example>
-        <title>CONCRETE TDD EXAMPLE</title>
-        <scenario>Adding a new validation function</scenario>
-
-        <step number="1" phase="red">
-            <description>Write failing test</description>
-            <code><![CDATA[
-def test_validate_email_rejects_missing_at_symbol():
-    # given
-    invalid_email = "userexample.com"
-
-    # when
-    result = validate_email(invalid_email)
-
-    # then
-    assert result is False
-            ]]></code>
-        </step>
-
-        <step number="2" phase="green">
-            <description>Minimum implementation with type annotations</description>
-            <code><![CDATA[
-def validate_email(email: str) -> bool:
-    return "@" in email
-            ]]></code>
-        </step>
-
-        <step number="3" phase="verify">
-            <description>Run linting and type checks</description>
-            <commands>
-                <command>just lint</command>
-                <command>just fmt</command>
-                <command>just semgrep  # when .semgrep/ exists</command>
-            </commands>
-            <alternative>
-                <command>uv run ruff check .</command>
-                <command>uv run ruff format .</command>
-                <command>uv run mypy .</command>
-            </alternative>
-        </step>
-
-        <step number="4" phase="refactor">
-            <description>Structural improvement (separate commit)</description>
-            <action>Extract to validation module if pattern emerges</action>
-            <commit-example>refactor(validation): extract email validator into dedicated module</commit-example>
-        </step>
-    </workflow-example>
-
-    <ai-assistant-directives>
-        <title>DIRECTIVES FOR AI ASSISTANT</title>
-
-        <response-format>
-            <rule>Always indicate which TDD phase (Red/Green/Refactor) the suggestion belongs to</rule>
-            <rule>Propose commit messages in Conventional Commits format; the type prefix encodes STRUCTURAL vs BEHAVIORAL (see commit-discipline section)</rule>
-            <rule>When proposing code changes, show the test first</rule>
-            <rule>Always include type annotations in Python code suggestions</rule>
-            <rule>Use .yaml extension when creating YAML files, never .yml</rule>
-            <rule>Use `compose.yaml` for Docker Compose files (see file-conventions section for deprecated alternatives)</rule>
-        </response-format>
-
-        <ascii-art-guidelines>
-            <title>ASCII ART AND DIAGRAM GUIDELINES</title>
-            <description>Rules for creating text-based visualizations that render correctly</description>
-
-            <character-restrictions>
-                <rule>Use ONLY ASCII characters (single-byte) in diagrams</rule>
-                <prohibited>Japanese (日本語), Chinese (中文), Korean (한국어), emoji (🔥), and other multi-byte characters</prohibited>
-                <reason>Multi-byte characters cause misalignment in monospace rendering</reason>
-            </character-restrictions>
-
-            <legend-requirement>
-                <rule>ALWAYS include a legend directly below the ASCII art</rule>
-                <rule>Legend must provide Japanese translations unless explicitly instructed otherwise</rule>
-                <format>English term: Japanese translation</format>
-            </legend-requirement>
-
-            <example><![CDATA[
-+-------------------+
-|   Request Handler |
-+-------------------+
-         |
-         v
-+-------------------+
-|   Validator       |
-+-------------------+
-         |
-         v
-+-------------------+
-|   Repository      |
-+-------------------+
-
-Legend / 凡例:
-- Request Handler: リクエストハンドラー
-- Validator: バリデーター
-- Repository: リポジトリ
-            ]]></example>
-        </ascii-art-guidelines>
-
-        <prohibited-actions>
-            <action>Never suggest untested code for production</action>
-            <action>Never mix structural and behavioral changes in one suggestion</action>
-            <action>Never skip the failing test step</action>
-            <action>Never suggest mocks in e2e tests</action>
-            <action>Never suggest code that would fail ruff or mypy checks</action>
-            <action>Never suggest modifying the ruff configuration</action>
-            <action>Never suggest using pip, npm, yarn, or make (pnpm is allowed only when pnpm-lock.yaml exists)</action>
-            <action>Never use .yml extension for YAML files</action>
-            <action>Never use Compose v1 deprecated filenames (listed in file-conventions section under prohibited-filenames); always use `compose.yaml`</action>
-            <action>Never use `[STRUCTURAL]` or `[BEHAVIORAL]` tags in commit messages (use Conventional Commits types instead)</action>
-            <action>Never create or update docs/intent.md with guessed intent; always clarify with the human first</action>
-            <action>Never create multiple justfiles in subdirectories; there MUST be exactly one at the root</action>
-            <action>Never use multi-byte characters (Japanese, Chinese, Korean, emoji) inside ASCII art diagrams</action>
-        </prohibited-actions>
-
-        <encouraged-actions>
-            <action>Ask clarifying questions before writing code</action>
-            <action>Suggest smaller increments if proposed change is large</action>
-            <action>Point out missing test cases</action>
-            <action>Recommend parameterized tests when multiple similar scenarios exist</action>
-            <action>Include ruff, mypy, and semgrep verification steps in suggestions</action>
-            <action>Suggest creating an ADR when proposing significant architectural changes</action>
-            <action>Suggest adding a semgrep rule when the same review comment appears twice</action>
-            <action>Suggest updating docs/handover.md at the end of a work session</action>
-            <action>Use uv for Python package operations</action>
-            <action>Use bun for Node.js package operations (use pnpm only when pnpm-lock.yaml exists)</action>
-            <action>Use just commands for task automation</action>
-            <action>Include Japanese legend below ASCII art diagrams</action>
-        </encouraged-actions>
-    </ai-assistant-directives>
-</development-guidelines>
+<!--
+  AGENTS.md — cross-tool agent instructions (read by Codex, Cursor, Copilot,
+  Claude Code via @import, and others). Keep this file SHORT and always-loaded.
+
+  Why short: frontier models reliably follow ~150-200 instructions; the agent's
+  own system prompt already spends ~50. Every line here dilutes every other line.
+  Adherence — not token cost — is the constraint. Anything that is not needed on
+  turn one lives in docs/agents/*.md and is read on demand (see the index below).
+
+  Self-reference: this file and docs/agents/*.md intentionally name a few
+  prohibited patterns as examples. Exclude them from repo scans:
+    git grep: add :(exclude)**/AGENTS.md :(exclude)**/CLAUDE.md :(exclude)docs/agents/**
+    semgrep : paths.exclude: [AGENTS.md, CLAUDE.md, "docs/agents/**"]
+-->
+
+# AGENTS.md
+
+Production code for a solo-operated, human-on-the-loop agentic engineering
+ecosystem (Go services + Python tooling on GCP). Treat changes conservatively:
+prefer the smallest correct change, prove it, and leave the tree green.
+
+When instructions conflict, the closest file to the edited file wins, and an
+explicit chat instruction overrides everything here.
+
+## Non-negotiables (enforced by hooks + CI — see Enforcement)
+
+These are not preferences. They are gated mechanically; the reasons are given so
+you generalize correctly to unlisted cases.
+
+- **`uv` only** for Python (`uv sync`, `uv add`, `uv run`). Never `pip`, `poetry`,
+  `pipenv` — mixed resolvers desync the lockfile.
+- **`bun` only** for Node, **unless `pnpm-lock.yaml` exists** (then `pnpm`).
+  Never `npm`/`yarn` — same lockfile-desync reason.
+- **`just` is the only task runner.** Exactly one `justfile` at the repo root,
+  no subdirectory justfiles, no `make`. One entrypoint = one place to look.
+- **`.yaml`, never `.yml`.** Compose files are `compose.yaml` (Compose Spec v2+);
+  `docker-compose.y{a,}ml` is the deprecated v1 name. One spelling avoids
+  tool-discovery misses and review churn.
+- **No mocks in e2e tests.** If a real dependency can't be used, it isn't an e2e
+  test — move it to integration. Mocked e2e tests assert nothing about reality.
+- **No manual mutation of IaC-managed infra.** Production (GCP, IAM, Cloud Run,
+  Coder VMs) changes only through OpenTofu + PR + CD. A stray `gcloud ... update`
+  creates drift the next `tofu apply` silently reverts. Details:
+  docs/agents/iac-drift-policy.md.
+- **Never weaken the gates to pass.** Do not edit ruff/mypy/semgrep config to
+  silence a finding, and never commit with failing tests or non-zero lint/type
+  findings. Fix the cause.
+
+## Golden-path commands
+
+```sh
+just            # list all tasks (default: help)
+just check      # the full local gate: fmt + lint + types + semgrep + test
+just test       # uv run pytest
+just lint       # ruff check + mypy
+just fmt        # ruff format
+just semgrep    # semgrep --config .semgrep/rules/ --error  (when .semgrep/ exists)
+just install-hooks   # wire .githooks as core.hooksPath (run once per clone)
+```
+
+If a command you need isn't a `just` task, add it to the root `justfile` rather
+than inventing a one-off script (see docs/agents/project-structure.md).
+
+## Decision priorities (when principles conflict)
+
+1. Safety & correctness over performance.
+2. Passing tests over code elegance.
+3. Readability over brevity.
+4. Explicit over implicit.
+
+When in doubt, write a test to pin down the requirement before coding.
+
+## How to work here (TDD + Tidy First, in brief)
+
+- Drive every change with a failing test first: **Red → Green → Refactor.**
+  Write the minimum to pass; refactor only on green. Full cycle + worked example:
+  docs/agents/tdd-workflow.md.
+- **Separate structural from behavioral changes** — never in the same commit.
+  Structural first, behavioral second. The Conventional Commit *type* encodes
+  which is which; mixing types in one commit is forbidden. Full mapping +
+  examples: docs/agents/commit-discipline.md.
+- **Verify before claiming done.** Run `just check`. State results honestly;
+  report failures rather than papering over them.
+
+## GRIT (the trait that decides whether work succeeds — required both ways)
+
+GRIT = Guts (度胸) / Resilience (復元力) / Initiative (主体性) / Tenacity (執念).
+You MUST embody it AND demand it from whoever you collaborate with (human or
+another agent).
+
+- **Guts** — go at the scariest/least-known part first; state unknowns plainly.
+- **Resilience** — a failed build/test/approach is a signal to change the
+  hypothesis and retry, never a reason to stop or hand back a half-result.
+- **Initiative** — take the obvious next step (investigate, verify/実証, fix what
+  you broke) unprompted — while still confirming before irreversible or
+  out-of-scope actions.
+- **Tenacity** — define "done" concretely (edge cases, error paths, docs,
+  verification) and grind to it; never claim success unproven.
+
+If a request shows weak resolve — a vague finish line, an unfaced unknown, a
+fragile-under-failure design, or a "waiting on someone else" gap — surface it and
+press for a concrete commitment before proceeding. When delegating, pass this on:
+demand a definition of done, a failure-recovery path, and proof of completion.
+If a counterpart won't commit on a blocking axis, record it as an open risk in
+docs/handover.md and don't pretend the work is on track. Scoring rubric (1-5)
+lives in the `grilling:grit-grill` skill; a score below 3 on any blocking axis is
+a stop-and-clarify condition.
+
+## Documentation contract (short version)
+
+- `docs/*.md` describe the **current** system only — no history, no TODOs, no
+  roadmap. Outdated docs are bugs; update docs in the same commit as the code.
+- `docs/adr/*.md` capture the **why** behind significant decisions; immutable
+  once accepted.
+- `docs/intent.md` = "why we're doing this now" (human-authored; never guess it —
+  ask). `docs/handover.md` = "where we are, what's next" (update each session).
+- Full rules: docs/agents/docs-discipline.md.
+
+## Detailed playbooks — read on demand (do not preload)
+
+Open the matching file the moment the trigger applies:
+
+| When you are…                                  | Read                                |
+| ---------------------------------------------- | ----------------------------------- |
+| writing/changing Python                        | docs/agents/python-tooling.md       |
+| in the Red/Green/Refactor loop                 | docs/agents/tdd-workflow.md         |
+| writing a commit message                       | docs/agents/commit-discipline.md    |
+| writing or placing tests / asking "mock?"      | docs/agents/testing.md              |
+| adding telemetry, spans, or a service          | docs/agents/observability.md        |
+| touching `tofu/`, `gcloud`, `cdr`, Cloud Run   | docs/agents/iac-drift-policy.md     |
+| adding/maintaining a Semgrep rule              | docs/agents/semgrep.md              |
+| editing docs / writing an ADR / intent / handover | docs/agents/docs-discipline.md   |
+| creating dirs/files or unsure where code goes  | docs/agents/project-structure.md    |
+
+## Enforcement (deterministic — independent of model judgment)
+
+Instructions in this file are advisory; the rules below are not. They run
+regardless of what an agent decides:
+
+- **Claude Code hooks** (`.claude/settings.json`): block prohibited filenames
+  (`.yml`, deprecated compose names) and prohibited commands (`pip`/`poetry`/
+  `npm`/`yarn`/`make`, drift-causing `gcloud` mutations, obvious secrets) before
+  they execute; auto-run `ruff format`/`ruff check --fix` after edits.
+- **Git pre-commit** (`.githooks/pre-commit` → `just check`): no commit lands
+  red. Enable with `just install-hooks`.
+- **CI** (`.github/workflows/quality-gate.yaml`): same gate + `tofu plan` drift
+  check, required before merge.
+
+Setup and rationale: see README-agents-setup.md.

--- a/ROOT_AGENTS_docs_agents_commit-discipline.md
+++ b/ROOT_AGENTS_docs_agents_commit-discipline.md
@@ -1,0 +1,80 @@
+# Commit Discipline
+
+Read this before writing a commit message. Root summary is in AGENTS.md.
+
+## Pre-commit conditions (ALL must hold)
+
+- All tests pass.
+- Zero ruff violations, zero mypy errors.
+- Zero semgrep findings under `.semgrep/` (when it exists).
+- The change is a single logical unit of work.
+- Message follows Conventional Commits v1.0.0.
+
+`just check` runs the whole gate; the git pre-commit hook runs it too, so a red
+tree cannot be committed (see README-agents-setup.md).
+
+## Format
+
+```
+<type>(<scope>)<!>: <subject>
+
+<body>
+
+<footer>
+```
+
+- Subject: imperative mood, lowercase, no trailing period, ≤72 chars.
+- Scope: optional but recommended in monorepos / multi-module repos
+  (e.g. `feat(sightjack):`).
+- Breaking change: `!` after type/scope **and** a `BREAKING CHANGE:` footer.
+
+## Type ⇄ Tidy First mapping (fixed — mixing is forbidden)
+
+Each type is permanently either behavioral or structural. One commit = one type.
+If a change needs two types, it needs two commits — structural first.
+
+**Behavioral** (changes what the system does):
+
+| type   | meaning                                          |
+| ------ | ------------------------------------------------ |
+| `feat` | new feature (behavior added)                     |
+| `fix`  | bug fix (behavior corrected)                     |
+| `perf` | performance change (measurable behavior change)  |
+
+**Structural** (no behavior change):
+
+| type       | meaning                                            |
+| ---------- | -------------------------------------------------- |
+| `refactor` | restructuring without behavior change              |
+| `style`    | formatting, whitespace, naming                     |
+| `test`     | add/fix tests (no production behavior change)      |
+| `docs`     | documentation only                                 |
+| `chore`    | tooling, dependency bumps without behavior impact  |
+| `build`    | build system or external dependency changes        |
+| `ci`       | CI/CD configuration changes                        |
+
+Never add `[STRUCTURAL]` / `[BEHAVIORAL]` tags — the type already encodes it.
+
+## Examples
+
+Good:
+
+```
+feat(auth): add refresh token rotation
+refactor(paintress): extract gauge tracker into dedicated module
+fix(d-mail): handle empty outbox on startup
+chore(deps): bump otelcol-contrib to 0.110.0
+```
+
+Bad:
+
+```
+update stuff
+feat: refactor auth and add new endpoint     # two types in one commit
+[BEHAVIORAL] feat: add login                  # redundant tag
+```
+
+## Practice
+
+- Small, frequent commits over large, infrequent ones.
+- When you catch yourself wanting an "and" in the subject, split the commit.

--- a/ROOT_AGENTS_docs_agents_docs-discipline.md
+++ b/ROOT_AGENTS_docs_agents_docs-discipline.md
@@ -1,0 +1,131 @@
+# Documentation Discipline
+
+Read this when editing docs, writing an ADR, or touching `intent.md`/
+`handover.md`. Root summary is in AGENTS.md.
+
+Four documentation kinds, four questions:
+
+| file              | answers                                  | mutability             |
+| ----------------- | ---------------------------------------- | ---------------------- |
+| `docs/*.md`       | What does the system do **now**?         | always current         |
+| `docs/adr/*.md`   | **Why** did we decide X (in the past)?   | immutable once accepted|
+| `docs/intent.md`  | **Why** are we doing this right now?     | updated when intent shifts |
+| `docs/handover.md`| **Where** are we, what's **next**?       | updated each session   |
+
+## `docs/*.md` — current state only
+
+- Document only the current implementation. No history, no "why we changed from
+  X to Y" (that's an ADR), no TODOs, no roadmap, no deprecated-feature notes.
+- Docs and implementation stay consistent at all times; when code changes, update
+  docs in the **same commit**. Outdated docs are bugs.
+- Use code references where possible to keep accuracy.
+- Exempt from "current state only": `docs/adr/`, `docs/intent.md`,
+  `docs/handover.md`.
+
+## `docs/adr/` — Architecture Decision Records
+
+Capture the *why* behind significant decisions (docs only capture the *what*).
+
+Create one when: introducing a new technology/framework; changing an established
+pattern; making a non-obvious tradeoff with significant consequences; deprecating
+or replacing an approach; making a decision future developers might question.
+
+Naming: `docs/adr/NNNN-short-title.md` (sequential `0001`, `0002`, …; lowercase
+hyphenated title), e.g. `docs/adr/0001-use-fastapi-for-api-layer.md`.
+
+Template:
+
+```markdown
+# {NNNN}. {Title}
+
+**Date:** YYYY-MM-DD
+**Status:** Proposed / Accepted / Deprecated / Superseded by [NNNN]
+
+## Context
+{The problem and constraints at the time. What forces are at play?}
+
+## Decision
+{What we are doing. State it clearly and concisely.}
+
+## Consequences
+### Positive
+- {Benefit}
+### Negative
+- {Tradeoff}
+### Neutral
+- {Implication that's neither clearly positive nor negative}
+```
+
+Immutability: ADRs are never modified after acceptance. To change a decision,
+write a **new** ADR that supersedes the old one, and set the old one's status to
+`Superseded by [NNNN]` — the only allowed edit. ADRs complement docs; they don't
+replace them.
+
+## `docs/intent.md` — the human's intent for the current work unit
+
+**Before creating or updating it, clarify ambiguous intent by asking the human.
+Never guess; never fill gaps with assumptions.** If any of these are unclear,
+STOP and ask: goal, success criteria, scope boundaries, non-goals, constraints,
+deadlines, affected components, rollback conditions.
+
+```markdown
+# Intent
+
+**Last updated:** YYYY-MM-DD
+**Requester:** {name}
+**Work unit:** {concise id, e.g. Linear issue}
+
+## Goal
+{One or two sentences. What outcome does the requester want?}
+
+## Success Criteria
+- {Observable, testable criterion}
+
+## Scope
+### In scope
+- {Item}
+### Out of scope (Non-goals)
+- {Item}
+
+## Constraints
+- {Technical, deadline, budget, compliance}
+
+## Open Questions
+- [ ] {Resolve before implementation}
+```
+
+Update when the requester's intent changes (not every implementation detail).
+Superseded versions live in git history, not in the file.
+
+## `docs/handover.md` — for the next actor
+
+Optimized to be read in under two minutes; consumable by both humans and agents.
+
+```markdown
+# Handover
+
+**Last updated:** YYYY-MM-DD HH:MM (timezone)
+**Updated by:** {human name or AI session id}
+
+## Current State
+{What is done. One paragraph.}
+
+## In Progress
+{Active work. Branch, PR link, Linear issue.}
+
+## Next Actions
+1. {Concrete next step}
+
+## Known Risks / Blockers
+- {Item and mitigation}
+
+## Context the Next Actor Needs
+- {Non-obvious gotchas, env quirks, external deps}
+
+## Relevant Files and Commands
+- `path/to/file.py` — {why it matters}
+- `just {command}` — {what it does}
+```
+
+Update at the end of every significant work session (session-level, not
+commit-level). Don't duplicate `intent.md`; reference it.

--- a/ROOT_AGENTS_docs_agents_iac-drift-policy.md
+++ b/ROOT_AGENTS_docs_agents_iac-drift-policy.md
@@ -1,0 +1,66 @@
+# IaC Drift Avoidance
+
+Read this before any `gcloud`, `cdr`, `kubectl`, or console action against
+production. Root summary is in AGENTS.md.
+
+Production infra (GCP resources, IAM, Cloud Run revisions, Coder workspace VMs)
+is managed **exclusively** through OpenTofu + the standard PR + CD flow. Manual
+mutations create drift between live infra and the repo; the next `tofu apply`
+either silently reverts your change or fails on unexpected state.
+
+## Prohibited (these mutate state OpenTofu owns)
+
+- `gcloud compute disks resize` / `... instances set-machine-type` against any
+  resource declared in `tofu/exe/` or `tofu/`.
+- `gcloud iam service-accounts add-iam-policy-binding` /
+  `gcloud projects add-iam-policy-binding` for bindings that exist in
+  `iam_*.tf` — IAM drift is the top source of "works for me / fails in CI".
+- `gcloud secrets versions add` with content the IaC doesn't know about — add
+  only secrets for which tofu has reserved a slot.
+- `cdr workspaces update` / `... edit` to change parameters that belong as
+  `coder_parameter` defaults — push the template, don't patch the running VM.
+- Editing live Cloud Run revisions in the console (env vars, traffic split) when
+  managed by `google_cloud_run_v2_service` / CD `gcloud run deploy`.
+
+## Allowed exceptions
+
+- One-off **bootstrap** before IaC can manage the resource (e.g. `bootstrap.sh`
+  creates the GCS state bucket; the bucket is then not tofu-managed, by design).
+- **Read-only debug** (`gcloud compute ssh ... --command 'df -h'`,
+  `... get-serial-port-output`, `cdr show`, …).
+- **Emergency rollback when CD itself is broken** — open an incident, run the
+  manual command, then immediately file a PR re-syncing the IaC.
+- **Interactive prompts IaC can't pre-fill** (e.g. `cdr create`'s region
+  selector) — choose at create-time; don't edit the workspace afterwards.
+
+## When drift happens — recover same session
+
+1. If a manual change shipped, open a PR **this session** reflecting it in IaC.
+   Don't leave live state ahead of the repo overnight.
+2. If the IaC PR can't land immediately (waiting on review), record the drift in
+   `docs/handover.md` so the next operator doesn't blindly `tofu apply` and
+   revert the fix.
+3. About to type `gcloud ... update/resize` on a resource mentioned anywhere in
+   `tofu/`? **Stop. Open a PR.** 30 minutes of latency beats a drift incident.
+
+## Detecting drift
+
+- `tofu plan` shows changes you didn't write — something was hand-edited.
+- CD's apply step fails with "resource already exists" / "permission denied on
+  existing resource" — IaC and live state disagree on ownership.
+- A VM or Cloud Run revision behaves differently from a same-template-version
+  peer — runtime state was poked manually.
+
+## Agent directive
+
+- Default to the IaC PR path. Suggest a manual `gcloud`/`cdr` command only for
+  one of the four exceptions above.
+- If a manual command is unavoidable to unblock the operator, spell out the IaC
+  follow-up in the same message ("this bridges the gap; PR XYZ lands within the
+  hour to capture it permanently").
+- Refuse to **chain** manual mutations — one emergency mutation is acceptable;
+  a sequence means the IaC needs restructuring.
+
+(A PreToolUse hook flags `gcloud … add-iam-policy-binding` / `… update` /
+`… resize` and Cloud Run console-equivalent calls for confirmation; see
+README-agents-setup.md.)

--- a/ROOT_AGENTS_docs_agents_observability.md
+++ b/ROOT_AGENTS_docs_agents_observability.md
@@ -1,0 +1,65 @@
+# Observability (OpenTelemetry + Jaeger)
+
+Read this when adding a new service/binary or any telemetry. All services emit
+telemetry via OpenTelemetry. Local dev uses Jaeger; production backends are
+chosen per project in an ADR.
+
+## Scope
+
+In: distributed tracing (traces + spans), structured logs correlated with
+`trace_id`/`span_id`, metrics via OTLP when applicable.
+Out: non-OTel vendor SDKs — use OTel with an exporter instead.
+
+## Instrumentation rules
+
+- Every service/binary initializes an OTel `TracerProvider` at startup.
+- Exporter is **OTLP** — gRPC preferred (`:4317`), HTTP fallback (`:4318`).
+- Endpoint via the standard `OTEL_EXPORTER_OTLP_ENDPOINT` env var — never
+  hard-code it (especially not production endpoints).
+- `OTEL_SERVICE_NAME` matches the tool/module name (`sightjack`, `paintress`,
+  `amadeus`, `phonewave`, `dominator`).
+- Propagate W3C Trace Context across process boundaries (SDK default).
+- Never put PII or secrets in span attributes; scrub before export.
+
+## Minimum span coverage
+
+- Every inbound RPC/HTTP handler → a root span.
+- Every outbound RPC/HTTP client call → a child span.
+- Every message-bus enqueue/dequeue (including D-Mail Protocol inbox/outbox
+  writes) → a span with `messaging.*` attributes.
+- Every LLM call (Anthropic, Gemini, …) → a span with `gen_ai.*` attributes
+  (model, input tokens, output tokens, latency).
+
+## Python setup
+
+```sh
+uv add opentelemetry-api opentelemetry-sdk opentelemetry-exporter-otlp
+# plus opentelemetry-instrumentation-* per framework: fastapi, httpx, sqlalchemy, …
+```
+
+## Go setup
+
+```
+go.opentelemetry.io/otel
+go.opentelemetry.io/otel/sdk
+go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc
+```
+
+## Local Jaeger
+
+`compose.yaml` runs a Jaeger all-in-one (`jaegertracing/all-in-one`,
+`COLLECTOR_OTLP_ENABLED=true`; ports `16686` UI / `4317` gRPC / `4318` HTTP).
+Apps set `OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317` and
+`OTEL_SERVICE_NAME=<module>`.
+
+```sh
+just trace-up     # docker compose -f compose.yaml up -d jaeger
+just trace-down   # stop it
+just trace-view   # open http://localhost:16686
+```
+
+## Production
+
+The production exporter target is decided per project and recorded in an ADR
+(e.g. Cloud Trace, Grafana Tempo, Honeycomb). Always reach it via
+`OTEL_EXPORTER_OTLP_ENDPOINT`.

--- a/ROOT_AGENTS_docs_agents_project-structure.md
+++ b/ROOT_AGENTS_docs_agents_project-structure.md
@@ -1,0 +1,89 @@
+# Project Structure
+
+Read this when creating directories/files or when unsure where something goes.
+
+Standard directories exist **once**, at the repository root. They must not be
+duplicated in subdirectories. External dependencies (submodules, cloned repos)
+are exempt.
+
+## Root directories
+
+| path            | purpose                                                       |
+| --------------- | ------------------------------------------------------------- |
+| `docs/`         | current-implementation docs + ADRs                            |
+| `experiments/`  | research, preliminary experiments, exploratory implementations|
+| `output/`       | generated artifacts and build outputs                         |
+| `examples/`     | usage examples and sample code                                |
+| `scripts/`      | development and utility scripts                               |
+| `tests/`        | all test code (unit, integration, e2e, scenario)              |
+| `docker/`       | *(optional)* Dockerfiles — only when there are ≥2 (see below) |
+| `.semgrep/`     | *(optional)* project-specific Semgrep rules                   |
+
+## Root files
+
+| path            | purpose                                                       |
+| --------------- | ------------------------------------------------------------- |
+| `justfile`      | task runner config (required, exactly one, at root)           |
+| `pyproject.toml`| Python project config incl. ruff settings                     |
+| `compose.yaml`  | Docker Compose file (when Docker is used)                     |
+
+## Docker layout
+
+- **One** Dockerfile → keep it at the repo root as `Dockerfile`.
+- **Two or more** → create `docker/` at the root and put all inside
+  (`docker/api.Dockerfile`, `docker/worker.Dockerfile`, …).
+- `compose.yaml` stays at the root regardless, referencing `docker/*.Dockerfile`
+  via `build.dockerfile`.
+
+```
+# single-service           # multi-service
+Dockerfile                  docker/
+compose.yaml                  api.Dockerfile
+                              worker.Dockerfile
+                              migration.Dockerfile
+                            compose.yaml
+```
+
+## docs/ subdirectories
+
+- `docs/adr/` — Architecture Decision Records (see docs/agents/docs-discipline.md).
+
+## tests/ subdirectories
+
+`tests/unit/`, `tests/integration/`, `tests/e2e/`, `tests/runn/` (scenario
+`*.yaml`), `tests/utils/` (only importable test location). See
+docs/agents/testing.md.
+
+## scripts/ rules
+
+- Shebang `#!/usr/bin/env bash` for portability.
+- Scripts must be idempotent.
+- Process arguments early.
+- Prefer defining common tasks in the `justfile` over standalone scripts.
+- Optimize for: standardization & error prevention, developer experience,
+  idempotency, and clear guidance for the next action.
+
+## experiments/ layout
+
+```
+experiments/README.md                              # overview + index table
+experiments/YYYY-MM-DD_{name}.md                   # experiment plan
+experiments/run_{name}_benchmark.sh                # benchmark script
+experiments/test_{name}.py                         # experiment test
+```
+
+Experiment doc header: Date, Objective, Status (🟢 Complete / 🟡 In Progress /
+⚪ Not Started). Body: Background, Hypothesis, Experiment Design, Expected
+Results, Results, Conclusion.
+
+Generated output naming (required: experiment-variable id; recommended:
+resolution, step count, guidance scale, other params):
+
+```
+preprocessed/{experiment_note_name}/{resolution}/
+output/{experiment_note_name}/sage_attention_720p_steps20_cfg5.0.mp4
+```
+
+Keep the `experiments/README.md` index updated; summary results there are
+reference-only — always check the full note. Organize by status: Complete /
+In Progress / Planned.

--- a/ROOT_AGENTS_docs_agents_python-tooling.md
+++ b/ROOT_AGENTS_docs_agents_python-tooling.md
@@ -1,0 +1,79 @@
+# Python Tooling
+
+Read this when writing or changing Python. Package management is `uv` (AGENTS.md).
+
+## Required tools
+
+- **ruff** — linting + formatting
+- **mypy** — static type checking (strict where possible)
+- **uv** — packages (`uv sync`, `uv add`, `uv add --dev`, `uv run`)
+
+## ruff configuration (canonical — in `pyproject.toml`)
+
+Do **not** modify this without explicit human approval, and never relax it to
+silence a finding.
+
+```toml
+[tool.ruff.lint]
+# see: https://docs.astral.sh/ruff/rules/
+select = [
+    "FAST", # FastAPI
+    "C90",  # mccabe
+    "NPY",  # numpy
+    "PD",   # pandas
+    "B",    # flake8-bugbear
+    "A",    # flake8-builtins
+    "DTZ",  # flake8-datetimez
+    "T20",  # flake8-print
+    "N",    # pep8-naming
+    "I",    # isort
+    "E",    # pycodestyle errors
+    "F",    # Pyflakes
+    "PLE",  # Pylint errors
+    "PLR",  # Pylint refactor
+    "UP",   # pyupgrade
+    "FURB", # refurb
+    # "DOC", # pydoclint
+    # "D",   # pydocstyle
+    "RUF",  # Ruff-specific rules
+]
+extend-ignore = ["E501", "RUF002", "RUF003"]
+```
+
+## mypy
+
+- All code is type-annotated.
+- mypy passes with zero errors before commit.
+- Strict mode where possible.
+- Avoid `# type: ignore`; if unavoidable, add a one-line justification comment.
+
+## Refactoring rules (Python-specific)
+
+- Imports at the top of the file — never inside function/method bodies.
+- Use `pathlib.Path` for path manipulation; `os.path` is deprecated here.
+- Iterate dicts as `for key in d`, not `for key in d.keys()`.
+- Combine multiple context managers with 3.10+ parenthesized form.
+- All code conforms to the ruff + mypy rules above.
+
+## Pre-commit sequence
+
+```sh
+just lint   # uv run ruff check .  &&  uv run mypy .
+just fmt    # uv run ruff format .
+just semgrep   # when .semgrep/ exists
+just test   # uv run pytest
+```
+
+(The `format-after-edit` hook already runs `ruff format` + `ruff check --fix`
+on each edited `.py` file, so most violations are fixed before you reach commit.)
+
+## External data & encoding
+
+All text processed in-repo must be strict UTF-8. Convert legacy Japanese
+encodings with `iconv` (POSIX-standard, pre-installed) the moment a web-fetched
+page or external file is unreadable:
+
+```sh
+iconv -f SHIFT-JIS -t UTF-8 input > output
+iconv -f EUC-JP   -t UTF-8 input > output
+```

--- a/ROOT_AGENTS_docs_agents_semgrep.md
+++ b/ROOT_AGENTS_docs_agents_semgrep.md
@@ -1,0 +1,68 @@
+# Semgrep Rules (`.semgrep/`)
+
+Read this when adding or maintaining a project-specific static-analysis rule.
+Start light at project inception; grow rules as patterns stabilize.
+
+## Philosophy
+
+- Rules codify the team's *unwritten* rules — what reviewers catch repeatedly.
+- Write a rule the **second** time you catch the same issue in review (once is a
+  coincidence, twice is a pattern).
+- Density grows toward mid-lifecycle, once architectural patterns settle.
+
+## Directory structure
+
+```
+.semgrep/rules/{category}/{rule-id}.yaml
+.semgrep/tests/{category}/{rule-id}.{py|go|ts|…}
+.semgrep/README.md          # ruleset overview + how to add a rule
+```
+
+## Rule file convention
+
+- One rule per file; filename matches the rule id.
+- `.yaml` extension (never `.yml`).
+- Rule id: `{project-prefix}-{category}-{short-name}`
+  (e.g. `paintress-concurrency-unguarded-goroutine`).
+- Every rule has a test file with at least one positive (matching) and one
+  negative (non-matching) example.
+
+## Rule template
+
+```yaml
+rules:
+  - id: paintress-concurrency-unguarded-goroutine
+    message: |
+      Launching a goroutine without passing a context.Context is forbidden.
+      Pass ctx explicitly so the caller can cancel.
+    severity: ERROR
+    languages: [go]
+    pattern: |
+      go func() {
+        ...
+      }()
+    metadata:
+      category: concurrency
+      added: "2026-04-18"
+      adr: docs/adr/NNNN-goroutine-context.md
+```
+
+## Execution
+
+- `just semgrep` runs `semgrep --config .semgrep/rules/ --error`.
+- Wire semgrep into CI as a required check before merge (see the quality-gate
+  workflow).
+- Pre-commit runs semgrep alongside ruff + mypy.
+
+## When to add a rule
+
+- The same review comment has been made twice or more.
+- An ADR decision needs mechanical enforcement (e.g. "always Cloud SQL
+  PostgreSQL, never Spanner").
+- A production incident's root cause is expressible as a code pattern.
+
+## When *not* to add a rule
+
+- A type checker would catch it — let mypy do its job.
+- ruff already has a built-in rule for it.
+- It would fire false positives frequently — tune or drop it.

--- a/ROOT_AGENTS_docs_agents_tdd-workflow.md
+++ b/ROOT_AGENTS_docs_agents_tdd-workflow.md
@@ -1,0 +1,82 @@
+# TDD Workflow (Red → Green → Refactor)
+
+Read this when you are in the implementation loop. The root contract is in
+AGENTS.md; this file is the full procedure.
+
+## The cycle
+
+1. **Red** — write the simplest *failing* test that defines one small increment
+   of behavior. Use a behavior-describing name
+   (`test_should_sum_two_positive_numbers`). Make the failure message clear.
+2. **Green** — write the *minimum* code to pass. No more. With type annotations.
+3. **Verify** — run `just lint` (ruff + mypy), `just fmt`, and `just semgrep`
+   (when `.semgrep/` exists), then `just test`.
+4. **Refactor** — only on green. One refactoring at a time; run tests after each.
+   Prioritize removing duplication and clarifying intent.
+5. **Commit** — structural and behavioral changes as *separate* commits
+   (Tidy First). See docs/agents/commit-discipline.md.
+6. Repeat for the next increment.
+
+Always: one test at a time → make it run → improve structure. Run all tests
+(except long-running) each time.
+
+## Fixing a defect
+
+1. Write a failing test at the API level that expresses the defect.
+2. Write the smallest test that reproduces the root cause.
+3. Make both pass.
+
+## Tidy First — structural vs behavioral
+
+- **Structural**: rearranging code without changing behavior (rename, extract,
+  move). Validate behavior is unchanged by running tests before *and* after.
+- **Behavioral**: adding or changing functionality.
+- Never mix them in one commit. When a change needs both, do the structural part
+  first, commit it, then the behavioral part.
+
+## Worked example — adding a validator
+
+**[Red]** failing test:
+
+```python
+def test_validate_email_rejects_missing_at_symbol() -> None:
+    # given
+    invalid_email = "userexample.com"
+
+    # when
+    result = validate_email(invalid_email)
+
+    # then
+    assert result is False
+```
+
+**[Green]** minimum implementation (typed):
+
+```python
+def validate_email(email: str) -> bool:
+    return "@" in email
+```
+
+**[Verify]**:
+
+```sh
+just lint     # or: uv run ruff check . && uv run mypy .
+just fmt      # or: uv run ruff format .
+just semgrep  # when .semgrep/ exists
+just test     # or: uv run pytest
+```
+
+**[Refactor]** (separate commit) — extract once a pattern emerges:
+
+```
+refactor(validation): extract email validator into dedicated module
+```
+
+## Test mechanics
+
+- Structure every test as **given / when / then**.
+- No try/except inside tests. Keep tests flat; avoid deep nesting.
+- Prefer function-based tests over class-based.
+- Only import helpers from `tests/utils/`.
+- Prefer real code over mocks; parameterize when several similar scenarios exist.
+- For *which* test type and the mock policy per type, see docs/agents/testing.md.

--- a/ROOT_AGENTS_docs_agents_testing.md
+++ b/ROOT_AGENTS_docs_agents_testing.md
@@ -1,0 +1,77 @@
+# Testing
+
+Read this when writing or placing a test, or whenever you're about to reach for a
+mock. The TDD *cycle* is in docs/agents/tdd-workflow.md.
+
+## Where tests live
+
+| dir                  | purpose                                              |
+| -------------------- | ---------------------------------------------------- |
+| `tests/unit/`        | isolated component tests                             |
+| `tests/integration/` | component-interaction tests                          |
+| `tests/e2e/`         | full-system tests with **real** dependencies         |
+| `tests/runn/`        | scenario tests (`*.yaml`) — API/CLI/agent workflows  |
+| `tests/utils/`       | shared helpers (the only importable test location)   |
+
+## Mock policy by test type
+
+- **Unit** — minimize mocks; prefer real code. Mock only external dependencies
+  impractical to use in a test. No oversized/complex mocks.
+- **Integration** — minimal mocks for *external services only*; prefer test
+  containers or local instances.
+- **e2e** — **mocks are strictly prohibited.** All dependencies real (DB,
+  services, filesystem, network). If a real dependency can't be used, the test
+  is not e2e — move it to integration. This is enforced by a Semgrep rule
+  (see docs/agents/semgrep.md), not just convention.
+
+## Unit test rules
+
+- Structure as **given / when / then**.
+- No try/except inside tests. Keep flat; avoid deep nesting.
+- Function-based over class-based.
+- Import only from `tests/utils/`.
+- Real code over large mocks.
+
+## e2e test rules
+
+Principles: test as a user experiences it; all deps real; deterministic and
+repeatable; each test independent. Prohibited: mocks, stubs, fakes,
+in-memory replacements, patching/monkey-patching. Required: real DB connections,
+real external calls, real filesystem, real network.
+
+Use a dedicated test environment with real services; clean up test data after
+each test/session; document setup in `tests/e2e/README.md`.
+
+### Parameterize for coverage
+
+```python
+@pytest.mark.parametrize(
+    "input_data,expected_status,expected_result",
+    [
+        pytest.param({"valid": "data"}, 200, {"success": True}, id="valid-input-succeeds"),
+        pytest.param({}, 400, {"error": "missing fields"}, id="empty-input-fails"),
+        pytest.param({"invalid": "schema"}, 422, {"error": "validation"}, id="invalid-schema-fails"),
+    ],
+)
+def test_api_endpoint(input_data, expected_status, expected_result) -> None:
+    # given
+    client = create_real_client()
+    # when
+    response = client.post("/api/endpoint", json=input_data)
+    # then
+    assert response.status_code == expected_status
+    assert response.json() == expected_result
+```
+
+## runn scenario tests (`tests/runn/`)
+
+`runn` is a YAML-driven scenario runner for API/CLI testing.
+
+- Files: `tests/runn/*.yaml` and `tests/runn/vars/*.yaml` (never `.yml`).
+- Concepts: *runbook* (the YAML scenario), *step* (one HTTP/command action),
+  *vars* (values passed between steps).
+- Scenarios are realistic; they don't need unit/integration-level coverage.
+- A2A protocol scenarios comply with JSON-RPC 2.0.
+- Describe steps from the **agent's perspective**:
+  - good: `Agent requests task delegation`
+  - bad:  `POST to /jsonrpc endpoint`

--- a/ROOT_AGENTS_hooks_block-prohibited-commands.sh
+++ b/ROOT_AGENTS_hooks_block-prohibited-commands.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# .claude/hooks/block-prohibited-commands.sh
+# PreToolUse hook (matcher: Bash). Enforces the command-level non-negotiables in
+# AGENTS.md and docs/agents/iac-drift-policy.md.
+#
+# Exit-code contract:
+#   exit 0  -> allow
+#   exit 2  -> BLOCK (stderr -> Claude). exit 1 would NOT block.
+set -euo pipefail
+
+input="$(cat)"
+cmd="$(printf '%s' "$input" | jq -r '.tool_input.command // empty')"
+[ -z "$cmd" ] && exit 0
+
+block() { echo "BLOCKED: $1" >&2; exit 2; }
+
+# --- Package managers ---------------------------------------------------------
+# Python: uv only.
+if printf '%s' "$cmd" | grep -Eq '(^|[^[:alnum:]_./-])(pip3?|poetry|pipenv)([[:space:]]|$)'; then
+  block "Python package management is 'uv' only (uv add / uv sync / uv run). Do not use pip/poetry/pipenv."
+fi
+
+# Node: bun, unless pnpm-lock.yaml exists (then pnpm). Never npm/yarn.
+if printf '%s' "$cmd" | grep -Eq '(^|[^[:alnum:]_./-])(npm|yarn)([[:space:]]|$)'; then
+  block "Node package management is 'bun' (or 'pnpm' iff pnpm-lock.yaml exists). Do not use npm/yarn."
+fi
+if printf '%s' "$cmd" | grep -Eq '(^|[^[:alnum:]_./-])pnpm([[:space:]]|$)'; then
+  if [ ! -f pnpm-lock.yaml ]; then
+    block "'pnpm' is allowed only when pnpm-lock.yaml exists in this project. Use 'bun' instead."
+  fi
+fi
+
+# Task runner: just only, no make.
+if printf '%s' "$cmd" | grep -Eq '(^|[^[:alnum:]_./-])make([[:space:]]|$)'; then
+  block "Task automation is 'just' only. Add a recipe to the root justfile instead of using make."
+fi
+
+# --- Obviously destructive ----------------------------------------------------
+if printf '%s' "$cmd" | grep -Eq 'rm[[:space:]]+(-[a-zA-Z]*[rR][a-zA-Z]*[[:space:]]+)?(-[a-zA-Z]*f[a-zA-Z]*[[:space:]]+)?/($|[[:space:]])'; then
+  block "Refusing 'rm -rf /' (or equivalent root deletion)."
+fi
+if printf '%s' "$cmd" | grep -Eq 'git[[:space:]]+push[[:space:]].*--force([[:space:]]|=).*(main|master)'; then
+  block "Refusing force-push to main/master. Open a PR; never rewrite shared history on the default branch."
+fi
+
+# --- IaC drift (see docs/agents/iac-drift-policy.md) --------------------------
+# These mutate state OpenTofu owns. Read-only verbs (describe/list/get/show) pass.
+if printf '%s' "$cmd" | grep -Eq 'gcloud[[:space:]].*(add-iam-policy-binding|set-iam-policy)'; then
+  block "IAM changes go through OpenTofu (iam_*.tf) + PR, not gcloud. See docs/agents/iac-drift-policy.md."
+fi
+if printf '%s' "$cmd" | grep -Eq 'gcloud[[:space:]]+(compute|run|sql|secrets)[[:space:]].*(set-machine-type|resize|update|deploy|versions[[:space:]]+add)'; then
+  block "This gcloud command mutates IaC-managed infra and will drift from tofu. Open an IaC PR. (Read-only debug is fine; emergency rollback must be followed by an IaC PR same session.)"
+fi
+if printf '%s' "$cmd" | grep -Eq 'cdr[[:space:]]+workspaces[[:space:]]+(update|edit)'; then
+  block "Patch the Coder template (coder_parameter), not the running workspace. See docs/agents/iac-drift-policy.md."
+fi
+
+exit 0

--- a/ROOT_AGENTS_hooks_block-prohibited-files.sh
+++ b/ROOT_AGENTS_hooks_block-prohibited-files.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# .claude/hooks/block-prohibited-files.sh
+# PreToolUse hook (matcher: Write|Edit). Blocks creating/editing files that
+# violate the file-naming non-negotiables in AGENTS.md.
+#
+# Exit-code contract (Claude Code):
+#   exit 0  -> allow
+#   exit 2  -> BLOCK (stderr is fed back to Claude as the reason)
+#   exit 1  -> non-blocking error, action PROCEEDS (do NOT use it to block)
+set -euo pipefail
+
+input="$(cat)"
+file_path="$(printf '%s' "$input" | jq -r '.tool_input.file_path // empty')"
+
+# Nothing to check (e.g. tool input without a path).
+[ -z "$file_path" ] && exit 0
+
+base="$(basename "$file_path")"
+
+# Self-reference exemption: the policy files themselves may name prohibited
+# patterns as examples.
+case "$file_path" in
+  */AGENTS.md|AGENTS.md|*/CLAUDE.md|CLAUDE.md|*/docs/agents/*) exit 0 ;;
+esac
+
+# GitHub Actions accepts .yaml, so workflow files are not exempted here; the rule
+# is global. (If you ever must keep a vendored .yml you cannot rename, add an
+# explicit allowlist case above this block.)
+
+# Rule 1: deprecated Docker Compose v1 filenames.
+case "$base" in
+  docker-compose.yaml|docker-compose.yml)
+    echo "BLOCKED: '$base' is the deprecated Compose v1 name. Use 'compose.yaml' (Compose Spec v2+)." >&2
+    exit 2
+    ;;
+esac
+
+# Rule 2: .yml extension anywhere. Canonical extension is .yaml.
+case "$base" in
+  *.yml)
+    echo "BLOCKED: '$base' uses '.yml'. This project uses '.yaml' exclusively. Rename to '${base%.yml}.yaml'." >&2
+    exit 2
+    ;;
+esac
+
+exit 0

--- a/ROOT_AGENTS_hooks_block-secrets.sh
+++ b/ROOT_AGENTS_hooks_block-secrets.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# .claude/hooks/block-secrets.sh
+# PreToolUse hook (matcher: Write|Edit). Blocks writing obvious credential
+# patterns into files. Defense-in-depth only — not a substitute for a real
+# secret scanner in CI.
+#
+#   exit 0 -> allow ; exit 2 -> BLOCK (stderr -> Claude)
+set -euo pipefail
+
+input="$(cat)"
+# Edit uses new_string; Write uses content.
+content="$(printf '%s' "$input" | jq -r '.tool_input.content // .tool_input.new_string // empty')"
+[ -z "$content" ] && exit 0
+
+# Common high-confidence token shapes.
+if printf '%s' "$content" | grep -Eq 'sk-[a-zA-Z0-9]{20,}|ghp_[a-zA-Z0-9]{36}|AKIA[A-Z0-9]{16}|-----BEGIN [A-Z ]*PRIVATE KEY-----'; then
+  echo "BLOCKED: content looks like a live secret (API key / token / private key). Do not commit secrets; use a secret manager and reference via env var." >&2
+  exit 2
+fi
+
+exit 0

--- a/ROOT_AGENTS_hooks_format-after-edit.sh
+++ b/ROOT_AGENTS_hooks_format-after-edit.sh
@@ -28,11 +28,15 @@ case "$file_path" in
     fi
     ;;
   *.go)
-    command -v gofmt >/dev/null 2>&1 && gofmt -w "$file_path" >/dev/null 2>&1 || true
+    if command -v gofmt >/dev/null 2>&1; then
+      gofmt -w "$file_path" >/dev/null 2>&1 || true
+    fi
     ;;
   *.ts|*.tsx|*.js|*.jsx)
     # Use the project's configured formatter via just if present; stay silent otherwise.
-    command -v just >/dev/null 2>&1 && just --show fmt >/dev/null 2>&1 && just fmt >/dev/null 2>&1 || true
+    if command -v just >/dev/null 2>&1 && just --show fmt >/dev/null 2>&1; then
+      just fmt >/dev/null 2>&1 || true
+    fi
     ;;
 esac
 

--- a/ROOT_AGENTS_hooks_format-after-edit.sh
+++ b/ROOT_AGENTS_hooks_format-after-edit.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# .claude/hooks/format-after-edit.sh
+# PostToolUse hook (matcher: Write|Edit). Runs after a file is written/edited.
+# PostToolUse CANNOT undo the action; it formats and surfaces remaining issues so
+# Claude fixes them on the next turn. Always exit 0 (this is not a gate; the gate
+# is `just check` at commit time + CI).
+#
+# Loop-safety: this hook does not write files via a tool, so it won't retrigger
+# PostToolUse. It calls formatters directly.
+set -uo pipefail
+
+input="$(cat)"
+file_path="$(printf '%s' "$input" | jq -r '.tool_input.file_path // empty')"
+[ -z "$file_path" ] && exit 0
+[ -f "$file_path" ] || exit 0
+
+case "$file_path" in
+  *.py)
+    if command -v uv >/dev/null 2>&1; then
+      uv run ruff format "$file_path"        >/dev/null 2>&1 || true
+      uv run ruff check --fix "$file_path"   >/dev/null 2>&1 || true
+      # Surface anything auto-fix couldn't resolve, as feedback for Claude.
+      remaining="$(uv run ruff check "$file_path" 2>&1 || true)"
+      if [ -n "$remaining" ] && ! printf '%s' "$remaining" | grep -q "All checks passed"; then
+        echo "ruff still reports issues in $file_path:" >&2
+        printf '%s\n' "$remaining" >&2
+      fi
+    fi
+    ;;
+  *.go)
+    command -v gofmt >/dev/null 2>&1 && gofmt -w "$file_path" >/dev/null 2>&1 || true
+    ;;
+  *.ts|*.tsx|*.js|*.jsx)
+    # Use the project's configured formatter via just if present; stay silent otherwise.
+    command -v just >/dev/null 2>&1 && just --show fmt >/dev/null 2>&1 && just fmt >/dev/null 2>&1 || true
+    ;;
+esac
+
+exit 0

--- a/ROOT_CLAUDE.md
+++ b/ROOT_CLAUDE.md
@@ -1,0 +1,79 @@
+<!--
+  CLAUDE.md — Claude Code overlay. The shared, cross-tool base lives in AGENTS.md
+  and is imported below. Put ONLY Claude-specific behavior here so the two files
+  never drift. Codex reads AGENTS.md and ignores this file; Claude Code reads both.
+  Keep this short for the same adherence-budget reason AGENTS.md is short.
+-->
+
+@AGENTS.md
+
+# CLAUDE.md (Claude-specific overlay)
+
+Everything in AGENTS.md applies. The items below are additional behaviors that
+only make sense for Claude Code.
+
+## Response format
+
+- Always label which TDD phase a suggestion belongs to: **[Red] / [Green] /
+  [Refactor]**.
+- When proposing code, **show the failing test first**, then the implementation.
+- All Python suggestions include type annotations.
+- Propose commit messages in Conventional Commits form; the type prefix already
+  encodes structural-vs-behavioral, so never add `[STRUCTURAL]`/`[BEHAVIORAL]`
+  tags (see docs/agents/commit-discipline.md).
+
+## Plan review with codex (before showing a plan to the human)
+
+For any non-trivial implementation plan, run a codex review **before** presenting
+it. Skip silently only on a rate-limit error (e.g. "You've hit your usage
+limit…").
+
+```sh
+# First review of a new plan:
+codex exec -m gpt-5.5 --skip-git-repo-check \
+  "このプランをレビューして。瑣末な点へのクソリプはしないで。致命的な点だけ指摘して: {plan_full_path} (ref: {AGENTS.md full_path})"
+
+# Reviewing an updated plan — keep prior context with `resume --last`:
+codex exec resume --skip-git-repo-check --last -m gpt-5.5 \
+  "プランを更新したからレビューして。瑣末な点へのクソリプはしないで。致命的な点だけ指摘して: {plan_full_path} (ref: {AGENTS.md full_path})"
+```
+
+To counter the reviewer model's stale knowledge, gather current docs/URLs into a
+temp file and pass its path in the prompt.
+
+## ASCII diagrams in responses
+
+- Use **single-byte ASCII only** inside diagrams — no Japanese/Chinese/Korean/
+  emoji (multi-byte chars break monospace alignment).
+- Always add a legend directly below, with Japanese glosses unless told
+  otherwise (`English term: 日本語`).
+
+```
++-------------------+
+|  Request Handler  |
++-------------------+
+         |
+         v
++-------------------+
+|     Validator     |
++-------------------+
+
+Legend / 凡例:
+- Request Handler: リクエストハンドラー
+- Validator: バリデーター
+```
+
+## Hook awareness
+
+`.claude/settings.json` enforces the non-negotiables mechanically. If a hook
+blocks an action (exit 2 with a reason), do not try to route around it — the
+block is policy. Read the reason and change approach (e.g. switch `npm` → `bun`,
+`.yml` → `.yaml`, or open an IaC PR instead of a manual `gcloud` mutation).
+
+## Never (Claude-specific reminders; the rest are in AGENTS.md)
+
+- Never suggest untested code for production, or skip the failing-test step.
+- Never mix structural and behavioral changes in one suggestion.
+- Never create or update `docs/intent.md` with guessed intent — ask the human
+  first.
+- Never suggest editing the ruff/mypy/semgrep configuration to make a check pass.

--- a/justfile
+++ b/justfile
@@ -148,7 +148,11 @@ deploy:
     fi
     echo "==> Deploy complete!"
 
-# Sync: copy ROOT_AGENTS files to agent instruction directories
+# Sync: distribute the hub-and-spoke agent instructions to agent home dirs.
+#   ROOT_AGENTS.md (base) -> codex/AGENTS.md, gemini/GEMINI.md, claude/AGENTS.md
+#   ROOT_CLAUDE.md (overlay, @AGENTS.md) -> claude-family/CLAUDE.md
+#   ROOT_AGENTS_docs_agents_*.md (spokes) -> <agent>/docs/agents/* (abs refs)
+#   ROOT_AGENTS_hooks_*.sh + .claude/settings.hooks.json -> claude-family only
 # Default scope = .claude only. Pass targets to widen:
 #   just sync-agents               -> ~/.claude only
 #   just sync-agents a b           -> + ~/.claude-work-a, ~/.claude-work-b
@@ -157,6 +161,21 @@ deploy:
 [group('Agents')]
 sync-agents *args:
     @{{UV_RUN}} scripts/sync_agents.py {{ args }}
+
+# Scaffold: copy the agent-baseline template (per-repo enforcement: just check
+# gate, .githooks/pre-commit, quality-gate CI, agentcore semgrep rules) into a
+# target repo, then enable its git hooks. NOT applied to this repo (dotfiles
+# uses prek + its own CI/.semgrep). See templates/agent-baseline/README-agents-setup.md.
+[group('Agents')]
+scaffold-agent-baseline dir:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    src="{{ justfile_directory() }}/templates/agent-baseline"
+    dest="{{ dir }}"
+    [ -d "$dest" ] || { echo "❌ target dir does not exist: $dest"; exit 1; }
+    echo "📦 Copying agent-baseline scaffold into $dest ..."
+    cp -R "$src/." "$dest/"
+    echo "✅ Scaffold copied. Next: cd '$dest' && just install-hooks"
 
 # Sync (preview): show what would be synced without making changes
 [group('Agents')]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,9 @@ extend-exclude = [
     "protocols",
     "skills",
     "telemetry",
+    # templates/agent-baseline/.semgrep/tests/* are intentional-violation
+    # fixtures (os.path.join / MagicMock) for the scaffold's own semgrep rules.
+    "templates",
     "tools",
     # `private/certificates/` is created by Let's Encrypt with mode 0700.
     # Inside a bind-mounted dev container ruff cannot traverse it and aborts.

--- a/scripts/sync_agents.py
+++ b/scripts/sync_agents.py
@@ -41,6 +41,11 @@ from typing import Literal
 
 DOTFILES_DIR = Path.home() / "dotfiles"
 BASE_FILE = "ROOT_AGENTS.md"
+# Claude-only overlay (imports the base via `@AGENTS.md`). Distributed as the
+# main_file for claude-family agents; the base is written alongside as AGENTS.md.
+OVERLAY_FILE = "ROOT_CLAUDE.md"
+# Hooks settings fragment merged into each claude-family agent's settings.json.
+HOOK_SETTINGS_FRAGMENT = ".claude/settings.hooks.json"
 
 # Directories to sync directly (in addition to ROOT_AGENTS_* files)
 SYNC_DIRECTORIES = ["commands", "skills", "agents"]
@@ -56,6 +61,17 @@ class AgentTarget:
     main_file: str | None = None
     is_import_source: bool = False
     sync_directories: list[str] | None = None
+    # Hub-and-spoke distribution:
+    #   overlay_main=True  -> main_file gets the OVERLAY (ROOT_CLAUDE.md) and the
+    #                         base (ROOT_AGENTS.md) is written to base_secondary.
+    #   overlay_main=False -> main_file gets the base directly (codex/gemini).
+    # base_secondary       -> extra file that receives the base (e.g. AGENTS.md),
+    #                         so a CLAUDE.md `@AGENTS.md` import resolves.
+    # receives_hooks       -> hooks/* and the settings.json hook merge apply only
+    #                         to claude-family agents (Claude-only mechanism).
+    overlay_main: bool = False
+    base_secondary: str | None = None
+    receives_hooks: bool = False
 
     def get_sync_directories(self) -> list[str]:
         """Return directories to sync for this agent."""
@@ -73,30 +89,45 @@ AGENTS: list[AgentTarget] = [
         key="claude",
         main_file="CLAUDE.md",
         is_import_source=True,
+        overlay_main=True,
+        base_secondary="AGENTS.md",
+        receives_hooks=True,
     ),
     AgentTarget(
         Path.home() / ".claude-work-a",
         "Claude(Work-A)",
         key="work-a",
         main_file="CLAUDE.md",
+        overlay_main=True,
+        base_secondary="AGENTS.md",
+        receives_hooks=True,
     ),
     AgentTarget(
         Path.home() / ".claude-work-b",
         "Claude(Work-B)",
         key="work-b",
         main_file="CLAUDE.md",
+        overlay_main=True,
+        base_secondary="AGENTS.md",
+        receives_hooks=True,
     ),
     AgentTarget(
         Path.home() / ".claude-work-c",
         "Claude(Work-C)",
         key="work-c",
         main_file="CLAUDE.md",
+        overlay_main=True,
+        base_secondary="AGENTS.md",
+        receives_hooks=True,
     ),
     AgentTarget(
         Path.home() / ".claude-work-d",
         "Claude(Work-D)",
         key="work-d",
         main_file="CLAUDE.md",
+        overlay_main=True,
+        base_secondary="AGENTS.md",
+        receives_hooks=True,
     ),
     AgentTarget(
         Path.home() / ".gemini",
@@ -225,6 +256,10 @@ class _SyncAction:
     relative_path: str
     is_directory: bool
     status: Literal["new", "changed", "synced"]
+    # When True, the target is written as text rendered by _render_for_agent
+    # (docs/agents/ references rewritten to the agent's absolute path) instead of
+    # a byte-for-byte copy. Set for the base, overlay, and spoke .md files.
+    render: bool = False
 
 
 @dataclass
@@ -559,6 +594,22 @@ def _sync_directory(source: Path, target: Path) -> None:
         shutil.copytree(source, target, ignore=_make_copytree_ignore())
 
 
+def _apply_sync_action(action: _SyncAction, agent: AgentTarget) -> None:
+    """Execute one sync action.
+
+    Rendered actions (base/overlay/spokes) are written as text with
+    docs/agents/ references rewritten to the agent's absolute path; everything
+    else is a byte-for-byte file or directory copy.
+    """
+    if action.render:
+        action.target.parent.mkdir(parents=True, exist_ok=True)
+        action.target.write_text(_render_for_agent(action.source.read_text(), agent))
+    elif action.is_directory:
+        _sync_directory(action.source, action.target)
+    else:
+        _sync_file(action.source, action.target)
+
+
 def _link_learned_skills(skills_dir: Path) -> None:
     """Create symlinks for learned skills at the top-level skills directory.
 
@@ -601,33 +652,129 @@ def _link_learned_skills(skills_dir: Path) -> None:
         link_path.symlink_to(Path("learned") / skill_name)
 
 
+def _render_for_agent(text: str, agent: AgentTarget) -> str:
+    """Rewrite on-demand spoke references to the agent's absolute location.
+
+    The base/overlay/spoke prose references playbooks as `docs/agents/X.md`
+    (relative). When distributed globally, a relative path would resolve against
+    the working project, not the agent's home, so it is rewritten to an absolute
+    `<agent_home>/docs/agents/X.md`. Deterministic -> idempotent.
+    """
+    return text.replace("docs/agents/", f"{agent.directory}/docs/agents/")
+
+
+def _is_spoke(relative_path: str) -> bool:
+    """A spoke is a docs/agents/*.md file (its references need rendering)."""
+    return relative_path.startswith("docs/agents/") and relative_path.endswith(".md")
+
+
+def _render_hook_command(command: str, agent: AgentTarget) -> str:
+    """Point a hook command at the agent's global hooks dir, not a project dir."""
+    return command.replace(
+        '"$CLAUDE_PROJECT_DIR/.claude/hooks/', f'"{agent.directory}/hooks/'
+    )
+
+
+def _merge_hook_settings(
+    dotfiles_dir: Path, agent: AgentTarget, dry_run: bool = False
+) -> bool:
+    """Idempotently merge the hook fragment into the agent's settings.json.
+
+    NOT manifest-tracked: settings.json is a user-owned shared file, so the
+    item-granular manifest (whole-file add/delete) would clobber user hooks on an
+    orphan sweep. Identity is the (event, matcher, rendered-command-set) tuple, so
+    re-running is a no-op. User keys and unmanaged hook entries are preserved.
+    With dry_run=True nothing is written. Returns True if the file would change.
+    """
+    fragment_path = dotfiles_dir / HOOK_SETTINGS_FRAGMENT
+    if not fragment_path.exists():
+        return False
+    fragment = json.loads(fragment_path.read_text())
+    target_path = agent.directory / "settings.json"
+    target = json.loads(target_path.read_text()) if target_path.exists() else {}
+
+    hooks = target.setdefault("hooks", {})
+    changed = False
+    for event, blocks in fragment.get("hooks", {}).items():
+        existing_blocks = hooks.setdefault(event, [])
+        for block in blocks:
+            rendered = {
+                "matcher": block.get("matcher"),
+                "hooks": [
+                    {**h, "command": _render_hook_command(h["command"], agent)}
+                    for h in block.get("hooks", [])
+                ],
+            }
+            if rendered not in existing_blocks:
+                existing_blocks.append(rendered)
+                changed = True
+
+    if changed and not dry_run:
+        target_path.parent.mkdir(parents=True, exist_ok=True)
+        target_path.write_text(json.dumps(target, indent=2, ensure_ascii=False) + "\n")
+    return changed
+
+
+def _plan_text_file(
+    source: Path, target: Path, relative_path: str, agent: AgentTarget
+) -> _SyncAction:
+    """Plan a rendered text file: status uses the rendered expected content."""
+    rendered = _render_for_agent(source.read_text(), agent)
+    if not target.exists():
+        status: Literal["new", "changed", "synced"] = "new"
+    elif target.read_text() == rendered:
+        status = "synced"
+    else:
+        status = "changed"
+    return _SyncAction(
+        source=source,
+        target=target,
+        relative_path=relative_path,
+        is_directory=False,
+        status=status,
+        render=True,
+    )
+
+
 def _build_sync_plan(
     dotfiles_dir: Path, agent: AgentTarget, additional_sources: list[_SyncItem]
 ) -> _SyncPlan:
     """Build sync plan for an agent."""
     actions: list[_SyncAction] = []
 
-    # Base file (skip for agents without a main_file)
+    # Base + overlay (skip for agents without a main_file, e.g. .agents global).
     if agent.main_file is not None:
-        source_base = dotfiles_dir / BASE_FILE
-        target_base = agent.directory / agent.main_file
-
-        if not target_base.exists():
-            status: Literal["new", "changed", "synced"] = "new"
-        elif _compare_files(source_base, target_base):
-            status = "synced"
-        else:
-            status = "changed"
-
-        actions.append(
-            _SyncAction(
-                source=source_base,
-                target=target_base,
-                relative_path=agent.main_file,
-                is_directory=False,
-                status=status,
+        base_src = dotfiles_dir / BASE_FILE
+        if agent.overlay_main:
+            # claude-family: main_file <- overlay; base written alongside.
+            overlay_src = dotfiles_dir / OVERLAY_FILE
+            actions.append(
+                _plan_text_file(
+                    overlay_src,
+                    agent.directory / agent.main_file,
+                    agent.main_file,
+                    agent,
+                )
             )
-        )
+            if agent.base_secondary is not None:
+                actions.append(
+                    _plan_text_file(
+                        base_src,
+                        agent.directory / agent.base_secondary,
+                        agent.base_secondary,
+                        agent,
+                    )
+                )
+        else:
+            # codex/gemini: main_file <- base directly.
+            actions.append(
+                _plan_text_file(
+                    base_src,
+                    agent.directory / agent.main_file,
+                    agent.main_file,
+                    agent,
+                )
+            )
 
     # Additional sources (filtered by agent's sync_directories if customized)
     for item in additional_sources:
@@ -636,8 +783,25 @@ def _build_sync_plan(
             item_dir = item.relative_path.split("/")[0]
             if item_dir not in agent.sync_directories:
                 continue
+        # Hooks are a Claude-only mechanism: skip for non-claude agents.
+        if item.relative_path.startswith("hooks/") and not agent.receives_hooks:
+            continue
+
+        # Spokes (docs/agents/*.md) are rendered like the base/overlay.
+        if not item.is_directory and _is_spoke(item.relative_path):
+            actions.append(
+                _plan_text_file(
+                    item.source,
+                    agent.directory / item.relative_path,
+                    item.relative_path,
+                    agent,
+                )
+            )
+            continue
+
         target_path = agent.directory / item.relative_path
 
+        status: Literal["new", "changed", "synced"]
         if target_path.is_symlink():
             # Symlinks in targets should always be replaced with real copies
             status = "changed"
@@ -708,6 +872,12 @@ def _print_plan(
                 has_changes = True
             elif verbose:
                 print(f"  ✅ {icon} {action.relative_path} [SYNCED]")
+
+        if plan.agent.receives_hooks and _merge_hook_settings(
+            dotfiles_dir, plan.agent, dry_run=True
+        ):
+            print("  📝 📄 settings.json [HOOKS MERGE]")
+            has_changes = True
 
         for deletion in plan.deletions:
             icon = "📁" if deletion.is_directory else "📄"
@@ -1109,21 +1279,20 @@ def sync_mode(
             icon = "📁" if action.is_directory else "📄"
 
             if action.status == "new":
-                if action.is_directory:
-                    _sync_directory(action.source, action.target)
-                else:
-                    _sync_file(action.source, action.target)
+                _apply_sync_action(action, plan.agent)
                 print(f"  ✅ {icon} {action.relative_path}: Created")
 
             elif action.status == "changed":
                 if auto_yes or _confirm(f"  Overwrite {action.relative_path}?"):
-                    if action.is_directory:
-                        _sync_directory(action.source, action.target)
-                    else:
-                        _sync_file(action.source, action.target)
+                    _apply_sync_action(action, plan.agent)
                     print(f"  ✅ {icon} {action.relative_path}: Updated")
                 else:
                     print(f"  ⏭️  {icon} {action.relative_path}: Skipped")
+
+        # Merge the Claude hook fragment into the agent's settings.json
+        # (claude-family only; idempotent, manifest-independent).
+        if plan.agent.receives_hooks and _merge_hook_settings(dotfiles_dir, plan.agent):
+            print("  ✅ 📄 settings.json: hooks merged")
 
         # Apply deletions
         for deletion in plan.deletions:

--- a/templates/agent-baseline/.githooks/pre-commit
+++ b/templates/agent-baseline/.githooks/pre-commit
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# .githooks/pre-commit
+# Deterministic commit gate for HUMANS (and any tool that runs git commit).
+# Mirrors the Claude Code hooks so the same rules apply whoever commits.
+# Enable once per clone:  just install-hooks   (sets core.hooksPath=.githooks)
+set -euo pipefail
+
+if ! command -v just >/dev/null 2>&1; then
+  echo "pre-commit: 'just' is required but not found. Install just, then retry." >&2
+  exit 1
+fi
+
+echo "pre-commit: running 'just check' (fmt + lint + types + semgrep + test)…"
+just check

--- a/templates/agent-baseline/.github/workflows/quality-gate.yaml
+++ b/templates/agent-baseline/.github/workflows/quality-gate.yaml
@@ -1,0 +1,55 @@
+# .github/workflows/quality-gate.yaml
+# Required check before merge. Mirrors `just check` so local == CI, and adds a
+# tofu drift check (see docs/agents/iac-drift-policy.md).
+# Note: GitHub Actions accepts .yaml, so this respects the .yaml-only rule.
+
+name: quality-gate
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  gate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Install just
+        uses: extractions/setup-just@v2
+
+      - name: Install Semgrep
+        run: uv tool install semgrep
+
+      - name: Sync dependencies
+        run: uv sync --all-extras --dev
+
+      # Single source of truth for "green": the same recipe humans run locally.
+      - name: Run the gate
+        run: just check
+
+  iac-drift:
+    runs-on: ubuntu-latest
+    if: ${{ hashFiles('tofu/**') != '' }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup OpenTofu
+        uses: opentofu/setup-opentofu@v1
+
+      - name: tofu init
+        working-directory: tofu
+        run: tofu init -backend=false
+
+      # -detailed-exitcode: 0 = no changes, 2 = drift, 1 = error.
+      # A non-empty plan on a PR means live infra and the repo disagree.
+      - name: tofu plan (fail on drift)
+        working-directory: tofu
+        run: tofu plan -detailed-exitcode -lock=false

--- a/templates/agent-baseline/.semgrep/README.md
+++ b/templates/agent-baseline/.semgrep/README.md
@@ -1,0 +1,36 @@
+# Semgrep ruleset
+
+Project-specific static analysis. These rules mechanically enforce decisions that
+are otherwise only advisory in `AGENTS.md` / `docs/agents/`. Full philosophy and
+conventions: `docs/agents/semgrep.md`.
+
+## Layout
+
+```
+.semgrep/rules/{category}/{rule-id}.yaml    # one rule per file, id == filename
+.semgrep/tests/{category}/{rule-id}.{py,…}  # >=1 positive (# ruleid:) + 1 negative (# ok:)
+```
+
+## Run
+
+```sh
+just semgrep                              # = semgrep --config .semgrep/rules/ --error
+semgrep --test --config .semgrep/rules/ .semgrep/tests/   # validate the rules themselves
+```
+
+CI runs `just semgrep` as part of the required quality gate; the pre-commit hook
+runs it too.
+
+## Current rules
+
+| id                                    | enforces                                  |
+| ------------------------------------- | ----------------------------------------- |
+| `agentcore-testing-no-mock-in-e2e`    | no mocks/patching under `tests/e2e/`      |
+| `agentcore-python-no-os-path`         | `pathlib.Path` instead of `os.path`       |
+
+## Adding a rule
+
+Add the rule the **second** time the same issue shows up in review. Use the id
+format `{project-prefix}-{category}-{short-name}`, `.yaml` extension, and include
+a test file with at least one match and one non-match. Link the backing ADR in
+`metadata.adr` when the rule enforces an ADR decision.

--- a/templates/agent-baseline/.semgrep/rules/python-style/agentcore-python-no-os-path.yaml
+++ b/templates/agent-baseline/.semgrep/rules/python-style/agentcore-python-no-os-path.yaml
@@ -1,0 +1,18 @@
+rules:
+  - id: agentcore-python-no-os-path
+    message: |
+      Use pathlib.Path for path manipulation; os.path is deprecated in this
+      project. See docs/agents/python-tooling.md.
+    severity: ERROR
+    languages: [python]
+    paths:
+      exclude:
+        - "tests/"
+    patterns:
+      - pattern-either:
+          - pattern: os.path.$F(...)
+          - pattern: from os.path import $F
+    metadata:
+      category: python-style
+      added: "2026-06-10"
+      ref: docs/agents/python-tooling.md

--- a/templates/agent-baseline/.semgrep/rules/testing/agentcore-testing-no-mock-in-e2e.yaml
+++ b/templates/agent-baseline/.semgrep/rules/testing/agentcore-testing-no-mock-in-e2e.yaml
@@ -1,0 +1,24 @@
+rules:
+  - id: agentcore-testing-no-mock-in-e2e
+    message: |
+      Mocks/stubs/patching are forbidden in e2e tests. e2e uses real
+      dependencies; if a real dependency cannot be used, move the test to
+      integration. See docs/agents/testing.md.
+    severity: ERROR
+    languages: [python]
+    paths:
+      include:
+        - "tests/e2e/"
+    patterns:
+      - pattern-either:
+          - pattern: unittest.mock.$ANY(...)
+          - pattern: mock.$ANY(...)
+          - pattern: $M.patch(...)
+          - pattern: MagicMock(...)
+          - pattern: Mock(...)
+          - pattern: mocker.$ANY(...)
+          - pattern: monkeypatch.$ANY(...)
+    metadata:
+      category: testing
+      added: "2026-06-10"
+      ref: docs/agents/testing.md

--- a/templates/agent-baseline/.semgrep/tests/python-style/agentcore-python-no-os-path.py
+++ b/templates/agent-baseline/.semgrep/tests/python-style/agentcore-python-no-os-path.py
@@ -1,0 +1,13 @@
+# Test fixture for agentcore-python-no-os-path.
+import os.path  # noqa
+from pathlib import Path
+
+
+def build_path_bad(root: str, name: str) -> str:
+    # ruleid: agentcore-python-no-os-path
+    return os.path.join(root, name)
+
+
+def build_path_good(root: str, name: str) -> Path:
+    # ok: agentcore-python-no-os-path
+    return Path(root) / name

--- a/templates/agent-baseline/.semgrep/tests/testing/agentcore-testing-no-mock-in-e2e.py
+++ b/templates/agent-baseline/.semgrep/tests/testing/agentcore-testing-no-mock-in-e2e.py
@@ -1,0 +1,23 @@
+# Test fixture for agentcore-testing-no-mock-in-e2e.
+# Semgrep test annotations: a line ending in the rule id after "rule"+"id:" marks
+# an expected match; "ok:" + rule id marks an expected non-match. (Worded to
+# avoid embedding those literal tokens in this header.)
+from unittest import mock
+from unittest.mock import MagicMock
+
+
+def test_uses_mock_is_flagged() -> None:
+    # ruleid: agentcore-testing-no-mock-in-e2e
+    client = MagicMock()
+    assert client is not None
+
+
+def test_uses_patch_is_flagged(mocker) -> None:
+    # ruleid: agentcore-testing-no-mock-in-e2e
+    mocker.patch("service.call")
+
+
+def test_real_dependency_is_ok() -> None:
+    # ok: agentcore-testing-no-mock-in-e2e
+    client = create_real_client()
+    assert client.ping() is True

--- a/templates/agent-baseline/README-agents-setup.md
+++ b/templates/agent-baseline/README-agents-setup.md
@@ -1,0 +1,138 @@
+# Agent instruction set — structure & setup
+
+This replaces the single 1,156-line `ROOT_AGENTS.md` with a **hub-and-spoke**
+layout plus a **deterministic enforcement layer**. The reasoning, in one
+paragraph: AI coding agents reliably follow only ~150-200 instructions before
+adherence degrades (the agent's own system prompt already spends ~50), and a long
+instruction file dilutes every rule in it. So the always-loaded files are kept
+short, the detail is loaded on demand, and anything that must hold *every time*
+is moved out of prose into hooks/CI that don't depend on model judgment.
+
+## File map
+
+```
+AGENTS.md                      # always-loaded, cross-tool base (~150 lines)
+CLAUDE.md                      # @imports AGENTS.md + Claude-only overlay
+justfile                       # the only task runner; `just check` is the gate
+README-agents-setup.md         # this file
+
+docs/agents/                   # spokes — read on demand (NOT preloaded)
+  tdd-workflow.md
+  commit-discipline.md
+  python-tooling.md
+  testing.md
+  observability.md
+  iac-drift-policy.md
+  semgrep.md
+  docs-discipline.md
+  project-structure.md
+
+.claude/
+  settings.json                # wires the hooks below
+  hooks/
+    block-prohibited-files.sh    # PreToolUse: blocks .yml / docker-compose.*
+    block-prohibited-commands.sh # PreToolUse: blocks pip/npm/yarn/make, IaC drift, rm -rf /
+    block-secrets.sh             # PreToolUse: blocks obvious secrets in writes
+    format-after-edit.sh         # PostToolUse: ruff format + --fix on edited files
+
+.githooks/pre-commit           # human/git gate -> runs `just check`
+.github/workflows/quality-gate.yaml  # CI gate + tofu drift check
+.semgrep/                      # project-specific rules (see its README)
+```
+
+## Why two files (AGENTS.md + CLAUDE.md) and not one symlink
+
+Codex reads only `AGENTS.md`; Claude Code reads `CLAUDE.md` and pulls in
+`AGENTS.md` via the `@AGENTS.md` import at its top. The symlink pattern is for
+when the two files are *identical*. Here they're not — `CLAUDE.md` adds
+Claude-only behavior (codex plan-review, ASCII-legend rules, response-format
+directives). The import keeps the shared base in exactly one place so the two
+never drift. Cursor/Copilot read `AGENTS.md` too, so the base is shared across
+every tool.
+
+## The three enforcement layers (and why prose isn't enough)
+
+`AGENTS.md`/`CLAUDE.md` instructions are **advisory** — the agent reads them and
+*usually* complies, but can decide a rule doesn't apply. For rules that must hold
+with zero exceptions, that's not good enough. So:
+
+1. **Claude Code hooks** — fire before/after tool calls, bypassing model
+   judgment. PreToolUse hooks **block** with `exit 2` (the script's stderr is fed
+   back to the agent as the reason). Critical gotcha baked into every guard:
+   `exit 2` blocks, `exit 1` does **not** — `exit 1` is a non-blocking error and
+   the action proceeds.
+2. **Git pre-commit** (`.githooks/pre-commit` → `just check`) — same gate for
+   humans and any tool that runs `git commit`.
+3. **CI** (`quality-gate.yaml`) — the merge gate; runs `just check` plus a
+   `tofu plan` drift check.
+
+The prose still matters: it carries the **why**, which is how an agent
+generalizes a rule to cases the hook doesn't pattern-match. Hooks guarantee the
+common cases; prose covers the long tail.
+
+## One-time setup per clone
+
+```sh
+just install-hooks      # sets core.hooksPath=.githooks and chmod +x the hooks
+```
+
+Claude Code picks up `.claude/settings.json` automatically. Verify hooks load
+with `/hooks` inside Claude Code. Personal-only experiments go in
+`.claude/settings.local.json` (auto-gitignored).
+
+## Repo-scan self-reference
+
+`AGENTS.md` and `docs/agents/*.md` deliberately name a few prohibited patterns as
+examples. Exclude them when scanning the repo:
+
+```sh
+# git grep
+git grep <pattern> -- ':(exclude)**/AGENTS.md' ':(exclude)**/CLAUDE.md' ':(exclude)docs/agents/**'
+```
+
+```yaml
+# semgrep rule
+paths:
+  exclude: [AGENTS.md, CLAUDE.md, "docs/agents/**"]
+```
+
+The `block-prohibited-files` hook already exempts these paths.
+
+## Tuning the hooks
+
+The command/file guards use conservative regexes. If a guard misfires (false
+positive) or misses a case you care about (false negative), edit the matching
+`.claude/hooks/*.sh` script — they're plain bash with the logic inline and
+commented. Test a hook in isolation:
+
+```sh
+echo '{"tool_input":{"command":"npm install"}}' | bash .claude/hooks/block-prohibited-commands.sh; echo "exit=$?"
+echo '{"tool_input":{"file_path":"config.yml"}}' | bash .claude/hooks/block-prohibited-files.sh; echo "exit=$?"
+```
+
+(`exit=2` means the guard would block; `exit=0` means it would allow.)
+
+## What changed vs the old ROOT_AGENTS.md (nothing dropped)
+
+Every rule from the original survives — it was relocated, not removed:
+
+| original section                              | now lives in                          |
+| --------------------------------------------- | ------------------------------------- |
+| role, decision priorities, core principles    | `AGENTS.md`                           |
+| GRIT requirement                               | `AGENTS.md` (rubric → grit-grill skill) |
+| tooling standards (uv/bun/just/.yaml)          | `AGENTS.md` non-negotiables + hooks   |
+| TDD methodology + workflow + example           | `docs/agents/tdd-workflow.md`         |
+| Tidy First + commit discipline + Conv. Commits | `docs/agents/commit-discipline.md`    |
+| python-tooling (ruff/mypy) + refactoring + encoding | `docs/agents/python-tooling.md`  |
+| mock policy + unit/e2e/runn                    | `docs/agents/testing.md`              |
+| observability (OTel/Jaeger)                    | `docs/agents/observability.md`        |
+| IaC drift policy                               | `docs/agents/iac-drift-policy.md` + command hook |
+| semgrep guidelines                             | `docs/agents/semgrep.md` + `.semgrep/`|
+| docs / ADR / intent / handover                 | `docs/agents/docs-discipline.md`      |
+| project/docker/scripts/experiments structure   | `docs/agents/project-structure.md`    |
+| codex plan-review, ASCII-art, response format  | `CLAUDE.md`                           |
+| "prohibited actions" list                      | split: hooks (mechanical) + `CLAUDE.md` (judgment) |
+
+The instruction files are kept in English (as the original was) for cross-tool
+and cross-model reliability; intentional Japanese (GRIT glosses, the codex review
+prompt, ASCII legends) is preserved.

--- a/templates/agent-baseline/justfile
+++ b/templates/agent-baseline/justfile
@@ -1,0 +1,55 @@
+# justfile — the ONLY task runner for this repo (no make, no npm scripts).
+# Exactly one justfile, at the root. `just` with no args prints this list.
+
+# Show available tasks (default)
+default: help
+
+help:
+    @just --list
+
+# The full local gate. This is what the pre-commit hook and CI both run.
+# Keep this as the single source of truth for "is the tree green?".
+check: fmt lint semgrep test
+
+# Run all tests
+test:
+    uv run pytest
+
+# Lint + type-check
+lint:
+    uv run ruff check .
+    uv run mypy .
+
+# Format code
+fmt:
+    uv run ruff format .
+
+# Run e2e tests
+test-e2e:
+    uv run pytest tests/e2e/
+
+# Run semgrep (project-specific rules). No-op-safe when .semgrep/ is absent.
+semgrep:
+    @test -d .semgrep/rules && semgrep --config .semgrep/rules/ --error || \
+     echo "no .semgrep/rules — skipping"
+
+# Wire the repo-managed git hooks (run once per clone).
+install-hooks:
+    git config core.hooksPath .githooks
+    chmod +x .githooks/* .claude/hooks/*.sh 2>/dev/null || true
+    @echo "git hooks enabled (core.hooksPath=.githooks). Claude Code hooks live in .claude/settings.json."
+
+# Start local observability stack (Jaeger)
+trace-up:
+    docker compose -f compose.yaml up -d jaeger
+
+# Stop local observability stack
+trace-down:
+    docker compose -f compose.yaml stop jaeger
+
+# Open Jaeger UI in browser
+trace-view:
+    @echo "Jaeger UI: http://localhost:16686"
+    @command -v open >/dev/null 2>&1 && open http://localhost:16686 || \
+     command -v xdg-open >/dev/null 2>&1 && xdg-open http://localhost:16686 || \
+     echo "Please open http://localhost:16686 manually"

--- a/tests/test_sync_agents.py
+++ b/tests/test_sync_agents.py
@@ -2077,3 +2077,101 @@ def test_just_sync_agents_override_default_scope_does_not_touch_work_a(docker_im
     result = _run_in_container(docker_image, cmd)
 
     assert "work-a orphan preserved" in result.stdout
+
+
+# =============================================================================
+# Hub-and-spoke layout: ROOT_AGENTS.md (base) + ROOT_CLAUDE.md (overlay) +
+# ROOT_AGENTS_docs_agents_* (spokes) + ROOT_AGENTS_hooks_* + settings merge.
+# =============================================================================
+
+
+def test_hub_and_spoke_claude_gets_overlay_base_spokes_hooks(docker_image):
+    """claude-family: CLAUDE.md=overlay(@AGENTS.md), AGENTS.md=base, docs/agents/
+    spokes with absolute refs, executable hooks, merged settings.json."""
+    cmd = r"""
+    set -euo pipefail
+    cd /root/dotfiles && just sync-agents-auto p
+
+    grep -q '^@AGENTS.md' /root/.claude/CLAUDE.md && echo "overlay-imports-base"
+    grep -q 'Non-negotiables' /root/.claude/AGENTS.md && echo "base-is-agents-md"
+    [ -f /root/.claude/docs/agents/python-tooling.md ] && echo "spoke-present"
+    [ -x /root/.claude/hooks/block-prohibited-commands.sh ] && echo "hook-executable"
+    grep -q '/root/.claude/docs/agents/python-tooling.md' /root/.claude/AGENTS.md && echo "spoke-ref-absolute"
+    grep -q '/root/.claude/hooks/block-prohibited-commands.sh' /root/.claude/settings.json && echo "settings-merged-absolute"
+    """
+    result = _run_in_container(docker_image, cmd)
+    for marker in (
+        "overlay-imports-base",
+        "base-is-agents-md",
+        "spoke-present",
+        "hook-executable",
+        "spoke-ref-absolute",
+        "settings-merged-absolute",
+    ):
+        assert marker in result.stdout, f"missing {marker}\n{result.stdout}"
+
+
+def test_hub_and_spoke_codex_gemini_base_only_no_hooks(docker_image):
+    """codex/gemini get the base directly (no overlay, no hooks); spokes present
+    with refs rewritten to each agent's own absolute path."""
+    cmd = r"""
+    set -euo pipefail
+    cd /root/dotfiles && just sync-agents-auto x g
+
+    grep -q 'Non-negotiables' /root/.codex/AGENTS.md && echo "codex-base"
+    grep -q 'Non-negotiables' /root/.gemini/GEMINI.md && echo "gemini-base"
+    [ -f /root/.codex/docs/agents/testing.md ] && echo "codex-spoke"
+    grep -q '/root/.codex/docs/agents/testing.md' /root/.codex/AGENTS.md && echo "codex-spoke-ref-absolute"
+    [ -d /root/.codex/hooks ] && echo "ERR-codex-hooks" || echo "codex-no-hooks"
+    [ -d /root/.gemini/hooks ] && echo "ERR-gemini-hooks" || echo "gemini-no-hooks"
+    [ -f /root/.codex/CLAUDE.md ] && echo "ERR-codex-overlay" || echo "codex-no-overlay"
+    """
+    result = _run_in_container(docker_image, cmd)
+    for marker in (
+        "codex-base",
+        "gemini-base",
+        "codex-spoke",
+        "codex-spoke-ref-absolute",
+        "codex-no-hooks",
+        "gemini-no-hooks",
+        "codex-no-overlay",
+    ):
+        assert marker in result.stdout, f"missing {marker}\n{result.stdout}"
+    assert "ERR-" not in result.stdout, result.stdout
+
+
+def test_hub_and_spoke_settings_merge_idempotent_preserves_user_keys(docker_image):
+    """settings.json merge preserves user keys + user hooks, adds managed hooks
+    with absolute paths, and is idempotent across repeated syncs."""
+    cmd = r"""
+    set -euo pipefail
+    mkdir -p /root/.claude
+    cat > /root/.claude/settings.json <<'JSON'
+{
+  "theme": "dark",
+  "hooks": {
+    "PreToolUse": [
+      { "matcher": "Read", "hooks": [ { "type": "command", "command": "echo user-hook" } ] }
+    ]
+  }
+}
+JSON
+    cd /root/dotfiles
+    just sync-agents-auto p
+    just sync-agents-auto p
+
+    python3 - <<'PY'
+import json
+s = json.load(open("/root/.claude/settings.json"))
+assert s.get("theme") == "dark", "user key lost"
+pre = s["hooks"]["PreToolUse"]
+cmds = [h["command"] for b in pre for h in b["hooks"]]
+assert "echo user-hook" in cmds, "user hook lost"
+managed = [c for c in cmds if c.endswith('block-prohibited-files.sh"')]
+assert len(managed) == 1, f"managed hook not idempotent: {managed}"
+assert all("/root/.claude/hooks/" in c for c in cmds if "block-" in c), "hook path not absolute"
+print("settings-merge-ok")
+PY
+    """
+    result = _run_in_container(docker_image, cmd)
+    assert "settings-merge-ok" in result.stdout, result.stdout


### PR DESCRIPTION
## 概要

`/Users/nino/Downloads/files-2.zip` の設計に基づき、global agent 指示を
**monolithic `ROOT_AGENTS.md` (1,156行) → hub-and-spoke** に移行。短い常時 load
の base + on-demand spoke + 機械 enforcement(hooks/CI) で「指示の希釈」を抑える。

## 配布モデル（sync_agents.py を per-tool に改修）

```
ROOT_AGENTS.md (base)  → codex/AGENTS.md, gemini/GEMINI.md, claude/AGENTS.md
ROOT_CLAUDE.md (overlay, @AGENTS.md) → claude-family/CLAUDE.md
ROOT_AGENTS_docs_agents_*.md (spoke ×9) → <agent>/docs/agents/* (絶対パス rewrite)
ROOT_AGENTS_hooks_*.sh + .claude/settings.hooks.json → claude-family のみ
```

- **spoke の絶対パス rewrite**: base 内 `docs/agents/X.md` を配布時に各 agent home の
  絶対パスへ。相対だと作業 project 側に解決して外すため。rendered 内容で比較し冪等維持。
- **settings.json マージ**: user キー非破壊・冪等。manifest 非追跡（item 粒度 manifest だと
  orphan sweep で user hooks を壊すため。codex レビュー指摘を反映）。
- **hooks は claude-family のみ**（Claude 専用機構）。

## per-repo enforcement は scaffold 保管

`.githooks/pre-commit` / `quality-gate.yaml` CI / `just check` gate / agentcore-* semgrep
rule は `templates/agent-baseline/` に保管（dotfiles 自身には未適用＝既存 prek/CI/.semgrep
と非競合）。`just scaffold-agent-baseline <dir>` で新規 repo へ展開。

## 検証

- **devcontainer サンドボックス（隔離・実 home 非汚染）で配置を実証**:
  - `test_hub_and_spoke_claude_gets_overlay_base_spokes_hooks` ✅
  - `test_hub_and_spoke_codex_gemini_base_only_no_hooks` ✅
  - `test_hub_and_spoke_settings_merge_idempotent_preserves_user_keys` ✅
  - 既存代表テスト（idempotent / creates-files / underscore→hooks / all-agents）✅ 回帰なし
- `just ci` ✅（ruff / shellcheck / markdownlint / meta-semgrep 0 / semgrep-test 27-27 / tofu 6）

## collateral

markdownlint/ruff の除外（新 source + scaffold fixture）、justfile recipe+コメント、
repo CLAUDE.md の二層構造節を更新。

> 注: 配布は **未 apply**（実 `~/.claude` は触っていない）。merge 後に各自
> `just sync-agents` で展開する想定。

## Known limitations（自己レビューで特定、merge 後の follow-up 候補）

1. **render は naive 全置換** — base 冒頭コメントの repo-scan 除外ガイド
   （`:(exclude)docs/agents/**` 等）も絶対パス化される。配布版コメント内の参考例が
   不正確になるだけで実害は小（global ファイルで project scan はしない）。
2. **settings.json マージは append-only** — fragment の hook command を将来変更すると
   旧エントリが残存し両方発火する（update-in-place 未実装）。fragment 改版時は
   手動掃除 or marker 置換の実装が必要。
3. **spoke / hooks の削除は自動掃除されない** — manifest は commands/skills/agents のみ
   追跡（legacy `ROOT_AGENTS_*` と同一挙動）。spoke を rename/削除したら配布先の
   旧ファイルは手動除去。
4. **`@AGENTS.md` の global 解決は実 apply 時に要確認** — `~/.claude/CLAUDE.md` からの
   import が `~/.claude/AGENTS.md` に解決しない場合は base inline 化へ fallback。
5. **`block-prohibited-commands.sh` の誤爆観察** — regex 検証済み（mise の npm: backend /
   npm_args / npx / bunx は非ブロック）だが、global 有効化後の実トラフィックで
   `gcloud ... update` 系の境界は要観察。
