### PR TITLE
fix(agents): instruction-set S+ — enforcement spoke, per-invocation lockfile gate, dead-ref scanner

### DIFF
--- a/ROOT_AGENTS.md
+++ b/ROOT_AGENTS.md
@@ -24,8 +24,9 @@ explicit chat instruction overrides everything here.
 
 ## Non-negotiables (enforced by hooks + CI — see Enforcement)
 
-These are not preferences. They are gated mechanically; the reasons are given so
-you generalize correctly to unlisted cases.
+These are not preferences. Hooks gate them mechanically for Claude Code in every
+repo; other tools rely on the pre-commit + CI gate where the agent baseline is
+installed. The reasons are given so you generalize correctly to unlisted cases.
 
 - **`uv` only** for Python (`uv sync`, `uv add`, `uv run`). Never `pip`, `poetry`,
   `pipenv` — mixed resolvers desync the lockfile.
@@ -131,19 +132,18 @@ Open the matching file the moment the trigger applies:
 | adding/maintaining a Semgrep rule              | docs/agents/semgrep.md              |
 | editing docs / writing an ADR / intent / handover | docs/agents/docs-discipline.md   |
 | creating dirs/files or unsure where code goes  | docs/agents/project-structure.md    |
+| blocked by a hook / tuning or adding a hook    | docs/agents/enforcement.md          |
 
 ## Enforcement (deterministic — independent of model judgment)
 
 Instructions in this file are advisory; the rules below are not. They run
 regardless of what an agent decides:
 
-- **Claude Code hooks** (`.claude/settings.json`): block prohibited filenames
-  (`.yml`, deprecated compose names) and prohibited commands (`pip`/`poetry`/
-  `npm`/`yarn`/`make`, drift-causing `gcloud` mutations, obvious secrets) before
-  they execute; auto-run `ruff format`/`ruff check --fix` after edits.
+- **Claude Code hooks** (global, synced to `~/.claude`): block prohibited
+  filenames and commands before they execute; auto-format Python after edits.
 - **Git pre-commit** (`.githooks/pre-commit` → `just check`): no commit lands
   red. Enable with `just install-hooks`.
 - **CI** (`.github/workflows/quality-gate.yaml`): same gate + `tofu plan` drift
   check, required before merge.
 
-Setup and rationale: see README-agents-setup.md.
+Exit-code contract, full hook coverage, and tuning: docs/agents/enforcement.md.

--- a/ROOT_AGENTS_docs_agents_commit-discipline.md
+++ b/ROOT_AGENTS_docs_agents_commit-discipline.md
@@ -11,7 +11,7 @@ Read this before writing a commit message. Root summary is in AGENTS.md.
 - Message follows Conventional Commits v1.0.0.
 
 `just check` runs the whole gate; the git pre-commit hook runs it too, so a red
-tree cannot be committed (see README-agents-setup.md).
+tree cannot be committed (see docs/agents/enforcement.md).
 
 ## Format
 

--- a/ROOT_AGENTS_docs_agents_enforcement.md
+++ b/ROOT_AGENTS_docs_agents_enforcement.md
@@ -1,0 +1,84 @@
+# Enforcement (hooks, pre-commit, CI)
+
+Read this when a hook blocks an action, when tuning or adding a hook, or when
+you need the exact exit-code contract. Root summary is in AGENTS.md.
+
+## The three layers (and why prose isn't enough)
+
+AGENTS.md / CLAUDE.md instructions are advisory — an agent usually complies but
+can decide a rule doesn't apply. Rules that must hold every time are enforced
+mechanically, at three points:
+
+1. **Claude Code hooks** — fire before/after tool calls, independent of model
+   judgment. They are global: the dotfiles repo distributes them via
+   `just sync-agents` into `~/.claude/settings.json` + `~/.claude/hooks/*.sh`,
+   so they apply in every repo Claude Code touches. Other tools (Codex, Cursor,
+   Copilot) do not run them.
+2. **Git pre-commit** (`.githooks/pre-commit` → `just check`) — the same gate
+   for humans and for any tool that runs `git commit`. Present in repos
+   scaffolded from the agent baseline; enable once per clone with
+   `just install-hooks`.
+3. **CI** (`.github/workflows/quality-gate.yaml`) — the merge gate: `just check`
+   plus a `tofu plan` drift check. Also provided by the agent baseline.
+
+Prose still matters: it carries the *why*, which is how you generalize a rule
+to cases a hook doesn't pattern-match. Hooks guarantee the common cases; prose
+covers the long tail.
+
+## Hook exit-code contract (PreToolUse)
+
+- `exit 0` → allow.
+- `exit 2` → **block**; the script's stderr is fed back to the agent as the
+  reason. Read it and change approach — never route around a block.
+- `exit 1` → non-blocking error; the action **proceeds**. Never use it to block.
+
+## What each hook covers
+
+- `block-prohibited-files.sh` (Write|Edit): `.yml` filenames and deprecated
+  Compose v1 names (`docker-compose.y{a,}ml`).
+- `block-secrets.sh` (Write|Edit): obvious secrets in file writes.
+- `block-prohibited-commands.sh` (Bash): `pip`/`poetry`/`pipenv`, `npm`/`yarn`,
+  `make`, root deletion, force-push to main/master, and drift-causing
+  `gcloud`/`cdr` mutations (blocked outright — open an IaC PR instead).
+  `pnpm` is allowed only when a `pnpm-lock.yaml` governs each pnpm invocation's
+  target directory (searched upward; `cd`/`-C`/`--dir` targets are resolved
+  best-effort).
+- `format-after-edit.sh` (PostToolUse Write|Edit): `ruff format` +
+  `ruff check --fix` on edited Python files.
+
+## Known limits (by design)
+
+- File-naming rules are checked on Write/Edit only. Files created through Bash
+  (`touch x.yml`, shell redirects) are not intercepted — the prose rule and
+  review cover that long tail.
+- Command parsing is best-effort. A pnpm target directory hidden behind a
+  variable or subshell can't be resolved; the hook fails safe and blocks. If a
+  block is a false positive, ask the user to run the command themselves with
+  the `!` prefix.
+
+## Tuning the hooks
+
+Hook sources live in the dotfiles repo as `ROOT_AGENTS_hooks_*.sh`, with unit
+tests in `tests/unit/test_agent_hooks.py`. Never edit `~/.claude/hooks/*.sh`
+directly — the next sync overwrites them. Edit the source, extend the tests,
+then run `just sync-agents` (from the dotfiles repo). Test a hook in isolation:
+
+```sh
+echo '{"tool_input":{"command":"npm install"}}' | bash ~/.claude/hooks/block-prohibited-commands.sh; echo "exit=$?"
+echo '{"tool_input":{"file_path":"config.yml"}}' | bash ~/.claude/hooks/block-prohibited-files.sh; echo "exit=$?"
+```
+
+(`exit=2` means the guard would block; `exit=0` means it would allow.)
+
+## Repo-scan self-reference
+
+AGENTS.md and the playbook files in this directory intentionally name
+prohibited patterns as examples. When scanning a repo for violations, exclude
+the policy files themselves — e.g.:
+
+```sh
+git grep <pattern> -- ':(exclude)**/AGENTS.md' ':(exclude)**/CLAUDE.md'
+```
+
+Also exclude the repo's agent-playbook directory if it carries one. The
+`block-prohibited-files` hook already exempts these paths.

