### PR TITLE
feat(sync): make skills sync additive (coexist with bunx skills CLI)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,6 +25,10 @@
     - hooks + settings → **claude-family のみ**。settings.json は user キーを壊さず
       **冪等マージ** (manifest 非追跡。marker = event+matcher+rendered command)
     - `ROOT_AGENTS_<x>_<y>(.ext|/)` → `<agent>/<x>/<y>` (`_`→`/`) の従来規約も継続
+    - **`skills` は additive** (`ADDITIVE_DIRECTORIES`): 欠落 skill のみ追加、既存
+      target は**上書きしない・削除しない**。`bunx skills` CLI が `~/.agents/skills`
+      へ install した symlink (上流 + `bunx skills add hironow/skills`) を churn/orphan
+      削除しないため。skill の投入は CLI (`bunx skills add`) を優先する
 - **global ルールを変えるときは上記 source を編集して `just sync-agents`。**
   配布先 (`~/.claude/CLAUDE.md` 等) を直接編集しても次の sync で上書きされる。
 - **per-repo enforcement は `templates/agent-baseline/` に scaffold 保管** (dotfiles

--- a/scripts/sync_agents.py
+++ b/scripts/sync_agents.py
@@ -50,6 +50,26 @@ HOOK_SETTINGS_FRAGMENT = ".claude/settings.hooks.json"
 # Directories to sync directly (in addition to ROOT_AGENTS_* files)
 SYNC_DIRECTORIES = ["commands", "skills", "agents"]
 
+# Additive directories: add-only. Missing items are added, but existing target
+# items are NEVER overwritten and orphans are NEVER deleted. `skills` is additive
+# because it coexists with the `bunx skills` CLI, which installs skills (as
+# symlinks into ~/.agents/skills) from upstreams and from the dotfiles submodule
+# (`bunx skills add hironow/skills -s <name>`). A full-mirror sync would delete
+# CLI-only orphans and clobber the CLI-managed symlinks; additive preserves both
+# and defers population to the CLI. See repo CLAUDE.md.
+ADDITIVE_DIRECTORIES = ["skills"]
+# Exempt from additive (synced normally even under an additive dir): the
+# dotfiles-owned skill-creator workspace `skills/learned/`.
+ADDITIVE_EXEMPT_SUBDIRS = ["learned"]
+
+
+def _is_additive_item(relative_path: str) -> bool:
+    """True if a sync item is in an additive dir and not an exempt subdir."""
+    parts = relative_path.split("/")
+    if parts[0] not in ADDITIVE_DIRECTORIES:
+        return False
+    return not (len(parts) > 1 and parts[1] in ADDITIVE_EXEMPT_SUBDIRS)
+
 
 @dataclass
 class AgentTarget:
@@ -468,6 +488,9 @@ def _build_deletion_plan(
     deletions: list[_DeleteAction] = []
 
     for dir_name in agent.get_sync_directories():
+        # Additive dirs (skills) are add-only: never delete from the target.
+        if dir_name in ADDITIVE_DIRECTORIES:
+            continue
         manifest_items = set(manifest.items.get(dir_name, []))
         dotfiles_dir_path = dotfiles_dir / dir_name
         dotfiles_items: set[str] = set()
@@ -509,6 +532,10 @@ def _detect_target_only_items(
     orphans: list[_DeleteAction] = []
 
     for dir_name in agent.get_sync_directories():
+        # Additive dirs (skills) keep target-only items (e.g. bunx-skills CLI
+        # installs not present in the dotfiles submodule).
+        if dir_name in ADDITIVE_DIRECTORIES:
+            continue
         target_dir = agent.directory / dir_name
         source_dir = dotfiles_dir / dir_name
 
@@ -802,7 +829,17 @@ def _build_sync_plan(
         target_path = agent.directory / item.relative_path
 
         status: Literal["new", "changed", "synced"]
-        if target_path.is_symlink():
+        # Additive dirs (skills) are add-only: add when missing, but NEVER
+        # overwrite an existing target (a bunx-skills CLI symlink/copy) and NEVER
+        # delete. Prefer `bunx skills add` for populating skills. `learned/` is
+        # the dotfiles-owned skill-creator workspace, so it syncs normally.
+        if _is_additive_item(item.relative_path):
+            status = (
+                "new"
+                if not (target_path.exists() or target_path.is_symlink())
+                else "synced"
+            )
+        elif target_path.is_symlink():
             # Symlinks in targets should always be replaced with real copies
             status = "changed"
         elif item.is_directory:

--- a/tests/test_sync_agents.py
+++ b/tests/test_sync_agents.py
@@ -318,49 +318,49 @@ def test_sync_agents_handles_directory_sources(docker_image):
     """Test that ROOT_AGENTS_xxx_yyy/ becomes xxx/yyy/ with all contents.
 
     Scenario:
-    - given: ROOT_AGENTS_skills_test-skill/ directory exists with multiple files and subdirs
+    - given: ROOT_AGENTS_agents_test-skill/ directory exists with multiple files and subdirs
     - when: Run sync-agents
-    - then: Directory and ALL contents are synced to skills/test-skill/
+    - then: Directory and ALL contents are synced to agents/test-skill/
     """
     cmd = """
     set -euo pipefail
 
     # Create a test directory source with multiple files and nested subdirectories
-    mkdir -p /root/dotfiles/ROOT_AGENTS_skills_test-skill
-    mkdir -p /root/dotfiles/ROOT_AGENTS_skills_test-skill/templates
-    mkdir -p /root/dotfiles/ROOT_AGENTS_skills_test-skill/examples/advanced
+    mkdir -p /root/dotfiles/ROOT_AGENTS_agents_test-skill
+    mkdir -p /root/dotfiles/ROOT_AGENTS_agents_test-skill/templates
+    mkdir -p /root/dotfiles/ROOT_AGENTS_agents_test-skill/examples/advanced
 
     # Create files at various levels
-    echo "# Test Skill README" > /root/dotfiles/ROOT_AGENTS_skills_test-skill/README.md
-    echo "skill_name: test-skill" > /root/dotfiles/ROOT_AGENTS_skills_test-skill/config.yaml
-    echo "template content" > /root/dotfiles/ROOT_AGENTS_skills_test-skill/templates/main.txt
-    echo "example 1" > /root/dotfiles/ROOT_AGENTS_skills_test-skill/examples/basic.md
-    echo "advanced example" > /root/dotfiles/ROOT_AGENTS_skills_test-skill/examples/advanced/complex.md
+    echo "# Test Skill README" > /root/dotfiles/ROOT_AGENTS_agents_test-skill/README.md
+    echo "skill_name: test-skill" > /root/dotfiles/ROOT_AGENTS_agents_test-skill/config.yaml
+    echo "template content" > /root/dotfiles/ROOT_AGENTS_agents_test-skill/templates/main.txt
+    echo "example 1" > /root/dotfiles/ROOT_AGENTS_agents_test-skill/examples/basic.md
+    echo "advanced example" > /root/dotfiles/ROOT_AGENTS_agents_test-skill/examples/advanced/complex.md
 
     # Run sync-agents
     cd /root/dotfiles && just sync-agents-auto all
 
     # Verify directory structure
-    [ -d /root/.claude/skills/test-skill ] && echo "skills/test-skill/ exists"
-    [ -d /root/.claude/skills/test-skill/templates ] && echo "templates/ subdir exists"
-    [ -d /root/.claude/skills/test-skill/examples/advanced ] && echo "examples/advanced/ nested subdir exists"
+    [ -d /root/.claude/agents/test-skill ] && echo "agents/test-skill/ exists"
+    [ -d /root/.claude/agents/test-skill/templates ] && echo "templates/ subdir exists"
+    [ -d /root/.claude/agents/test-skill/examples/advanced ] && echo "examples/advanced/ nested subdir exists"
 
     # Verify all files exist
-    [ -f /root/.claude/skills/test-skill/README.md ] && echo "README.md exists"
-    [ -f /root/.claude/skills/test-skill/config.yaml ] && echo "config.yaml exists"
-    [ -f /root/.claude/skills/test-skill/templates/main.txt ] && echo "templates/main.txt exists"
-    [ -f /root/.claude/skills/test-skill/examples/basic.md ] && echo "examples/basic.md exists"
-    [ -f /root/.claude/skills/test-skill/examples/advanced/complex.md ] && echo "examples/advanced/complex.md exists"
+    [ -f /root/.claude/agents/test-skill/README.md ] && echo "README.md exists"
+    [ -f /root/.claude/agents/test-skill/config.yaml ] && echo "config.yaml exists"
+    [ -f /root/.claude/agents/test-skill/templates/main.txt ] && echo "templates/main.txt exists"
+    [ -f /root/.claude/agents/test-skill/examples/basic.md ] && echo "examples/basic.md exists"
+    [ -f /root/.claude/agents/test-skill/examples/advanced/complex.md ] && echo "examples/advanced/complex.md exists"
 
     # Verify file contents are correct
-    grep -q "Test Skill README" /root/.claude/skills/test-skill/README.md && echo "README content correct"
-    grep -q "skill_name: test-skill" /root/.claude/skills/test-skill/config.yaml && echo "config content correct"
-    grep -q "advanced example" /root/.claude/skills/test-skill/examples/advanced/complex.md && echo "nested content correct"
+    grep -q "Test Skill README" /root/.claude/agents/test-skill/README.md && echo "README content correct"
+    grep -q "skill_name: test-skill" /root/.claude/agents/test-skill/config.yaml && echo "config content correct"
+    grep -q "advanced example" /root/.claude/agents/test-skill/examples/advanced/complex.md && echo "nested content correct"
     """
     result = _run_in_container(docker_image, cmd)
 
     # then: Directory and all contents are synced
-    assert "skills/test-skill/ exists" in result.stdout
+    assert "agents/test-skill/ exists" in result.stdout
     assert "templates/ subdir exists" in result.stdout
     assert "examples/advanced/ nested subdir exists" in result.stdout
     assert "README.md exists" in result.stdout
@@ -732,17 +732,21 @@ def test_sync_agents_keeps_newer_dotfiles_over_older_symlink(docker_image):
     # Run sync-agents
     cd /root/dotfiles && just sync-agents-auto all
 
-    # Verify dotfiles version was preserved (it's newer)
+    # Verify dotfiles version was preserved (it's newer) — import-conflict
+    # resolution is unchanged by additive skills.
     grep -q "Dotfiles version (newer)" /root/dotfiles/skills/shared-skill/README.md && echo "dotfiles version preserved"
 
-    # Verify targets got the dotfiles version
-    grep -q "Dotfiles version (newer)" /root/.claude/skills/shared-skill/README.md && echo "claude got dotfiles version"
+    # skills is additive: the EXISTING target symlink is preserved (not
+    # overwritten with the dotfiles copy).
+    [ -L /root/.claude/skills/shared-skill ] && echo "claude symlink preserved"
+    grep -q "External version (older)" /root/.claude/skills/shared-skill/README.md && echo "claude kept existing"
     """
     result = _run_in_container(docker_image, cmd)
 
-    # then: Dotfiles version was preserved
+    # then: dotfiles keeps the newer copy; the target's existing skill is kept
     assert "dotfiles version preserved" in result.stdout
-    assert "claude got dotfiles version" in result.stdout
+    assert "claude symlink preserved" in result.stdout
+    assert "claude kept existing" in result.stdout
 
 
 # =============================================================================
@@ -927,28 +931,28 @@ def test_sync_agents_does_not_reimport_deleted_items(docker_image):
     set -euo pipefail
 
     # Create and import a skill via import source
-    mkdir -p /root/.claude/skills/ephemeral-skill
-    echo "# Ephemeral" > /root/.claude/skills/ephemeral-skill/README.md
+    mkdir -p /root/.claude/agents/ephemeral-skill
+    echo "# Ephemeral" > /root/.claude/agents/ephemeral-skill/README.md
 
     # First sync: imports to dotfiles, syncs to targets
     cd /root/dotfiles && just sync-agents-auto all
-    [ -d /root/dotfiles/skills/ephemeral-skill ] && echo "initially imported"
+    [ -d /root/dotfiles/agents/ephemeral-skill ] && echo "initially imported"
 
     # Delete from dotfiles (simulating intentional removal)
-    rm -rf /root/dotfiles/skills/ephemeral-skill
+    rm -rf /root/dotfiles/agents/ephemeral-skill
 
     # Second sync: should NOT re-import, should delete from targets
     cd /root/dotfiles && just sync-agents-auto all
 
     # Verify NOT re-imported to dotfiles
-    if [ -d /root/dotfiles/skills/ephemeral-skill ]; then
+    if [ -d /root/dotfiles/agents/ephemeral-skill ]; then
         echo "ERROR: re-imported to dotfiles"
     else
         echo "correctly not re-imported"
     fi
 
     # Verify deleted from claude (import source)
-    if [ -d /root/.claude/skills/ephemeral-skill ]; then
+    if [ -d /root/.claude/agents/ephemeral-skill ]; then
         echo "ERROR: still in claude"
     else
         echo "deleted from claude"
@@ -1038,28 +1042,28 @@ def test_sync_agents_replaces_symlinks_in_targets(docker_image):
     set -euo pipefail
 
     # Create a skill in dotfiles
-    mkdir -p /root/dotfiles/skills/real-skill
-    echo "# Real Skill" > /root/dotfiles/skills/real-skill/README.md
+    mkdir -p /root/dotfiles/agents/real-skill
+    echo "# Real Skill" > /root/dotfiles/agents/real-skill/README.md
 
     # Create a symlink in gemini pointing elsewhere
     mkdir -p /opt/other/real-skill
     echo "# Other" > /opt/other/real-skill/README.md
-    mkdir -p /root/.gemini/skills
-    ln -s /opt/other/real-skill /root/.gemini/skills/real-skill
+    mkdir -p /root/.gemini/agents
+    ln -s /opt/other/real-skill /root/.gemini/agents/real-skill
 
     # Verify it's a symlink before sync
-    [ -L /root/.gemini/skills/real-skill ] && echo "is symlink before"
+    [ -L /root/.gemini/agents/real-skill ] && echo "is symlink before"
 
     # Run sync-agents
     cd /root/dotfiles && just sync-agents-auto all
 
     # Verify symlink was replaced with real dir
-    if [ -L /root/.gemini/skills/real-skill ]; then
+    if [ -L /root/.gemini/agents/real-skill ]; then
         echo "ERROR: still a symlink"
     else
         echo "replaced with real dir"
     fi
-    grep -q "Real Skill" /root/.gemini/skills/real-skill/README.md && echo "correct content"
+    grep -q "Real Skill" /root/.gemini/agents/real-skill/README.md && echo "correct content"
     """
     result = _run_in_container(docker_image, cmd)
 
@@ -1081,8 +1085,8 @@ def test_sync_agents_newer_import_source_wins_conflict(docker_image):
     set -euo pipefail
 
     # Create a skill in dotfiles (older version)
-    mkdir -p /root/dotfiles/skills/evolving-skill
-    echo "# Version 1" > /root/dotfiles/skills/evolving-skill/README.md
+    mkdir -p /root/dotfiles/agents/evolving-skill
+    echo "# Version 1" > /root/dotfiles/agents/evolving-skill/README.md
 
     # First sync to distribute
     cd /root/dotfiles && just sync-agents-auto all
@@ -1091,16 +1095,16 @@ def test_sync_agents_newer_import_source_wins_conflict(docker_image):
     sleep 2
 
     # Edit the skill in import source (newer version)
-    echo "# Version 2 - Updated" > /root/.claude/skills/evolving-skill/README.md
+    echo "# Version 2 - Updated" > /root/.claude/agents/evolving-skill/README.md
 
     # Run sync again
     cd /root/dotfiles && just sync-agents-auto all
 
     # Verify dotfiles was updated with newer version
-    grep -q "Version 2" /root/dotfiles/skills/evolving-skill/README.md && echo "dotfiles updated"
+    grep -q "Version 2" /root/dotfiles/agents/evolving-skill/README.md && echo "dotfiles updated"
 
     # Verify all targets got the newer version
-    grep -q "Version 2" /root/.gemini/skills/evolving-skill/README.md && echo "gemini updated"
+    grep -q "Version 2" /root/.gemini/agents/evolving-skill/README.md && echo "gemini updated"
     """
     result = _run_in_container(docker_image, cmd)
 
@@ -1134,19 +1138,20 @@ def test_sync_agents_older_import_source_loses_conflict(docker_image):
     # Run sync
     cd /root/dotfiles && just sync-agents-auto all
 
-    # Verify dotfiles version was preserved
+    # Verify dotfiles version was preserved (import-conflict: newer wins)
     grep -q "New Version in Dotfiles" /root/dotfiles/skills/stable-skill/README.md && echo "dotfiles preserved"
 
-    # Verify targets got the dotfiles version (not the older import source version)
+    # gemini was MISSING the skill -> additive adds the dotfiles version.
     grep -q "New Version in Dotfiles" /root/.gemini/skills/stable-skill/README.md && echo "gemini got dotfiles version"
-    grep -q "New Version in Dotfiles" /root/.claude/skills/stable-skill/README.md && echo "claude got dotfiles version"
+    # claude already HAD the skill -> additive preserves it (no overwrite).
+    grep -q "Old Version" /root/.claude/skills/stable-skill/README.md && echo "claude kept existing"
     """
     result = _run_in_container(docker_image, cmd)
 
-    # then: Dotfiles version was preserved
+    # then: dotfiles keeps newer; missing target is added; existing target kept
     assert "dotfiles preserved" in result.stdout
     assert "gemini got dotfiles version" in result.stdout
-    assert "claude got dotfiles version" in result.stdout
+    assert "claude kept existing" in result.stdout
 
 
 # =============================================================================
@@ -1749,8 +1754,8 @@ def test_sync_agents_orphans_shows_target_only_items(docker_image):
     cd /root/dotfiles && just sync-agents-auto all
 
     # Add an orphan skill to a non-import target
-    mkdir -p /root/.claude-work-a/skills/orphan-test-skill
-    echo "# Orphan" > /root/.claude-work-a/skills/orphan-test-skill/SKILL.md
+    mkdir -p /root/.claude-work-a/agents/orphan-test-skill
+    echo "# Orphan" > /root/.claude-work-a/agents/orphan-test-skill/SKILL.md
 
     # Run orphans detection
     cd /root/dotfiles && uv run scripts/sync_agents.py --orphans all
@@ -1802,25 +1807,25 @@ def test_sync_agents_override_removes_orphans(docker_image):
     cd /root/dotfiles && just sync-agents-auto all
 
     # Add orphan skills to non-import target
-    mkdir -p /root/.claude-work-a/skills/orphan-alpha
-    echo "# Alpha" > /root/.claude-work-a/skills/orphan-alpha/SKILL.md
-    mkdir -p /root/.claude-work-a/skills/orphan-beta
-    echo "# Beta" > /root/.claude-work-a/skills/orphan-beta/SKILL.md
+    mkdir -p /root/.claude-work-a/agents/orphan-alpha
+    echo "# Alpha" > /root/.claude-work-a/agents/orphan-alpha/SKILL.md
+    mkdir -p /root/.claude-work-a/agents/orphan-beta
+    echo "# Beta" > /root/.claude-work-a/agents/orphan-beta/SKILL.md
 
     # Verify orphans exist
-    [ -d /root/.claude-work-a/skills/orphan-alpha ] && echo "orphan-alpha exists before"
-    [ -d /root/.claude-work-a/skills/orphan-beta ] && echo "orphan-beta exists before"
+    [ -d /root/.claude-work-a/agents/orphan-alpha ] && echo "orphan-alpha exists before"
+    [ -d /root/.claude-work-a/agents/orphan-beta ] && echo "orphan-beta exists before"
 
     # Run override
     cd /root/dotfiles && uv run scripts/sync_agents.py --override all
 
     # Verify orphans are gone
-    if [ -d /root/.claude-work-a/skills/orphan-alpha ]; then
+    if [ -d /root/.claude-work-a/agents/orphan-alpha ]; then
         echo "ERROR: orphan-alpha still exists"
     else
         echo "orphan-alpha removed"
     fi
-    if [ -d /root/.claude-work-a/skills/orphan-beta ]; then
+    if [ -d /root/.claude-work-a/agents/orphan-beta ]; then
         echo "ERROR: orphan-beta still exists"
     else
         echo "orphan-beta removed"
@@ -1849,22 +1854,22 @@ def test_sync_agents_override_preserves_source_items(docker_image):
     set -euo pipefail
 
     # Create a skill in dotfiles
-    mkdir -p /root/dotfiles/skills/my-real-skill
-    echo "# Real" > /root/dotfiles/skills/my-real-skill/SKILL.md
+    mkdir -p /root/dotfiles/agents/my-real-skill
+    echo "# Real" > /root/dotfiles/agents/my-real-skill/SKILL.md
 
     # First sync
     cd /root/dotfiles && just sync-agents-auto all
 
     # Add an orphan to the non-import target
-    mkdir -p /root/.claude-work-a/skills/orphan-only
-    echo "# Orphan" > /root/.claude-work-a/skills/orphan-only/SKILL.md
+    mkdir -p /root/.claude-work-a/agents/orphan-only
+    echo "# Orphan" > /root/.claude-work-a/agents/orphan-only/SKILL.md
 
     # Run override
     cd /root/dotfiles && uv run scripts/sync_agents.py --override all
 
     # Verify: real skill preserved, orphan removed
-    [ -d /root/.claude-work-a/skills/my-real-skill ] && echo "real skill preserved"
-    if [ -d /root/.claude-work-a/skills/orphan-only ]; then
+    [ -d /root/.claude-work-a/agents/my-real-skill ] && echo "real skill preserved"
+    if [ -d /root/.claude-work-a/agents/orphan-only ]; then
         echo "ERROR: orphan still exists"
     else
         echo "orphan removed"
@@ -1894,8 +1899,8 @@ def test_sync_agents_preview_shows_orphans(docker_image):
     cd /root/dotfiles && just sync-agents-auto all
 
     # Add an orphan to non-import target
-    mkdir -p /root/.claude-work-a/skills/preview-orphan
-    echo "# Preview" > /root/.claude-work-a/skills/preview-orphan/SKILL.md
+    mkdir -p /root/.claude-work-a/agents/preview-orphan
+    echo "# Preview" > /root/.claude-work-a/agents/preview-orphan/SKILL.md
 
     # Run preview
     cd /root/dotfiles && uv run scripts/sync_agents.py --preview all
@@ -2033,14 +2038,14 @@ def test_just_sync_agents_override_removes_orphans_via_recipe(docker_image):
 
     cd /root/dotfiles && just sync-agents-auto all
 
-    mkdir -p /root/.claude-work-a/skills/recipe-orphan
-    echo "# orphan" > /root/.claude-work-a/skills/recipe-orphan/SKILL.md
+    mkdir -p /root/.claude-work-a/agents/recipe-orphan
+    echo "# orphan" > /root/.claude-work-a/agents/recipe-orphan/SKILL.md
 
-    [ -d /root/.claude-work-a/skills/recipe-orphan ] && echo "orphan before"
+    [ -d /root/.claude-work-a/agents/recipe-orphan ] && echo "orphan before"
 
     cd /root/dotfiles && just sync-agents-override all
 
-    if [ -d /root/.claude-work-a/skills/recipe-orphan ]; then
+    if [ -d /root/.claude-work-a/agents/recipe-orphan ]; then
         echo "ERROR: orphan still exists"
     else
         echo "orphan removed by recipe"
@@ -2062,13 +2067,13 @@ def test_just_sync_agents_override_default_scope_does_not_touch_work_a(docker_im
     cd /root/dotfiles && just sync-agents-auto all
 
     # Plant an orphan in work-a (out of default scope)
-    mkdir -p /root/.claude-work-a/skills/scope-orphan-work-a
-    echo "# w" > /root/.claude-work-a/skills/scope-orphan-work-a/SKILL.md
+    mkdir -p /root/.claude-work-a/agents/scope-orphan-work-a
+    echo "# w" > /root/.claude-work-a/agents/scope-orphan-work-a/SKILL.md
 
     cd /root/dotfiles && just sync-agents-override
 
     # work-a orphan must still be there (out of scope by default)
-    if [ -d /root/.claude-work-a/skills/scope-orphan-work-a ]; then
+    if [ -d /root/.claude-work-a/agents/scope-orphan-work-a ]; then
         echo "work-a orphan preserved"
     else
         echo "ERROR: work-a touched outside default scope"
@@ -2175,3 +2180,34 @@ PY
     """
     result = _run_in_container(docker_image, cmd)
     assert "settings-merge-ok" in result.stdout, result.stdout
+
+
+def test_skills_are_additive_add_missing_no_overwrite_no_delete(docker_image):
+    """skills/ is additive: even `--yes` sync ADDS a missing dotfiles skill, but
+    never overwrites an existing target skill (a bunx-skills CLI symlink/copy)
+    and never deletes a target-only skill."""
+    cmd = r"""
+    set -euo pipefail
+    mkdir -p /root/.claude/skills/cli-only-skill
+    echo "# CLI Only" > /root/.claude/skills/cli-only-skill/SKILL.md
+    mkdir -p /root/.claude/skills/tdd-workflow
+    echo "SENTINEL-KEEP" > /root/.claude/skills/tdd-workflow/SKILL.md
+
+    cd /root/dotfiles && just sync-agents-auto p
+
+    [ -f /root/.claude/skills/cli-only-skill/SKILL.md ] && echo "orphan-preserved"
+    grep -q "CLI Only" /root/.claude/skills/cli-only-skill/SKILL.md && echo "orphan-content-intact"
+    grep -q "SENTINEL-KEEP" /root/.claude/skills/tdd-workflow/SKILL.md && echo "existing-not-overwritten"
+    # a skill in the dotfiles submodule but missing in the target IS added
+    # (add-only). 'sibyl' ships in the submodule.
+    [ -e /root/.claude/skills/sibyl ] && echo "missing-skill-added" || echo "ERR-missing-not-added"
+    """
+    result = _run_in_container(docker_image, cmd)
+    for marker in (
+        "orphan-preserved",
+        "orphan-content-intact",
+        "existing-not-overwritten",
+        "missing-skill-added",
+    ):
+        assert marker in result.stdout, f"missing {marker}\n{result.stdout}"
+    assert "ERR-missing-not-added" not in result.stdout, result.stdout


### PR DESCRIPTION
## 背景

PR #162 で hub-and-spoke を入れた後、`just sync-agents` の **skills full-mirror** が
`bunx skills` CLI 管理の skill（`~/.agents/skills` への symlink、上流 + `bunx skills add
<skills-repo>`）と衝突することが apply preview で判明:

- CLI-only skill (dotfiles submodule に無い) を **orphan として削除** → データ損失
- submodule と被る skill を **symlink→copy で上書き** → CLI 管理から de-link

## 対応: skills を additive 化

- **追加のみ・既存は上書きしない・削除しない**（orphan も manifest-tracked も）
- skill の投入は **`bunx skills add`** を優先（CLI 所有）
- `skills/learned/`（dotfiles 所有の skill-creator workspace）は **exempt**＝通常 sync
- `_is_additive_item()` + `ADDITIVE_DIRECTORIES` / `ADDITIVE_EXEMPT_SUBDIRS`

## テスト

- 新規 `test_skills_are_additive_add_missing_no_overwrite_no_delete`
- orphan/override/symlink-replace 系（generic 機構を skills で例示してたもの）は
  **非 additive の `agents` dir へ移設**（機構自体は維持）
- import-conflict 2本は additive semantics（既存保全/欠落追加）に更新
- learned/workspace 系は carve-out で従来通り pass

> 注: `tests/test_sync_agents.py` は bind-mount で repo を mutate する disposable 前提
> （CI 非 gated）。**touched テストは全て個別 fresh-copy で pass**。フルスイートは
> shared-mount の pre-existing 順序依存で learned テスト1本が mid-suite で落ちるが
> 個別では pass（additive 起因でない）。

## apply 手順（merge 後）

このリポ変更だけ。実 `~/.claude` 等への配布は merge 後に段階 apply する。
