### PR TITLE
fix(emulator): revert a2a-inspector to python 3.12-slim (3.14 breaks build)

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -84,6 +84,16 @@ updates:
     commit-message:
       prefix: "chore"
       include: "scope"
+    ignore:
+      # Compiled-dep services (e.g. emulator/a2a-inspector: cffi / pydantic-core
+      # / asyncpg) lack cp314 wheels, so `uv sync` builds from sdist -> needs gcc,
+      # absent in python:*-slim -> build fails (verified 2026-06 on 3.14.5-slim).
+      # Keep docker python base images on their current minor; patch updates are
+      # still allowed. Revisit when upstream publishes 3.14 wheels.
+      - dependency-name: "python"
+        update-types:
+          - "version-update:semver-major"
+          - "version-update:semver-minor"
     groups:
       docker:
         patterns: ["*"]

--- a/emulator/a2a-inspector/Dockerfile
+++ b/emulator/a2a-inspector/Dockerfile
@@ -23,10 +23,13 @@ RUN npm rebuild esbuild
 RUN npm run build
 
 # Stage 2: assemble runtime image.
-# Kept on python 3.12 (not 3.14): a2a-inspector's deps lack cp314 wheels, so
+# Kept on python 3.12 (NOT 3.14): a2a-inspector's deps lack cp314 wheels, so
 # `uv sync` falls back to building from sdist, which needs gcc -- absent in the
-# slim image -> build fails. Revisit when upstream publishes 3.14 wheels.
-FROM python:3.14.5-slim
+# slim image -> build fails. Re-verified 2026-06 on 3.14.5-slim: cffi 1.17.1 /
+# pydantic-core / asyncpg build from sdist and die with "gcc: No such file".
+# Dependabot is told to ignore python minor/major bumps here (see dependabot
+# .yaml); revisit when upstream publishes 3.14 wheels.
+FROM python:3.12-slim
 WORKDIR /app
 
 # Install uv (no pip required)


### PR DESCRIPTION
Dependabot #160 bumped the a2a-inspector base 3.12-slim -> 3.14.5-slim against the in-file decision to stay on 3.12. **Verified the bump breaks the build**: cffi 1.17.1 / pydantic-core / asyncpg have no cp314 wheels, so `uv sync` builds from sdist and dies with `gcc: No such file or directory` (slim has no gcc). Revert to 3.12-slim and tell Dependabot to ignore python minor/major bumps for the docker ecosystem (patch updates still flow) so the broken bump cannot recur. (Separate, pre-existing: the Dockerfile has no non-root USER — flagged, not fixed here.)