### PR TITLE
feat(sync): settings.json hook merge updates managed blocks in place

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,7 +23,9 @@
     - spoke → `<agent>/docs/agents/*` (base 内の `docs/agents/` 参照は配布時に
       **その agent home の絶対パスへ rewrite**。相対だと作業 project 側に解決して外すため)
     - hooks + settings → **claude-family のみ**。settings.json は user キーを壊さず
-      **冪等マージ** (manifest 非追跡。marker = event+matcher+rendered command)
+      **update-in-place マージ** (manifest 非追跡)。sync が所有するのは command が
+      `<agent>/hooks/` を指す block のみで、毎回その managed block を最新 fragment で
+      置換 (hook command 変更でも stale 重複が残らない)、user 作成 block は保持
     - `ROOT_AGENTS_<x>_<y>(.ext|/)` → `<agent>/<x>/<y>` (`_`→`/`) の従来規約も継続
     - **`skills` は additive** (`ADDITIVE_DIRECTORIES`): 欠落 skill のみ追加、既存
       target は**上書きしない・削除しない**。`bunx skills` CLI が `~/.agents/skills`

--- a/scripts/sync_agents.py
+++ b/scripts/sync_agents.py
@@ -702,16 +702,27 @@ def _render_hook_command(command: str, agent: AgentTarget) -> str:
     )
 
 
+def _is_managed_hook_block(block: dict, agent: AgentTarget) -> bool:
+    """A hook block sync owns: every command points at the agent's hooks dir."""
+    inner = block.get("hooks", [])
+    marker = f"{agent.directory}/hooks/"
+    return bool(inner) and all(marker in h.get("command", "") for h in inner)
+
+
 def _merge_hook_settings(
     dotfiles_dir: Path, agent: AgentTarget, dry_run: bool = False
 ) -> bool:
-    """Idempotently merge the hook fragment into the agent's settings.json.
+    """Merge the hook fragment into the agent's settings.json, update-in-place.
 
     NOT manifest-tracked: settings.json is a user-owned shared file, so the
     item-granular manifest (whole-file add/delete) would clobber user hooks on an
-    orphan sweep. Identity is the (event, matcher, rendered-command-set) tuple, so
-    re-running is a no-op. User keys and unmanaged hook entries are preserved.
-    With dry_run=True nothing is written. Returns True if the file would change.
+    orphan sweep. Instead, sync OWNS exactly the hook blocks whose commands all
+    point at ``<agent>/hooks/`` (see _is_managed_hook_block): on each run those
+    managed blocks are replaced by the current fragment (so a changed/removed
+    hook command does not leave a stale duplicate), while user-authored blocks
+    and other settings keys are preserved untouched. Re-running with an unchanged
+    fragment is a no-op. With dry_run=True nothing is written. Returns True if the
+    file would change.
     """
     fragment_path = dotfiles_dir / HOOK_SETTINGS_FRAGMENT
     if not fragment_path.exists():
@@ -720,21 +731,39 @@ def _merge_hook_settings(
     target_path = agent.directory / "settings.json"
     target = json.loads(target_path.read_text()) if target_path.exists() else {}
 
-    hooks = target.setdefault("hooks", {})
-    changed = False
-    for event, blocks in fragment.get("hooks", {}).items():
-        existing_blocks = hooks.setdefault(event, [])
-        for block in blocks:
-            rendered = {
+    # Desired managed blocks per event, rendered to the agent's absolute hooks path.
+    desired: dict[str, list[dict]] = {
+        event: [
+            {
                 "matcher": block.get("matcher"),
                 "hooks": [
                     {**h, "command": _render_hook_command(h["command"], agent)}
                     for h in block.get("hooks", [])
                 ],
             }
-            if rendered not in existing_blocks:
-                existing_blocks.append(rendered)
-                changed = True
+            for block in blocks
+        ]
+        for event, blocks in fragment.get("hooks", {}).items()
+    }
+
+    hooks: dict[str, list[dict]] = target.get("hooks", {})
+    changed = False
+    for event in set(hooks) | set(desired):
+        existing = hooks.get(event, [])
+        # keep user (unmanaged) blocks; replace managed ones with the current set
+        kept = [b for b in existing if not _is_managed_hook_block(b, agent)]
+        new_list = kept + desired.get(event, [])
+        if new_list != existing:
+            changed = True
+        if new_list:
+            hooks[event] = new_list
+        else:
+            hooks.pop(event, None)
+
+    if hooks:
+        target["hooks"] = hooks
+    else:
+        target.pop("hooks", None)
 
     if changed and not dry_run:
         target_path.parent.mkdir(parents=True, exist_ok=True)

--- a/tests/test_sync_agents.py
+++ b/tests/test_sync_agents.py
@@ -2240,3 +2240,30 @@ def test_no_skills_flag_deploys_instructions_and_skips_skills(docker_image):
     ):
         assert marker in result.stdout, f"missing {marker}\n{result.stdout}"
     assert "ERR-skill-copied" not in result.stdout, result.stdout
+
+
+def test_hub_and_spoke_settings_merge_updates_managed_in_place(docker_image):
+    """When a managed hook command changes in the fragment, the old managed
+    block is REPLACED in settings.json (not left as a stale duplicate)."""
+    cmd = r"""
+    set -euo pipefail
+    cd /root/dotfiles
+    just sync-agents-auto p
+    grep -q 'hooks/block-secrets.sh' /root/.claude/settings.json && echo "v1-present"
+
+    # change a managed hook command in the fragment, then re-sync
+    sed -i 's#/.claude/hooks/block-secrets.sh#/.claude/hooks/block-secrets-v2.sh#' \
+        .claude/settings.hooks.json
+    just sync-agents-auto p
+
+    grep -q 'hooks/block-secrets-v2.sh' /root/.claude/settings.json && echo "v2-present"
+    if grep -q 'hooks/block-secrets\.sh"' /root/.claude/settings.json; then
+        echo "ERR-v1-stale"
+    else
+        echo "v1-removed"
+    fi
+    """
+    result = _run_in_container(docker_image, cmd)
+    for marker in ("v1-present", "v2-present", "v1-removed"):
+        assert marker in result.stdout, f"missing {marker}\n{result.stdout}"
+    assert "ERR-v1-stale" not in result.stdout, result.stdout


### PR DESCRIPTION
Replace the append-only hook merge with update-in-place. Sync owns exactly the hook blocks whose commands all point at `<agent>/hooks/`; each run replaces those managed blocks with the current fragment, so a changed/removed hook command no longer leaves a stale double-firing duplicate. User hook blocks + other settings keys preserved; re-run is a no-op. Adds a sandbox drift test. Resolves the append-only Known limitation from the hub-and-spoke rollout.