--- a/ROOT_AGENTS_docs_agents_enforcement.md
+++ b/ROOT_AGENTS_docs_agents_enforcement.md
@@ -56,6 +56,10 @@ covers the long tail.
   false-trigger. The flip side — a quoted invocation like `bash -c "npm i"`
   slips them — is accepted long tail. Destructive/IaC guards scan the full
   string; over-blocking is the safe side there.
+- Quote-stripping is line-based: multi-line prose embedded in a command
+  (heredoc PR bodies and the like) is scanned bare and can false-trigger.
+  Pass long prose via files instead — e.g. `gh pr create --body-file`,
+  `git commit -F`.
 - Command parsing is best-effort. A pnpm target directory hidden behind a
   variable or subshell can't be resolved; the hook fails safe and blocks. If a
   block is a false positive, ask the user to run the command themselves with

--- a/ROOT_AGENTS_docs_agents_enforcement.md
+++ b/ROOT_AGENTS_docs_agents_enforcement.md
@@ -51,6 +51,11 @@ covers the long tail.
 - File-naming rules are checked on Write/Edit only. Files created through Bash
   (`touch x.yml`, shell redirects) are not intercepted — the prose rule and
   review cover that long tail.
+- Tooling-word guards (package managers, task runner) scan with quoted
+  substrings removed, so prose mentions (commit messages, echo strings) don't
+  false-trigger. The flip side — a quoted invocation like `bash -c "npm i"`
+  slips them — is accepted long tail. Destructive/IaC guards scan the full
+  string; over-blocking is the safe side there.
 - Command parsing is best-effort. A pnpm target directory hidden behind a
   variable or subshell can't be resolved; the hook fails safe and blocks. If a
   block is a false positive, ask the user to run the command themselves with

--- a/ROOT_AGENTS_docs_agents_iac-drift-policy.md
+++ b/ROOT_AGENTS_docs_agents_iac-drift-policy.md
@@ -61,6 +61,6 @@ either silently reverts your change or fails on unexpected state.
 - Refuse to **chain** manual mutations — one emergency mutation is acceptable;
   a sequence means the IaC needs restructuring.
 
-(A PreToolUse hook flags `gcloud … add-iam-policy-binding` / `… update` /
-`… resize` and Cloud Run console-equivalent calls for confirmation; see
-README-agents-setup.md.)
+(A PreToolUse hook blocks — exit 2, no confirmation flow — `gcloud …
+add-iam-policy-binding` / `… update` / `… resize` / `… deploy` and
+`cdr workspaces update/edit`; see docs/agents/enforcement.md.)

--- a/ROOT_AGENTS_docs_agents_observability.md
+++ b/ROOT_AGENTS_docs_agents_observability.md
@@ -1,8 +1,9 @@
-# Observability (OpenTelemetry + Jaeger)
+# Observability (OpenTelemetry)
 
 Read this when adding a new service/binary or any telemetry. All services emit
-telemetry via OpenTelemetry. Local dev uses Jaeger; production backends are
-chosen per project in an ADR.
+telemetry via OpenTelemetry. Local dev uses the shared dotfiles telemetry stack
+(otel-collector → Tempo/Grafana); a per-project Jaeger is the isolation
+fallback. Production backends are chosen per project in an ADR.
 
 ## Scope
 
@@ -45,18 +46,30 @@ go.opentelemetry.io/otel/sdk
 go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc
 ```
 
-## Local Jaeger
+## Local telemetry
 
-`compose.yaml` runs a Jaeger all-in-one (`jaegertracing/all-in-one`,
-`COLLECTOR_OTLP_ENABLED=true`; ports `16686` UI / `4317` gRPC / `4318` HTTP).
-Apps set `OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317` and
+Either way, apps set `OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317` and
 `OTEL_SERVICE_NAME=<module>`.
 
+**Primary — shared stack (run from the dotfiles repo):**
+
 ```sh
-just trace-up     # docker compose -f compose.yaml up -d jaeger
-just trace-down   # stop it
-just trace-view   # open http://localhost:16686
+just tel-up     # otel-collector (OTLP :4317 gRPC / :4318 HTTP) -> Tempo + Grafana
+just tel-down   # stop it
+# UI: Grafana at http://localhost:3010 (https://grafana.localhost via portless)
 ```
+
+No per-repo telemetry services needed — point apps at the shared collector.
+
+**Fallback — per-project Jaeger (from the agent-baseline `justfile`),** for
+fully isolated work: `just trace-up` runs a Jaeger all-in-one
+(`jaegertracing/all-in-one`, `COLLECTOR_OTLP_ENABLED=true`; UI `:16686`,
+OTLP `:4317`/`:4318`) from the repo's `compose.yaml`; `just trace-down` stops
+it; `just trace-view` opens the UI.
+
+Never run both at once — they bind the same OTLP host ports (`4317`/`4318`),
+and that collision class has crashed the local Docker VM before. Prefer the
+shared stack.
 
 ## Production
 

--- a/ROOT_AGENTS_docs_agents_python-tooling.md
+++ b/ROOT_AGENTS_docs_agents_python-tooling.md
@@ -58,8 +58,9 @@ extend-ignore = ["E501", "RUF002", "RUF003"]
 ## Pre-commit sequence
 
 ```sh
-just lint   # uv run ruff check .  &&  uv run mypy .
+just check  # the full gate; or piecewise (format before linting):
 just fmt    # uv run ruff format .
