### PR TITLE
docs(agents): Antigravity CLI 移行 — instruction 層共有、skills/settings は agy 委譲

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,6 +19,9 @@
 - **`just sync-agents` (`scripts/sync_agents.py`) の配布 (per-tool):**
     - base → codex `~/.codex/AGENTS.md` / gemini `~/.gemini/GEMINI.md` /
       claude-family `~/.claude*/AGENTS.md`
+        - **`~/.gemini/GEMINI.md` は Gemini CLI (2026-06-18 sunset) と Antigravity
+          CLI (`agy`) が共有する** global rules (issue google-gemini/gemini-cli#16058)。
+          base sync 先は変更不要で、既存の gemini ターゲットがそのまま Antigravity を兼ねる。
     - overlay → claude-family `~/.claude*/CLAUDE.md` (`@AGENTS.md` で base を import)
     - spoke → `<agent>/docs/agents/*` (base 内の `docs/agents/` 参照は配布時に
       **その agent home の絶対パスへ rewrite**。相対だと作業 project 側に解決して外すため)
@@ -31,6 +34,14 @@
       target は**上書きしない・削除しない**。`bunx skills` CLI が `~/.agents/skills`
       へ install した symlink (上流 + `bunx skills add <skills-repo>`) を churn/orphan
       削除しないため。skill の投入は CLI (`bunx skills add`) を優先する
+    - **Antigravity CLI (`agy`) は自己管理 — dotfiles は skills/settings/mcp を sync
+      しない**: Antigravity は skills を `agy plugin` (=
+      `~/.gemini/antigravity-cli/plugins/<name>/skills/`)、settings/mcp を `agy import`
+      (= `~/.gemini/antigravity-cli/settings.json` + `mcp/`) で持つ。これらを raw sync
+      すると agy の自己管理を迂回/clobber する (= `bunx skills` へ委譲するのと同理由)
+      ため dotfiles は触らない。instruction 層 (`~/.gemini/GEMINI.md`) のみ共有で兼用。
+      既存の `~/.gemini/skills/` additive は Antigravity が plugins/ から読むため
+      vestigial だが additive で無害・残置 (詳細 ADR 0026)。
 - **global ルールを変えるときは上記 source を編集して `just sync-agents`。**
   配布先 (`~/.claude/CLAUDE.md` 等) を直接編集しても次の sync で上書きされる。
 - **per-repo enforcement は `templates/agent-baseline/` に scaffold 保管** (dotfiles

--- a/docs/adr/0026-antigravity-cli-instruction-layer.md
+++ b/docs/adr/0026-antigravity-cli-instruction-layer.md
@@ -1,0 +1,71 @@
+# 0026. Antigravity CLI: instruction 層のみ共有、skills/settings/mcp は agy 委譲
+
+**Date:** 2026-06-10
+**Status:** Accepted
+
+## Context
+
+Google は **Gemini CLI を 2026-06-18 に sunset** し（AI Pro/Ultra/free の Gemini
+CLI および Gemini Code Assist IDE 拡張がリクエスト停止）、後継 **Antigravity CLI
+(`agy`)** へ移行する（公式 developers blog / antigravity.google、2026-05 発表）。
+本機では `agy` 1.0.6 が mise 経由で install 済み、`~/.gemini/antigravity-cli/` が
+active な config dir。
+
+dotfiles は `just sync-agents` (`scripts/sync_agents.py`) で hub-and-spoke の agent
+指示を配布する。gemini ターゲットは base を **`~/.gemini/GEMINI.md`** へ書く。Gemini
+CLI 退役にあたり「gemini への配布を Antigravity 用に移す/拡張する必要があるか」を
+調査した結果、以下が判明した:
+
+1. **instruction 層は既に共有**。Antigravity CLI は global rules に
+   **`~/.gemini/GEMINI.md` を引き続き使う**（全 workspace で自動 load/enforce、
+   `google-gemini/gemini-cli#16058` で両者が同ファイルへ書く挙動も確認）。dotfiles の
+   base sync 先は移動不要で、既存 gemini ターゲットがそのまま Antigravity を兼ねる。
+2. **skills は `agy plugin` 管理**。Antigravity の skills は
+   `~/.gemini/antigravity-cli/plugins/<name>/skills/` に plugin 単位で入り、
+   `agy plugin install/import` で投入される。dotfiles の `bunx skills` CLI 委譲と同型。
+3. **settings/mcp は user-runtime + `agy import` 管理**。
+   `~/.gemini/antigravity-cli/settings.json` は model/permissions/oauth 等の個人状態、
+   `mcp/` は `agy` が gemini-cli から import した per-server dir。dotfiles が raw sync
+   すると、これら agy/個人所有の状態を clobber する。
+
+## Decision
+
+Antigravity CLI 移行に対し、dotfiles は **instruction 層のみを共有し、skills/
+settings/mcp は `agy` の自己管理に委ねる**。
+
+1. **base (`~/.gemini/GEMINI.md`) の sync は無変更**。Gemini CLI と Antigravity CLI
+   が同一ファイルを読むため、既存 gemini ターゲットがそのまま両者を兼ねる。`agy` 専用
+   ターゲットや配布先の移動は追加しない。
+2. **skills を Antigravity へ raw sync しない**。skills の投入は `agy plugin` に委ねる
+   （dotfiles が `bunx skills add` を優先するのと同じ理由 = CLI 管理層を迂回しない）。
+3. **settings/mcp を sync しない**。これらは個人 runtime かつ `agy import` 管理であり、
+   dotfiles が書くと上書き事故になる。
+4. 上記の現状と境界を `CLAUDE.md`（repo dev rules の「二層構造」節）と
+   `scripts/sync_agents.py` の gemini ターゲット行コメントに記録する。
+
+この決定はコード/配布挙動を変えない（`just sync-agents-preview` の計画は不変）。
+変更は docs のみ。
+
+## Consequences
+
+### Positive
+
+- Gemini CLI 退役後も agent 指示が途切れない（`~/.gemini/GEMINI.md` 共有のため
+  Antigravity が同じ base を読む）。配布コードの変更ゼロでリスク最小。
+- Antigravity の個人 runtime（model 選択 / permissions / oauth-token）と `agy import`
+  済み mcp/skills を dotfiles が clobber しない。CLI 委譲方針が gemini/claude/codex と
+  一貫する（skills は常に CLI 管理）。
+
+### Negative
+
+- dotfiles 管理の skills は Antigravity から自動では見えない。Antigravity で使いたい
+  skill は `agy plugin` で別途投入する手作業が要る（`bunx skills` と同じ運用負荷）。
+- 既存の `~/.gemini/skills/` additive 配布は Antigravity が plugins/ から読むため
+  vestigial になる。additive ゆえ無害で残置するが、将来 Gemini CLI 完全廃止時に
+  撤去するか否かは別途判断（本 ADR では撤去しない）。
+
+### Neutral
+
+- 将来 Antigravity が top-level `~/.gemini/antigravity-cli/skills/` の global skills を
+  正式サポートし、かつ CLI 非経由の配布が妥当になった場合は、本決定を上書きする後続
+  ADR で `secondary_skills_dest` 等の sync 拡張を再検討する余地を残す。

--- a/scripts/sync_agents.py
+++ b/scripts/sync_agents.py
@@ -154,6 +154,11 @@ AGENTS: list[AgentTarget] = [
         "Gemini",
         key="gemini",
         main_file="GEMINI.md",
+        # ~/.gemini/GEMINI.md is shared: read by Gemini CLI (sunset 2026-06-18)
+        # AND Antigravity CLI (agy), so this base sync already serves both.
+        # Antigravity skills/settings/mcp live under ~/.gemini/antigravity-cli/
+        # and are agy-managed (plugin / import), NOT synced here -- same rationale
+        # as deferring skill installs to the bunx skills CLI. See ADR 0026.
     ),
     AgentTarget(
         Path.home() / ".codex",


### PR DESCRIPTION
## 何 / なぜ

Google が **Gemini CLI を 2026-06-18 に sunset** し、後継 **Antigravity CLI (`agy`)** へ移行する（公式 developers blog / antigravity.google）。本機にも `agy` 1.0.6 が install 済み。dotfiles は `just sync-agents` で agent 指示を `~/.gemini/GEMINI.md` 等へ配布しているため、Antigravity 移行で配布先を変える必要があるかを調査した。

## 調査結果（前提を覆す重要事実）

1. **instruction 層は既に共有** — Antigravity CLI は global rules に `~/.gemini/GEMINI.md` を引き続き使う（`google-gemini/gemini-cli#16058` で両者が同ファイルを読む挙動も確認）。**base sync 先は移動不要**で、既存 gemini ターゲットがそのまま Antigravity を兼ねる。
2. **skills は `agy plugin` 管理** — `~/.gemini/antigravity-cli/plugins/<name>/skills/` に plugin 単位で入る。dotfiles が `bunx skills` CLI に委譲するのと同型。
3. **settings/mcp は user-runtime + `agy import` 管理** — `~/.gemini/antigravity-cli/settings.json`（model/permissions/oauth）+ `mcp/`。dotfiles が raw sync すると clobber する。

## 決定（ADR 0026）

instruction 層のみ共有し、**skills/settings/mcp は `agy` の自己管理に委ねる**（迂回/clobber 回避）。配布コード・挙動は不変（`just sync-agents-preview` は差分ゼロ）＝ **docs-only**。

## 変更

- `CLAUDE.md`（repo dev rules の「二層構造」節）に Antigravity の実態と境界を追記
- `scripts/sync_agents.py` の gemini ターゲットに共有/委譲のインラインコメント
- `docs/adr/0026-antigravity-cli-instruction-layer.md`（新規、Accepted）

## 検証

- `just ci` green（ruff / shellcheck / markdownlint / meta-semgrep / semgrep-test 27/27 / portless-doc-check / tofu test）
- `just sync-agents-preview` = `All files are already in sync!`（コード挙動を変えていない実証）
