### PR TITLE
chore: gitignore docs/decision-queue.md (local-only patrol output)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,6 +75,10 @@ docs/intent-*.md
 docs/handover.md
 docs/handover-*.md
 docs/setup.md
+# Tooling-patrol working queue (local-only AI-agent output). Gitignored so an
+# external patrol automation can never commit/PR it into this public repo.
+docs/decision-queue.md
+docs/decision-queue-*.md
 node_modules
 
 # Defense-in-depth: these were previously only covered by the user's GLOBAL


### PR DESCRIPTION
An external tooling-patrol automation writes `docs/decision-queue.md` and opened a PR adding it to this public repo (it referenced private repos). Treat it like the other local-only AI-agent docs (intent/handover/setup): gitignore it + dated `-*` backups, so a patrol can **never** commit/PR its working queue into this public repo again. Structural guard; complements the redaction already applied.