+just lint   # uv run ruff check .  &&  uv run mypy .
 just semgrep   # when .semgrep/ exists
 just test   # uv run pytest
 ```

--- a/ROOT_AGENTS_docs_agents_tdd-workflow.md
+++ b/ROOT_AGENTS_docs_agents_tdd-workflow.md
@@ -9,8 +9,9 @@ AGENTS.md; this file is the full procedure.
    of behavior. Use a behavior-describing name
    (`test_should_sum_two_positive_numbers`). Make the failure message clear.
 2. **Green** — write the *minimum* code to pass. No more. With type annotations.
-3. **Verify** — run `just lint` (ruff + mypy), `just fmt`, and `just semgrep`
-   (when `.semgrep/` exists), then `just test`.
+3. **Verify** — run `just check` (the full gate). When running pieces
+   individually, format before linting: `just fmt` → `just lint` →
+   `just semgrep` (when `.semgrep/` exists) → `just test`.
 4. **Refactor** — only on green. One refactoring at a time; run tests after each.
    Prioritize removing duplication and clarifying intent.
 5. **Commit** — structural and behavioral changes as *separate* commits
@@ -60,10 +61,12 @@ def validate_email(email: str) -> bool:
 **[Verify]**:
 
 ```sh
-just lint     # or: uv run ruff check . && uv run mypy .
-just fmt      # or: uv run ruff format .
+just check    # the full gate: fmt + lint + types + semgrep + test
+# or piecewise (format before linting):
+just fmt      # uv run ruff format .
+just lint     # uv run ruff check . && uv run mypy .
 just semgrep  # when .semgrep/ exists
-just test     # or: uv run pytest
+just test     # uv run pytest
 ```
 
 **[Refactor]** (separate commit) — extract once a pattern emerges:

--- a/ROOT_AGENTS_hooks_block-prohibited-commands.sh
+++ b/ROOT_AGENTS_hooks_block-prohibited-commands.sh
@@ -15,23 +15,83 @@ cmd="$(printf '%s' "$input" | jq -r '.tool_input.command // empty')"
 block() { echo "BLOCKED: $1" >&2; exit 2; }
 
 # --- Package managers ---------------------------------------------------------
+# Tooling-word guards scan with quoted substrings removed, so prose mentions
+# (commit messages, echo strings) don't false-trigger. The flip side — a quoted
+# invocation like `bash -c "npm i"` slips these guards — is accepted long tail:
+# prose rules + review cover it. Destructive/IaC guards below keep scanning the
+# full string (over-blocking is the safe side there).
+scan="$(printf '%s' "$cmd" | sed -E -e 's/"[^"]*"//g' -e "s/'[^']*'//g")"
+
 # Python: uv only.
-if printf '%s' "$cmd" | grep -Eq '(^|[^[:alnum:]_./-])(pip3?|poetry|pipenv)([[:space:]]|$)'; then
+if printf '%s' "$scan" | grep -Eq '(^|[^[:alnum:]_./-])(pip3?|poetry|pipenv)([[:space:]]|$)'; then
   block "Python package management is 'uv' only (uv add / uv sync / uv run). Do not use pip/poetry/pipenv."
 fi
 
 # Node: bun, unless pnpm-lock.yaml exists (then pnpm). Never npm/yarn.
-if printf '%s' "$cmd" | grep -Eq '(^|[^[:alnum:]_./-])(npm|yarn)([[:space:]]|$)'; then
+if printf '%s' "$scan" | grep -Eq '(^|[^[:alnum:]_./-])(npm|yarn)([[:space:]]|$)'; then
   block "Node package management is 'bun' (or 'pnpm' iff pnpm-lock.yaml exists). Do not use npm/yarn."
 fi
-if printf '%s' "$cmd" | grep -Eq '(^|[^[:alnum:]_./-])pnpm([[:space:]]|$)'; then
-  if [ ! -f pnpm-lock.yaml ]; then
-    block "'pnpm' is allowed only when pnpm-lock.yaml exists in this project. Use 'bun' instead."
+
+# pnpm: allowed only when a pnpm-lock.yaml governs EACH pnpm invocation's
+# effective directory — the last `cd` target before it in its segment chain,
+# its -C/--dir flag, or the session cwd — searched upward to the filesystem
+# root. Parsing is best-effort; unresolvable targets (variables, subshells)
+# fail safe (block), and the block message offers the `!` escape hatch.
+find_pnpm_lock_upward() {
+  local d
+  d="$(cd "$1" 2>/dev/null && pwd)" || return 1
+  while :; do
+    [ -f "$d/pnpm-lock.yaml" ] && return 0
+    [ "$d" = "/" ] && return 1
+    d="$(dirname "$d")"
+  done
+}
+
+if printf '%s' "$scan" | grep -Eq '(^|[^[:alnum:]_./-])pnpm([[:space:]]|$)'; then
+  segs="$scan"
+  segs="${segs//";"/$'\n'}"
+  segs="${segs//"&&"/$'\n'}"
+  segs="${segs//"||"/$'\n'}"
+  eff_dir="$PWD"
+  pnpm_ok=1
+  while IFS= read -r seg; do
+    seg="$(printf '%s' "$seg" | sed -E 's/^[[:space:](]+//')"
+    case "$seg" in
+      cd|cd\ *)
+        tgt="${seg#cd}"
+        tgt="${tgt# }"
+        tgt="${tgt%%[[:space:]]*}"
+        tgt="${tgt/#\~/$HOME}"
+        case "$tgt" in
+          "" | \$* | \`*) eff_dir="" ;; # empty/variable/substitution: unresolvable
+          /*) eff_dir="$tgt" ;;
+          *) if [ -n "$eff_dir" ]; then eff_dir="$eff_dir/$tgt"; else eff_dir=""; fi ;;
+        esac
+        ;;
+    esac
+    if printf '%s' "$seg" | grep -Eq '(^|[^[:alnum:]_./-])pnpm([[:space:]]|$)'; then
+      if printf '%s' "$seg" | grep -Eq '[[:space:]](-C|--dir)[= ]'; then
+        tdir="$(printf '%s' "$seg" | sed -nE 's/.*[[:space:]](-C|--dir)[= ]([^[:space:]]+).*/\2/p')"
+        case "$tdir" in
+          "" | \$* | \`*) check_dir="" ;;
+          /*) check_dir="$tdir" ;;
+          *) if [ -n "$eff_dir" ]; then check_dir="$eff_dir/$tdir"; else check_dir=""; fi ;;
+        esac
+      else
+        check_dir="$eff_dir"
+      fi
+      if [ -z "$check_dir" ] || ! find_pnpm_lock_upward "$check_dir"; then
+        pnpm_ok=0
+      fi
+    fi
+  done <<<"$segs"
+  if [ "$pnpm_ok" -ne 1 ]; then
+    block "'pnpm' is allowed only when pnpm-lock.yaml governs each pnpm invocation's target directory (resolved cd/-C/--dir target or cwd, searched upward). Use 'bun' instead — or, for a legitimate cross-repo call this guard can't resolve, ask the user to run it with the '!' prefix."
   fi
 fi
 
 # Task runner: just only, no make.
-if printf '%s' "$cmd" | grep -Eq '(^|[^[:alnum:]_./-])make([[:space:]]|$)'; then
+if printf '%s' "$scan" | grep -Eq '(^|[^[:alnum:]_./-])make([[:space:]]|$)'; then
   block "Task automation is 'just' only. Add a recipe to the root justfile instead of using make."
 fi
 

--- a/ROOT_CLAUDE.md
+++ b/ROOT_CLAUDE.md
@@ -50,12 +50,15 @@ bounded and clear: a reviewer that surfaces observations it can't turn into a fi
 just grows the list without moving the plan forward.
 
 ```sh
