### PR TITLE
docs: genericize skills repo reference

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,7 +27,7 @@
     - `ROOT_AGENTS_<x>_<y>(.ext|/)` → `<agent>/<x>/<y>` (`_`→`/`) の従来規約も継続
     - **`skills` は additive** (`ADDITIVE_DIRECTORIES`): 欠落 skill のみ追加、既存
       target は**上書きしない・削除しない**。`bunx skills` CLI が `~/.agents/skills`
-      へ install した symlink (上流 + `bunx skills add hironow/skills`) を churn/orphan
+      へ install した symlink (上流 + `bunx skills add <skills-repo>`) を churn/orphan
       削除しないため。skill の投入は CLI (`bunx skills add`) を優先する
 - **global ルールを変えるときは上記 source を編集して `just sync-agents`。**
   配布先 (`~/.claude/CLAUDE.md` 等) を直接編集しても次の sync で上書きされる。

--- a/scripts/sync_agents.py
+++ b/scripts/sync_agents.py
@@ -54,7 +54,7 @@ SYNC_DIRECTORIES = ["commands", "skills", "agents"]
 # items are NEVER overwritten and orphans are NEVER deleted. `skills` is additive
 # because it coexists with the `bunx skills` CLI, which installs skills (as
 # symlinks into ~/.agents/skills) from upstreams and from the dotfiles submodule
-# (`bunx skills add hironow/skills -s <name>`). A full-mirror sync would delete
+# (`bunx skills add <skills-repo> -s <name>`). A full-mirror sync would delete
 # CLI-only orphans and clobber the CLI-managed symlinks; additive preserves both
 # and defers population to the CLI. See repo CLAUDE.md.
 ADDITIVE_DIRECTORIES = ["skills"]


### PR DESCRIPTION
Replace the explicit skills-repo name in the additive-skills note (repo CLAUDE.md) and the sync_agents.py comment with a generic `<skills-repo>` placeholder, so a private repo name is not recorded in tracked docs/code. Forward-fix; HEAD files are clean after merge.