### PR TITLE
docs(agents): codex review を強化 — actionable 限定・3 lens・codex 不可時は別 context で self-review

### DIFF
--- a/ROOT_CLAUDE.md
+++ b/ROOT_CLAUDE.md
@@ -25,17 +25,38 @@ only make sense for Claude Code.
 ## Plan review with codex (before showing a plan to the human)
 
 For any non-trivial implementation plan, run a codex review **before** presenting
-it. Skip silently only on a rate-limit error (e.g. "You've hit your usage
-limit…").
+it. Codex is the *preferred* reviewer, but the plan must always get an independent
+second pair of eyes — so the review is never skipped. If codex is unavailable
+(rate-limit — e.g. "You've hit your usage limit…" — or any hard error), review it
+yourself in a **separate context window**: spawn a subagent whose context is
+independent of the one that wrote the plan, hand it the same lenses below, and
+treat its findings exactly as you would codex's. Never self-review inline in the
+authoring context — that defeats the independence the review exists for.
+
+Carry three lenses through the whole review:
+
+- **何も信用しない — trust nothing.** Every claim is a hypothesis to verify —
+  codex's, the plan's, and your own. Don't act on a finding you haven't confirmed.
+- **Even the reviewers get reviewed.** codex is fallible (stale knowledge — see
+  below); judge each finding on the evidence and push back when it's wrong. Your
+  rebuttal must clear the same bar you hold codex to.
+- **Don't fix the code — fix the process that generates it.** When a finding is
+  real, prefer the change that stops the whole class from recurring (the rule,
+  template, or check that produced it) over patching the single instance.
+
+Ask for findings phrased as *actionable* items — each paired with a concrete fix
+or resolution, ordered by severity. The point is to keep the finding list
+bounded and clear: a reviewer that surfaces observations it can't turn into a fix
+just grows the list without moving the plan forward.
 
 ```sh
 # First review of a new plan:
 codex exec -m gpt-5.5 --skip-git-repo-check \
-  "このプランをレビューして。瑣末な点へのクソリプはしないで。致命的な点だけ指摘して: {plan_full_path} (ref: {AGENTS.md full_path})"
+  "このプランを批判的にレビューして。各指摘は具体的な修正・解決策とセットの actionable なものに絞って（直せない感想や瑣末な点で件数を増やさない）、致命的な点から優先して挙げて: {plan_full_path} (ref: {AGENTS.md full_path})"
 
 # Reviewing an updated plan — keep prior context with `resume --last`:
 codex exec resume --skip-git-repo-check --last -m gpt-5.5 \
-  "プランを更新したからレビューして。瑣末な点へのクソリプはしないで。致命的な点だけ指摘して: {plan_full_path} (ref: {AGENTS.md full_path})"
+  "プランを更新したから批判的にレビューして。各指摘は具体的な修正・解決策とセットの actionable なものに絞って（直せない感想や瑣末な点で件数を増やさない）、致命的な点から優先して挙げて: {plan_full_path} (ref: {AGENTS.md full_path})"
 ```
 
 To counter the reviewer model's stale knowledge, gather current docs/URLs into a


### PR DESCRIPTION
## What

`ROOT_CLAUDE.md` の「Plan review with codex」セクションを強化（agent 指示 source。`just sync-agents` で各 agent home へ配布される）。

### 1. codex への依頼文を「指摘の出し方」基準で明瞭化
- before: 「瑣末な点へのクソリプはしないで。致命的な点だけ指摘して」(何を *やめろ* かのみ)
- after : 「各指摘は具体的な修正・解決策とセットの actionable なものに絞って…致命的な点から優先して挙げて」(何を *出せ* かを固定 = finding が際限なく増えない)

### 2. レビュー全体に通す 3 lens を追加
- **何も信用しない** — finding は事実でなく検証すべき仮説（codex のも・プランも・自分の反論も）
- **even the reviewers get reviewed** — codex は可謬(stale knowledge)。証拠で吟味し押し返す。自分の反論も同基準
- **don't fix the code, fix the process** — 本物の指摘は 1 箇所でなく生成元(rule/template/check)を直す

### 3. codex 不可時の fallback を明示
- before: rate-limit なら **silent skip**
- after : skip せず **別の独立 context window（subagent）で Claude 自身がレビュー**。author の context から独立させ、同じ lens を渡す。inline self-review は独立性を失うので禁止

## Why
レビュー指摘が「直せない観点」で青天井に増えるのを止め（actionable 限定）、レビューの構えを明文化（3 lens）、かつ codex 不可時もプランが必ず第三者レビューを通る状態にする。

## Scope / gates
- docs-only。`ROOT_CLAUDE.md` は markdownlint ignore 対象（agent 指示 source は verbatim 配布）、禁止リテラル無しで meta-semgrep も無風。
- 配布挙動の変更なし（`just sync-agents-preview` の計画は不変）。ローカル `~/.claude/CLAUDE.md` へ反映済み。