+# Model selection is owned by ~/.codex/config.toml — never pin -m here
+# (a pinned model id rots when codex retires it and breaks every review).
+
 # First review of a new plan:
-codex exec -m gpt-5.5 --skip-git-repo-check \
+codex exec --skip-git-repo-check \
   "このプランを批判的にレビューして。各指摘は具体的な修正・解決策とセットの actionable なものに絞って（直せない感想や瑣末な点で件数を増やさない）、致命的な点から優先して挙げて: {plan_full_path} (ref: {AGENTS.md full_path})"
 
 # Reviewing an updated plan — keep prior context with `resume --last`:
-codex exec resume --skip-git-repo-check --last -m gpt-5.5 \
+codex exec resume --skip-git-repo-check --last \
   "プランを更新したから批判的にレビューして。各指摘は具体的な修正・解決策とセットの actionable なものに絞って（直せない感想や瑣末な点で件数を増やさない）、致命的な点から優先して挙げて: {plan_full_path} (ref: {AGENTS.md full_path})"
 ```
 

--- a/justfile
+++ b/justfile
@@ -350,6 +350,14 @@ test:
     uvx pytest -v -ra tests/test_just_sandbox.py tests/test_devcontainer.py tests/test_actor_type_injection.py
     @echo '✅ Tests finished.'
 
+# Test (unit): fast host-side unit tests — no Docker. Covers sync_agents
+# helpers and the agent hook scripts (tests/unit/). Runs as part of `ci`.
+[group('Test')]
+test-unit:
+    @echo '🧪 Running unit tests (host, no Docker)...'
+    uvx pytest -q -ra tests/unit/
+    @echo '✅ Unit tests finished.'
+
 # Test (install): run install.sh verification in Docker
 [group('Test')]
 test-install:
@@ -488,7 +496,7 @@ pre-commit:
 
 # Fast gate (no Docker / no heavy uv): lint+format+semgrep, rule self-tests, IaC tests
 [group('CI')]
-ci: check semgrep-test portless-doc-check test-iac
+ci: check test-unit semgrep-test portless-doc-check test-iac
     @echo "✅ ci (fast gate) passed"
 
 # Full non-emulator matrix: fast gate + Docker sandbox tests + install verification

--- a/justfile
+++ b/justfile
@@ -199,6 +199,12 @@ sync-agents-override *args:
 sync-agents-orphans *args:
     @{{UV_RUN}} scripts/sync_agents.py --orphans {{ args }}
 
+# Verify deployed agent-home instruction files have no dead file references
+# (run after sync-agents; environment-dependent, so not part of `ci`)
+[group('Agents')]
+check-agent-refs *homes:
+    @{{UV_RUN}} scripts/check_agent_home_refs.py {{ homes }}
+
 # Import only: target -> dotfiles. No forward sync, no orphan removal.
 # Default scope = .claude only. Pass targets to widen (same aliases as sync-agents).
 # Every selected agent becomes an import source — is_import_source flag is ignored.

--- a/scripts/check_agent_home_refs.py
+++ b/scripts/check_agent_home_refs.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+"""Scan deployed agent-home instruction files for dead file references.
+
+Verification gate for the distributed agent instruction set: after
+`just sync-agents`, every file reference inside the deployed base/overlay/
+spokes must resolve. Per agent home this checks that:
+
+1. absolute `/Users/...` and `~/...` references to .md/.sh/.yaml files exist
+   (glob-ish tokens like `*` are checked at their fixed directory prefix);
+2. no bare `docs/agents/` reference survived the sync path-rewrite;
+3. no reference to README-agents-setup.md (not distributed) remains.
+
+Exit code: 0 = clean, 1 = dead references found (listed on stdout).
+
+Usage: uv run scripts/check_agent_home_refs.py [AGENT_HOME ...]
+       (default: ~/.claude)
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+_PATH_RE = re.compile(r"(?:/Users/|~/)[\w@./*-]+")
+_SUFFIXES = {".md", ".sh", ".yaml"}
+_TRAILING_PUNCT = ".,;:'\")"
+
+# Explanatory strings exempt from existence checks (none needed today; add the
+# exact matched token here if a doc must show a deliberately fictional path).
+ALLOWLIST: frozenset[str] = frozenset()
+
+
+def _expand(ref: str) -> Path:
+    if ref.startswith("~/"):
+        return Path.home() / ref[2:]
+    return Path(ref)
+
+
+def _glob_prefix_exists(ref: str) -> bool:
+    fixed = ref.split("*", 1)[0]
+    path = _expand(fixed)
+    return path.is_dir() if fixed.endswith("/") else path.parent.is_dir()
+
+
+def _iter_instruction_files(home: Path) -> list[Path]:
+    files = [home / "AGENTS.md", home / "CLAUDE.md"]
+    files.extend(sorted((home / "docs" / "agents").glob("*.md")))
+    return [f for f in files if f.is_file()]
+
+
+def _scan_file(path: Path) -> list[str]:
+    problems: list[str] = []
+    text = path.read_text(encoding="utf-8")
+
+    spans: list[tuple[int, int]] = []
+    for match in _PATH_RE.finditer(text):
+        spans.append(match.span())
+        ref = match.group(0).rstrip(_TRAILING_PUNCT)
+        if ref in ALLOWLIST:
+            continue
+        if "*" in ref:
+            ok = _glob_prefix_exists(ref)
+        elif Path(ref).suffix in _SUFFIXES:
+            ok = _expand(ref).exists()
+        else:
+            continue  # directory or extensionless mention — not checked
+        if not ok:
+            problems.append(f"{path.name}: dead path reference '{ref}'")
+
+    for bare in re.finditer(r"docs/agents/", text):
+        inside_abs = any(start <= bare.start() < end for start, end in spans)
+        if not inside_abs:
+            line = text.count("\n", 0, bare.start()) + 1
+            problems.append(
+                f"{path.name}:{line}: bare 'docs/agents/' reference "
+                "(sync path-rewrite miss?)"
+            )
+
+    if "README-agents-setup" in text:
+        problems.append(
+            f"{path.name}: references README-agents-setup.md (not distributed)"
+        )
+
+    return problems
+
+
+def main(argv: list[str]) -> int:
+    homes = [Path(arg).expanduser() for arg in argv] or [Path.home() / ".claude"]
+    problems: list[str] = []
+    for home in homes:
+        files = _iter_instruction_files(home)
+        if not files:
+            problems.append(f"{home}: no instruction files found (wrong home?)")
+            continue
+        for file in files:
+            problems.extend(_scan_file(file))
+
+    if problems:
+        print("DEAD REFERENCES FOUND:")
+        for problem in problems:
+            print(f"  - {problem}")
+        return 1
+
+    homes_label = ", ".join(str(h) for h in homes)
+    print(f"OK: all instruction-file references resolve in {homes_label}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/templates/agent-baseline/README-agents-setup.md
+++ b/templates/agent-baseline/README-agents-setup.md
@@ -27,13 +27,10 @@ docs/agents/                   # spokes — read on demand (NOT preloaded)
   docs-discipline.md
   project-structure.md
 
-.claude/
-  settings.json                # wires the hooks below
-  hooks/
-    block-prohibited-files.sh    # PreToolUse: blocks .yml / docker-compose.*
-    block-prohibited-commands.sh # PreToolUse: blocks pip/npm/yarn/make, IaC drift, rm -rf /
-    block-secrets.sh             # PreToolUse: blocks obvious secrets in writes
-    format-after-edit.sh         # PostToolUse: ruff format + --fix on edited files
+# NOTE: Claude Code hooks are NOT files in this scaffold. The dotfiles repo
+# distributes them globally (~/.claude/settings.json + ~/.claude/hooks/*.sh,
+# via `just sync-agents`), so they already apply in every repo — including
+# this one. See ~/.claude/docs/agents/enforcement.md.
 
 .githooks/pre-commit           # human/git gate -> runs `just check`
 .github/workflows/quality-gate.yaml  # CI gate + tofu drift check
@@ -57,8 +54,10 @@ every tool.
 with zero exceptions, that's not good enough. So:
 
 1. **Claude Code hooks** — fire before/after tool calls, bypassing model
-   judgment. PreToolUse hooks **block** with `exit 2` (the script's stderr is fed
-   back to the agent as the reason). Critical gotcha baked into every guard:
+   judgment. Distributed globally from the dotfiles repo via `just sync-agents`
+   (`~/.claude/settings.json` + `~/.claude/hooks/*.sh`) — they are not files in
+   this repo. PreToolUse hooks **block** with `exit 2` (the script's stderr is
+   fed back to the agent as the reason). Critical gotcha baked into every guard:
    `exit 2` blocks, `exit 1` does **not** — `exit 1` is a non-blocking error and
    the action proceeds.
 2. **Git pre-commit** (`.githooks/pre-commit` → `just check`) — same gate for
@@ -76,8 +75,9 @@ common cases; prose covers the long tail.
 just install-hooks      # sets core.hooksPath=.githooks and chmod +x the hooks
 ```
 
-Claude Code picks up `.claude/settings.json` automatically. Verify hooks load
-with `/hooks` inside Claude Code. Personal-only experiments go in
+Claude Code hooks come from the global `~/.claude/settings.json` (synced from
+the dotfiles repo) — nothing to enable per repo. Verify they load with `/hooks`
+inside Claude Code. Personal-only experiments go in
 `.claude/settings.local.json` (auto-gitignored).
 
 ## Repo-scan self-reference
@@ -101,13 +101,15 @@ The `block-prohibited-files` hook already exempts these paths.
 ## Tuning the hooks
 
 The command/file guards use conservative regexes. If a guard misfires (false
-positive) or misses a case you care about (false negative), edit the matching
-`.claude/hooks/*.sh` script — they're plain bash with the logic inline and
-commented. Test a hook in isolation:
+positive) or misses a case you care about (false negative), edit the **source**
+in the dotfiles repo (`ROOT_AGENTS_hooks_*.sh`), extend
+`tests/unit/test_agent_hooks.py` there, then run `just sync-agents` — never
+edit `~/.claude/hooks/*.sh` directly (the next sync overwrites them). Test a
+hook in isolation:
 
 ```sh
-echo '{"tool_input":{"command":"npm install"}}' | bash .claude/hooks/block-prohibited-commands.sh; echo "exit=$?"
-echo '{"tool_input":{"file_path":"config.yml"}}' | bash .claude/hooks/block-prohibited-files.sh; echo "exit=$?"
+echo '{"tool_input":{"command":"npm install"}}' | bash ~/.claude/hooks/block-prohibited-commands.sh; echo "exit=$?"
+echo '{"tool_input":{"file_path":"config.yml"}}' | bash ~/.claude/hooks/block-prohibited-files.sh; echo "exit=$?"
 ```
 
 (`exit=2` means the guard would block; `exit=0` means it would allow.)

--- a/tests/unit/test_agent_hooks.py
+++ b/tests/unit/test_agent_hooks.py
@@ -90,6 +90,66 @@ def test_pnpm_without_lockfile_is_blocked(unlocked_repo: Path) -> None:
     assert _run_hook("pnpm install", unlocked_repo) == EXIT_BLOCK
 
 
+def test_pnpm_with_lockfile_in_ancestor_is_allowed(locked_repo: Path) -> None:
+    """Monorepo subdirectory: the lockfile lives at the repo root above cwd."""
+    sub = locked_repo / "packages" / "app"
+    sub.mkdir(parents=True)
+    assert _run_hook("pnpm install", sub) == EXIT_ALLOW
+
+
+def test_pnpm_cd_into_locked_repo_is_allowed(
+    locked_repo: Path, unlocked_repo: Path
+) -> None:
+    """Cross-repo: cwd has no lockfile, but the cd target does."""
+    cmd = f"cd {locked_repo} && pnpm install"
+    assert _run_hook(cmd, unlocked_repo) == EXIT_ALLOW
+
+
+def test_pnpm_dash_c_locked_repo_is_allowed(
+    locked_repo: Path, unlocked_repo: Path
+) -> None:
+    cmd = f"pnpm -C {locked_repo} install"
+    assert _run_hook(cmd, unlocked_repo) == EXIT_ALLOW
+
+
+def test_pnpm_mixed_cd_segments_blocked(
+    locked_repo: Path, unlocked_repo: Path, tmp_path: Path
+) -> None:
+    """Per-invocation gate: one governed pnpm call must not bless the others."""
+    cmd = f"cd {locked_repo} && pnpm install; cd {unlocked_repo} && pnpm install"
+    assert _run_hook(cmd, tmp_path) == EXIT_BLOCK
+
+
+def test_pnpm_dash_c_mixed_blocked(
+    locked_repo: Path, unlocked_repo: Path, tmp_path: Path
+) -> None:
+    cmd = f"pnpm -C {locked_repo} install && pnpm -C {unlocked_repo} install"
+    assert _run_hook(cmd, tmp_path) == EXIT_BLOCK
+
+
+def test_pnpm_variable_dir_is_blocked(unlocked_repo: Path) -> None:
+    """Unresolvable target (variable) fails safe: block."""
+    assert _run_hook('cd "$PROJECT_DIR" && pnpm install', unlocked_repo) == EXIT_BLOCK
+
+
+def test_pnpm_mention_in_commit_message_is_allowed(unlocked_repo: Path) -> None:
+    """Prose mentions inside quotes are not invocations (observed false block)."""
+    cmd = 'git commit -m "docs: explain why pnpm is gated on lockfiles"'
+    assert _run_hook(cmd, unlocked_repo) == EXIT_ALLOW
+
+
+def test_npm_mention_in_commit_message_is_allowed(unlocked_repo: Path) -> None:
+    cmd = 'git commit -m "build: switch from npm to bun"'
+    assert _run_hook(cmd, unlocked_repo) == EXIT_ALLOW
+
+
+def test_make_mention_in_commit_message_is_allowed(unlocked_repo: Path) -> None:
+    """The English verb 'make' in a quoted message must not trip the task-runner
+    guard (observed false block)."""
+    cmd = 'git commit -m "ci: have the gate make builds reproducible"'
+    assert _run_hook(cmd, unlocked_repo) == EXIT_ALLOW
+
+
 # --- Destructive / IaC drift ------------------------------------------------
 
 

--- a/tests/unit/test_agent_hooks.py
+++ b/tests/unit/test_agent_hooks.py
@@ -1,0 +1,118 @@
+"""Unit tests for the agent PreToolUse hook ROOT_AGENTS_hooks_block-prohibited-commands.sh.
+
+The hook receives Claude Code tool input as JSON on stdin and answers with its
+exit code: 0 allows the command, 2 blocks it (exit 1 would NOT block — see the
+exit-code contract in ROOT_AGENTS_docs_agents_enforcement.md).
+
+These tests run the real script through bash with a controlled cwd, so they
+pin both the block list and the pnpm lockfile-resolution behavior.
+"""
+
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+HOOK = (
+    Path(__file__).resolve().parents[2]
+    / "ROOT_AGENTS_hooks_block-prohibited-commands.sh"
+)
+
+EXIT_ALLOW = 0
+EXIT_BLOCK = 2
+
+pytestmark = pytest.mark.skipif(
+    shutil.which("bash") is None or shutil.which("jq") is None,
+    reason="hook needs bash + jq on PATH",
+)
+
+
+def _run_hook(command: str, cwd: Path) -> int:
+    """Feed a Bash tool_input payload to the hook and return its exit code."""
+    payload = json.dumps({"tool_input": {"command": command}})
+    result = subprocess.run(
+        ["bash", str(HOOK)],
+        input=payload,
+        capture_output=True,
+        text=True,
+        cwd=cwd,
+        check=False,
+    )
+    return result.returncode
+
+
+@pytest.fixture()
+def locked_repo(tmp_path: Path) -> Path:
+    """A project directory governed by pnpm-lock.yaml."""
+    repo = tmp_path / "locked"
+    repo.mkdir()
+    (repo / "pnpm-lock.yaml").write_text("lockfileVersion: '9.0'\n")
+    return repo
+
+
+@pytest.fixture()
+def unlocked_repo(tmp_path: Path) -> Path:
+    """A project directory without a pnpm lockfile."""
+    repo = tmp_path / "unlocked"
+    repo.mkdir()
+    return repo
+
+
+# --- Package managers -----------------------------------------------------
+
+
+def test_pip_is_blocked(tmp_path: Path) -> None:
+    assert _run_hook("pip install requests", tmp_path) == EXIT_BLOCK
+
+
+def test_npm_is_blocked(tmp_path: Path) -> None:
+    assert _run_hook("npm install", tmp_path) == EXIT_BLOCK
+
+
+def test_uv_is_allowed(tmp_path: Path) -> None:
+    assert _run_hook("uv add httpx", tmp_path) == EXIT_ALLOW
+
+
+def test_make_is_blocked(tmp_path: Path) -> None:
+    assert _run_hook("make build", tmp_path) == EXIT_BLOCK
+
+
+# --- pnpm lockfile gate ----------------------------------------------------
+
+
+def test_pnpm_with_lockfile_in_cwd_is_allowed(locked_repo: Path) -> None:
+    assert _run_hook("pnpm install", locked_repo) == EXIT_ALLOW
+
+
+def test_pnpm_without_lockfile_is_blocked(unlocked_repo: Path) -> None:
+    assert _run_hook("pnpm install", unlocked_repo) == EXIT_BLOCK
+
+
+# --- Destructive / IaC drift ------------------------------------------------
+
+
+def test_rm_rf_root_is_blocked(tmp_path: Path) -> None:
+    assert _run_hook("rm -rf /", tmp_path) == EXIT_BLOCK
+
+
+def test_force_push_to_main_is_blocked(tmp_path: Path) -> None:
+    assert _run_hook("git push --force origin main", tmp_path) == EXIT_BLOCK
+
+
+def test_readonly_gcloud_is_allowed(tmp_path: Path) -> None:
+    assert _run_hook("gcloud compute instances list", tmp_path) == EXIT_ALLOW
+
+
+def test_gcloud_iam_binding_is_blocked(tmp_path: Path) -> None:
+    cmd = "gcloud projects add-iam-policy-binding my-proj --member=x --role=y"
+    assert _run_hook(cmd, tmp_path) == EXIT_BLOCK
+
+
+def test_gcloud_run_deploy_is_blocked(tmp_path: Path) -> None:
+    assert _run_hook("gcloud run deploy api --image x", tmp_path) == EXIT_BLOCK
+
+
+def test_cdr_workspace_update_is_blocked(tmp_path: Path) -> None:
+    assert _run_hook("cdr workspaces update my-ws", tmp_path) == EXIT_BLOCK

--- a/tests/unit/test_detect_target_only_items.py
+++ b/tests/unit/test_detect_target_only_items.py
@@ -2,6 +2,11 @@
 
 Tests the orphan detection logic that identifies items existing
 only in the target directory (not in dotfiles source or manifest).
+
+`skills` is an ADDITIVE directory (see ADDITIVE_DIRECTORIES in sync_agents):
+target-only skills are never flagged as orphans because the `bunx skills`
+CLI owns installs there. Orphan detection still applies to the non-additive
+sync directories (`commands`, `agents`).
 """
 
 from pathlib import Path
@@ -43,12 +48,21 @@ def _make_skill(parent: Path, name: str) -> Path:
     return skill_dir
 
 
-def test_detects_orphan_skill_in_target(workspace: dict[str, Path]) -> None:
-    """Target-only skill (not in source, not in manifest) is detected as orphan."""
+def _make_command(parent: Path, name: str) -> Path:
+    """Create a minimal command file under commands/."""
+    cmd_dir = parent / "commands"
+    cmd_dir.mkdir(parents=True, exist_ok=True)
+    cmd_file = cmd_dir / f"{name}.md"
+    cmd_file.write_text(f"# {name}\n")
+    return cmd_file
+
+
+def test_additive_skills_orphan_not_detected(workspace: dict[str, Path]) -> None:
+    """Target-only skill is NOT an orphan — skills/ is additive (CLI-owned)."""
     # given
     _make_skill(workspace["dotfiles"], "my-skill")
     _make_skill(workspace["target"], "my-skill")
-    _make_skill(workspace["target"], "orphan-skill")
+    _make_skill(workspace["target"], "cli-installed-skill")
     manifest = _SyncManifest(items={"skills": ["my-skill"]})
     agent = _make_agent(workspace["target"])
 
@@ -56,9 +70,44 @@ def test_detects_orphan_skill_in_target(workspace: dict[str, Path]) -> None:
     orphans = _detect_target_only_items(workspace["dotfiles"], agent, manifest)
 
     # then
+    assert orphans == []
+
+
+def test_detects_orphan_command_in_target(workspace: dict[str, Path]) -> None:
+    """Target-only item in a non-additive dir (commands/) is detected as orphan."""
+    # given
+    _make_command(workspace["dotfiles"], "my-cmd")
+    _make_command(workspace["target"], "my-cmd")
+    _make_command(workspace["target"], "orphan-cmd")
+    manifest = _SyncManifest(items={"commands": ["my-cmd.md"]})
+    agent = _make_agent(workspace["target"])
+
+    # when
+    orphans = _detect_target_only_items(workspace["dotfiles"], agent, manifest)
+
+    # then
     assert len(orphans) == 1
-    assert orphans[0].relative_path == "skills/orphan-skill"
+    assert orphans[0].relative_path == "commands/orphan-cmd.md"
     assert orphans[0].reason == "orphan"
+    assert orphans[0].is_directory is False
+
+
+def test_detects_orphan_directory_in_target(workspace: dict[str, Path]) -> None:
+    """Target-only directory in a non-additive dir is detected with is_directory."""
+    # given
+    orphan_dir = workspace["target"] / "agents" / "orphan-agent"
+    orphan_dir.mkdir(parents=True, exist_ok=True)
+    (orphan_dir / "agent.md").write_text("# orphan\n")
+    (workspace["dotfiles"] / "agents").mkdir(parents=True, exist_ok=True)
+    manifest = _SyncManifest(items={})
+    agent = _make_agent(workspace["target"])
+
+    # when
+    orphans = _detect_target_only_items(workspace["dotfiles"], agent, manifest)
+
+    # then
+    assert len(orphans) == 1
+    assert orphans[0].relative_path == "agents/orphan-agent"
     assert orphans[0].is_directory is True
 
 
@@ -171,10 +220,10 @@ def test_source_symlinks_count_as_valid_names(workspace: dict[str, Path]) -> Non
 def test_multiple_orphans_sorted_by_name(workspace: dict[str, Path]) -> None:
     """Multiple orphans are returned sorted by directory iteration order."""
     # given
-    _make_skill(workspace["dotfiles"], "keep-me")
-    _make_skill(workspace["target"], "keep-me")
-    _make_skill(workspace["target"], "zebra-orphan")
-    _make_skill(workspace["target"], "alpha-orphan")
+    _make_command(workspace["dotfiles"], "keep-me")
+    _make_command(workspace["target"], "keep-me")
+    _make_command(workspace["target"], "zebra-orphan")
+    _make_command(workspace["target"], "alpha-orphan")
     manifest = _SyncManifest(items={})
     agent = _make_agent(workspace["target"])
 
@@ -184,7 +233,7 @@ def test_multiple_orphans_sorted_by_name(workspace: dict[str, Path]) -> None:
     # then
     assert len(orphans) == 2
     paths = [o.relative_path for o in orphans]
-    assert paths == ["skills/alpha-orphan", "skills/zebra-orphan"]
+    assert paths == ["commands/alpha-orphan.md", "commands/zebra-orphan.md"]
 
 
 def test_no_target_skills_dir(workspace: dict[str, Path]) -> None:
@@ -202,7 +251,7 @@ def test_no_target_skills_dir(workspace: dict[str, Path]) -> None:
 
 
 def test_no_source_skills_dir(workspace: dict[str, Path]) -> None:
-    """All target items are orphans when source has no skills/ directory."""
+    """Target-only skills survive even when source has no skills/ — additive."""
     # given
     _make_skill(workspace["target"], "lonely-skill")
     manifest = _SyncManifest(items={})
@@ -212,8 +261,22 @@ def test_no_source_skills_dir(workspace: dict[str, Path]) -> None:
     orphans = _detect_target_only_items(workspace["dotfiles"], agent, manifest)
 
     # then
+    assert orphans == []
+
+
+def test_no_source_commands_dir(workspace: dict[str, Path]) -> None:
+    """All target items are orphans when source lacks a non-additive dir."""
+    # given
+    _make_command(workspace["target"], "lonely-cmd")
+    manifest = _SyncManifest(items={})
+    agent = _make_agent(workspace["target"])
+
+    # when
+    orphans = _detect_target_only_items(workspace["dotfiles"], agent, manifest)
+
+    # then
     assert len(orphans) == 1
-    assert orphans[0].relative_path == "skills/lonely-skill"
+    assert orphans[0].relative_path == "commands/lonely-cmd.md"
     assert orphans[0].reason == "orphan"
 
 
@@ -243,10 +306,10 @@ def test_respects_agent_sync_directories(workspace: dict[str, Path]) -> None:
 def test_orphan_file_not_directory(workspace: dict[str, Path]) -> None:
     """Non-directory orphan items are detected with is_directory=False."""
     # given
-    skills_dir = workspace["target"] / "skills"
-    skills_dir.mkdir(parents=True, exist_ok=True)
-    (skills_dir / "stray-file.md").write_text("# stray\n")
-    (workspace["dotfiles"] / "skills").mkdir(parents=True, exist_ok=True)
+    commands_dir = workspace["target"] / "commands"
+    commands_dir.mkdir(parents=True, exist_ok=True)
+    (commands_dir / "stray-file.md").write_text("# stray\n")
+    (workspace["dotfiles"] / "commands").mkdir(parents=True, exist_ok=True)
     manifest = _SyncManifest(items={})
     agent = _make_agent(workspace["target"])
 
@@ -255,5 +318,5 @@ def test_orphan_file_not_directory(workspace: dict[str, Path]) -> None:
 
     # then
     assert len(orphans) == 1
-    assert orphans[0].relative_path == "skills/stray-file.md"
+    assert orphans[0].relative_path == "commands/stray-file.md"
     assert orphans[0].is_directory is False


### PR DESCRIPTION
## 概要

agent instruction set（ROOT_AGENTS / spokes / hooks）の S+ 化。監査で見つかった
「配布後に解決しない参照」「現実と乖離した spoke」「文書と hook 挙動の不一致」
「pnpm gate の cross-repo 誤爆」を根治する。作業指示書は
`private/plan-agent-instructions-s-plus.md`（local・codex gpt-5.5 レビュー済み）。

## 変更（commit 単位、structural / behavioral 分離）

| commit | type | 内容 |
|---|---|---|
| 6f58142 | test(sync) | tests/unit の stale red 4 件を additive skills 設計に整合（どこにも配線されておらず潜伏していた） |
| 7858a26 | docs(agents) | 新 spoke `docs/agents/enforcement.md`。README-agents-setup.md への dangling 参照 3 箇所を解消。Non-negotiables にツール別 enforcement 範囲のヘッジ。iac-drift の「flags for confirmation」→「blocks (exit 2)」 |
| 019a63d | docs(templates) | agent-baseline README の file map から実体のない `.claude/` を除去（hooks は global sync 供給） |
| 827b635 | docs(agents) | observability spoke を共有 tel スタック（tel-up: collector :4317 → Tempo/Grafana）優先に。Jaeger は隔離 fallback へ格下げ + 4317/4318 衝突警告 |
| a631dc3 | test(hooks) | hook unit harness 新設 + `just test-unit` を `ci` に配線 |
| c8b088d | fix(hooks) | pnpm gate を per-invocation lockfile 解決に（cd/-C/--dir 追跡 + 上方探索）。tooling-word guards は quoted 文字列を除外してスキャン |
| 25c0480 | docs(agents) | quoted-prose スキャン仕様を enforcement spoke に明記 |
| f268e62 | docs(agents) | Verify 手順を `just check` 優先 + fmt→lint 順に |
| 7ef8e58 | chore(scripts) | dead-reference scanner `scripts/check_agent_home_refs.py` + `just check-agent-refs` |
| 3e17656 | docs(agents) | 複数行 heredoc prose の誤爆限界と file-based payload（--body-file / -F）の推奨を明記 |

## hook 誤爆の実地観測（このブランチ作業中に 3 件 — すべてテスト/文書化済み）

1. commit message 内の package-manager 名の言及 → 旧 hook が block（→ quoted-strip で根治）
2. commit message 内の英語動詞（task-runner と同名）→ 同上
3. 複数行 heredoc の PR 本文 → quote-strip は行単位なので素通り走査（→ 限界として文書化、file-based payload を推奨）

## 検証

- `just ci` green（新設 test-unit 35 cases 含む）
- `just test` green（devcontainer sandbox 90 passed — recipe 追加につき full 実行）
- `just sync-agents all` 適用済み → `just check-agent-refs`（6 agent homes）dead ref 0 件
- 配布済み hook の smoke: cross-repo lockfile 解決 allow / lockless block / quoted prose allow / 素の node-pm token block
- `wc -l ROOT_AGENTS.md` = 149（≤150 budget 維持）

## 🙋 裁定依頼（T7a — この PR ではコード未変更）

`ROOT_CLAUDE.md` の codex review コマンドの `-m gpt-5.5` pin はモデル退役時に
全プランレビューが壊れる時限爆弾。どちらにするか裁定ください（裁定後 follow-up commit）:

- **案1（推奨）**: pin を撤去し、operator 管理の `~/.codex/config.toml` default に委譲。
  ROOT_CLAUDE.md には「モデル選択は codex 側 config が正」と一文。更新責務が dotfiles から消える。
- **案2**: pin を維持し、「codex のモデル退役時にこの行を更新する」owner 注記を付ける。
  レビュー品質を特定モデルに固定したい場合はこちら。

## 記録

- **T8（optional・承認待ち）**: ROOT_AGENTS.md の GRIT 節圧縮（23→12 行目安）は
  思想的セクションのため未実施。承認があれば follow-up。
- **T10（見送り決定）**: Bash 経由 `.yml` 生成の hook 検出は regex では信頼性を毀損
  するため不実施。enforcement spoke に既知の限界として明記。実施するなら別 PR で
  パーサ前提。
