### PR TITLE
ci: shellcheck workflow から mise-action を撤去

### DIFF
--- a/.github/workflows/shellcheck.yaml
+++ b/.github/workflows/shellcheck.yaml
@@ -15,7 +15,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
-        with:
-          experimental: true # [default: false] enable experimental features
+      # shellcheck は ubuntu-latest ランナーにプリインストール済み。
+      # CI は mise 非依存 (mise.toml はローカル開発用)。
       - run: shellcheck *.sh


### PR DESCRIPTION
## 概要

GitHub Actions から mise を撤去し、各ジョブが必要とするツールを素の setup アクション / ランナー標準ツールで直接供給する。あわせて、Actions 設定の組織標準 (`sha_pinning_required`) に合わせて全 action 参照を full-length commit SHA に pin した。

## 変更

- `jdx/mise-action` / `curl https://mise.run` を撤去し、必要なツールを個別にセットアップ
- 全 `uses:` 参照を commit SHA pin 化（`# vX` コメントで元 ref を併記）

## 備考

- `mise.toml` はローカル開発用としてそのまま残す（CI のみ mise 非依存化）
- merge 後、リポの Actions allowlist から `jdx/mise-action@*` を除去する
