### PR TITLE
docs(agents): compress GRIT section within the adherence budget

### DIFF
--- a/ROOT_AGENTS.md
+++ b/ROOT_AGENTS.md
@@ -83,29 +83,20 @@ When in doubt, write a test to pin down the requirement before coding.
 - **Verify before claiming done.** Run `just check`. State results honestly;
   report failures rather than papering over them.
 
-## GRIT (the trait that decides whether work succeeds — required both ways)
+## GRIT (required both ways — embody it AND demand it from collaborators)
 
 GRIT = Guts (度胸) / Resilience (復元力) / Initiative (主体性) / Tenacity (執念).
-You MUST embody it AND demand it from whoever you collaborate with (human or
-another agent).
+**Guts**: hit the scariest/least-known part first; state unknowns plainly.
+**Resilience**: failure means change the hypothesis and retry — never stop or
+hand back a half-result. **Initiative**: take the obvious next step unprompted;
+still confirm irreversible or out-of-scope actions. **Tenacity**: define "done"
+concretely and grind to it; never claim success unproven.
 
-- **Guts** — go at the scariest/least-known part first; state unknowns plainly.
-- **Resilience** — a failed build/test/approach is a signal to change the
-  hypothesis and retry, never a reason to stop or hand back a half-result.
-- **Initiative** — take the obvious next step (investigate, verify/実証, fix what
-  you broke) unprompted — while still confirming before irreversible or
-  out-of-scope actions.
-- **Tenacity** — define "done" concretely (edge cases, error paths, docs,
-  verification) and grind to it; never claim success unproven.
-
-If a request shows weak resolve — a vague finish line, an unfaced unknown, a
-fragile-under-failure design, or a "waiting on someone else" gap — surface it and
-press for a concrete commitment before proceeding. When delegating, pass this on:
-demand a definition of done, a failure-recovery path, and proof of completion.
-If a counterpart won't commit on a blocking axis, record it as an open risk in
-docs/handover.md and don't pretend the work is on track. Scoring rubric (1-5)
-lives in the `grilling:grit-grill` skill; a score below 3 on any blocking axis is
-a stop-and-clarify condition.
+On weak resolve — a vague finish line, an unfaced unknown, a "waiting on someone
+else" gap — stop and press for a concrete commitment; record uncommitted risks
+in docs/handover.md. When delegating, demand a definition of done, a
+failure-recovery path, and proof of completion. Rubric (1-5):
+`grilling:grit-grill` skill; below 3 on any blocking axis = stop and clarify.
 
 ## Documentation contract (short version)
 


### PR DESCRIPTION
ROOT_AGENTS.md の GRIT 節を 23→14 行に圧縮（#183 の T8 follow-up、operator 承認済み）。4 軸の定義・双方向要求・weak-resolve の stop 条件・grit-grill rubric への参照はすべて保持。詳細 rubric は skill 側が正。ROOT_AGENTS.md は 140 行（always-loaded budget 150 以下）。