### PR TITLE
feat(sync): clean orphaned spokes/hooks from agent dirs

### DIFF
--- a/scripts/sync_agents.py
+++ b/scripts/sync_agents.py
@@ -574,6 +574,45 @@ def _detect_target_only_items(
     return orphans
 
 
+def _detect_managed_dir_orphans(
+    agent: AgentTarget, additional_sources: list[_SyncItem]
+) -> list[_DeleteAction]:
+    """Detect distributed spoke/hook files no longer backed by a source.
+
+    `docs/agents/` (synced to every agent) and `hooks/` (claude-family only)
+    are fully sync-owned: a file there whose ROOT_AGENTS_* source was renamed or
+    removed is an orphan to delete, so stale spokes/hooks do not linger. These
+    dirs are NOT manifest-tracked; the current source set is the source of truth.
+    """
+    managed_dirs = ["docs/agents"]
+    if agent.receives_hooks:
+        managed_dirs.append("hooks")
+
+    orphans: list[_DeleteAction] = []
+    for mdir in managed_dirs:
+        prefix = f"{mdir}/"
+        expected = {
+            item.relative_path[len(prefix) :]
+            for item in additional_sources
+            if item.relative_path.startswith(prefix)
+        }
+        target_dir = agent.directory / mdir
+        if not target_dir.is_dir():
+            continue
+        for child in sorted(target_dir.iterdir(), key=lambda p: p.name):
+            if child.name.startswith(".") or child.name in expected:
+                continue
+            orphans.append(
+                _DeleteAction(
+                    target=child,
+                    relative_path=f"{mdir}/{child.name}",
+                    is_directory=child.is_dir() and not child.is_symlink(),
+                    reason="orphan",
+                )
+            )
+    return orphans
+
+
 def _sync_file(source: Path, target: Path) -> None:
     """Sync a single file."""
     target.parent.mkdir(parents=True, exist_ok=True)
@@ -1268,6 +1307,7 @@ def preview_mode(
         sync_plan.deletions.extend(
             _detect_target_only_items(dotfiles_dir, agent, manifest)
         )
+        sync_plan.deletions.extend(_detect_managed_dir_orphans(agent, additional))
         plans.append(sync_plan)
 
     has_changes = _print_plan(
@@ -1354,6 +1394,7 @@ def sync_mode(
         sync_plan.deletions.extend(
             _detect_target_only_items(dotfiles_dir, agent, manifest)
         )
+        sync_plan.deletions.extend(_detect_managed_dir_orphans(agent, additional))
         plans.append(sync_plan)
 
     has_changes = _print_plan(

--- a/tests/test_sync_agents.py
+++ b/tests/test_sync_agents.py
@@ -2267,3 +2267,36 @@ def test_hub_and_spoke_settings_merge_updates_managed_in_place(docker_image):
     for marker in ("v1-present", "v2-present", "v1-removed"):
         assert marker in result.stdout, f"missing {marker}\n{result.stdout}"
     assert "ERR-v1-stale" not in result.stdout, result.stdout
+
+
+def test_spoke_and_hook_orphans_are_cleaned(docker_image):
+    """A distributed spoke/hook whose ROOT_AGENTS_* source is gone is removed as
+    an orphan on the next sync; current spokes/hooks are preserved."""
+    cmd = r"""
+    set -euo pipefail
+    cd /root/dotfiles
+    just sync-agents-auto p
+    [ -f /root/.claude/docs/agents/testing.md ] && echo "current-spoke-present"
+
+    # plant stale files with no backing ROOT_AGENTS_* source
+    echo "# stale" > /root/.claude/docs/agents/removed-spoke.md
+    echo "#!/bin/sh" > /root/.claude/hooks/removed-hook.sh
+
+    just sync-agents-auto p
+
+    [ -f /root/.claude/docs/agents/removed-spoke.md ] && echo "ERR-spoke-stale" || echo "spoke-orphan-removed"
+    [ -f /root/.claude/hooks/removed-hook.sh ] && echo "ERR-hook-stale" || echo "hook-orphan-removed"
+    [ -f /root/.claude/docs/agents/testing.md ] && echo "current-spoke-kept"
+    [ -x /root/.claude/hooks/block-secrets.sh ] && echo "current-hook-kept"
+    """
+    result = _run_in_container(docker_image, cmd)
+    for marker in (
+        "current-spoke-present",
+        "spoke-orphan-removed",
+        "hook-orphan-removed",
+        "current-spoke-kept",
+        "current-hook-kept",
+    ):
+        assert marker in result.stdout, f"missing {marker}\n{result.stdout}"
+    assert "ERR-spoke-stale" not in result.stdout, result.stdout
+    assert "ERR-hook-stale" not in result.stdout, result.stdout


### PR DESCRIPTION
docs/agents/ (every agent) and hooks/ (claude-family) are fully sync-owned but were not orphan-checked, so a renamed/removed ROOT_AGENTS_docs_agents_* / ROOT_AGENTS_hooks_* source left a stale file lingering. Add `_detect_managed_dir_orphans`: files in those dirs not backed by the current source set are flagged for deletion (same confirm/--yes/--override gate as other deletions); current spokes/hooks preserved, non-claude agents skip hooks. Adds a sandbox test. Resolves the spoke/hook orphan Known limitation.