### PR TITLE
feat(hooks): parser-based command guard — heredoc-aware scanning and .yml creation detection

### DIFF
--- a/ROOT_AGENTS_docs_agents_enforcement.md
+++ b/ROOT_AGENTS_docs_agents_enforcement.md
@@ -37,29 +37,37 @@ covers the long tail.
 - `block-prohibited-files.sh` (Write|Edit): `.yml` filenames and deprecated
   Compose v1 names (`docker-compose.y{a,}ml`).
 - `block-secrets.sh` (Write|Edit): obvious secrets in file writes.
-- `block-prohibited-commands.sh` (Bash): `pip`/`poetry`/`pipenv`, `npm`/`yarn`,
-  `make`, root deletion, force-push to main/master, and drift-causing
-  `gcloud`/`cdr` mutations (blocked outright — open an IaC PR instead).
-  `pnpm` is allowed only when a `pnpm-lock.yaml` governs each pnpm invocation's
-  target directory (searched upward; `cd`/`-C`/`--dir` targets are resolved
-  best-effort).
+- `block-prohibited-commands.sh` (Bash): thin wrapper around a stdlib-only
+  Python guard (`block-prohibited-commands.py`, same directory) that parses
+  the command instead of regex-scanning it. Blocks: `pip`/`poetry`/`pipenv`,
+  `npm`/`yarn`, `make` (as command names), root deletion, force-push to
+  main/master, drift-causing `gcloud`/`cdr` mutations (open an IaC PR
+  instead), and **creating `.yml` files via Bash** (redirect targets,
+  `touch`/`tee` args, `cp`/`mv` destinations — reads stay allowed). `pnpm` is
+  allowed only when a `pnpm-lock.yaml` governs each pnpm invocation's target
+  directory (searched upward; `cd`/`-C`/`--dir` targets resolved, quoted
+  paths handled).
 - `format-after-edit.sh` (PostToolUse Write|Edit): `ruff format` +
   `ruff check --fix` on edited Python files.
 
-## Known limits (by design)
+## Parsing semantics (and accepted long tail)
 
-- File-naming rules are checked on Write/Edit only. Files created through Bash
-  (`touch x.yml`, shell redirects) are not intercepted — the prose rule and
-  review cover that long tail.
-- Tooling-word guards (package managers, task runner) scan with quoted
-  substrings removed, so prose mentions (commit messages, echo strings) don't
-  false-trigger. The flip side — a quoted invocation like `bash -c "npm i"`
-  slips them — is accepted long tail. Destructive/IaC guards scan the full
-  string; over-blocking is the safe side there.
-- Quote-stripping is line-based: multi-line prose embedded in a command
-  (heredoc PR bodies and the like) is scanned bare and can false-trigger.
-  Pass long prose via files instead — e.g. `gh pr create --body-file`,
-  `git commit -F`.
+- Quoted strings tokenize into single words, so prose mentions of tool names
+  (commit messages, echo strings, multi-line included) never false-trigger
+  the tooling guards. Flip side: a quoted invocation (`bash -c "npm i"`) and
+  wrapper forms outside the known set (`mise exec -- pnpm …`) slip them —
+  accepted long tail; prose rules + review cover it.
+- Heredocs are receiver-aware: a body consumed by a data sink (`cat`, `gh`,
+  `git`, …) is opaque prose and excluded from **all** guards (so PR bodies
+  via `gh pr create --body-file -` or `$(cat <<'EOF' …)` are safe); a body
+  fed to an interpreter (`bash`, `python`, `node`, …) is executable code and
+  is scanned like the top-level command.
+- Destructive/IaC guards still scan quoted text (only data-heredoc bodies are
+  excluded): a prose mention of e.g. a gcloud mutation inside `-m "…"` can
+  false-block. Over-blocking is the safe side there; put long prose in a
+  heredoc or a file (`git commit -F`, `--body-file`).
+- An unresolvable pnpm target (variable, subshell) fails safe (block); the
+  block message offers the `!` escape hatch for legitimate cross-repo calls.
 - Command parsing is best-effort. A pnpm target directory hidden behind a
   variable or subshell can't be resolved; the hook fails safe and blocks. If a
   block is a false positive, ask the user to run the command themselves with
@@ -67,10 +75,11 @@ covers the long tail.
 
 ## Tuning the hooks
 
-Hook sources live in the dotfiles repo as `ROOT_AGENTS_hooks_*.sh`, with unit
-tests in `tests/unit/test_agent_hooks.py`. Never edit `~/.claude/hooks/*.sh`
-directly — the next sync overwrites them. Edit the source, extend the tests,
-then run `just sync-agents` (from the dotfiles repo). Test a hook in isolation:
+Hook sources live in the dotfiles repo as `ROOT_AGENTS_hooks_*.sh` (plus the
+`*.py` companion for the command guard), with unit tests in
+`tests/unit/test_agent_hooks.py`. Never edit `~/.claude/hooks/*` directly —
+the next sync overwrites them. Edit the source, extend the tests, then run
+`just sync-agents` (from the dotfiles repo). Test a hook in isolation:
 
 ```sh
 echo '{"tool_input":{"command":"npm install"}}' | bash ~/.claude/hooks/block-prohibited-commands.sh; echo "exit=$?"

--- a/ROOT_AGENTS_hooks_block-prohibited-commands.py
+++ b/ROOT_AGENTS_hooks_block-prohibited-commands.py
@@ -1,0 +1,334 @@
+#!/usr/bin/env python3
+"""PreToolUse guard for Bash commands — parser-based, stdlib only.
+
+Invoked by the thin block-prohibited-commands.sh wrapper. Reads Claude Code
+tool input JSON on stdin and answers via exit code: 0 = allow, 2 = block
+(stderr becomes the reason fed back to the agent). exit 1 would NOT block.
+
+Pipeline (full semantics: docs/agents/enforcement.md):
+
+1. Heredoc separation (line state machine). Bodies consumed by data sinks
+   (cat, gh, git, tee, ...) are opaque prose and dropped before any scan;
+   bodies fed to interpreters (bash, python, node, ...) are executable code
+   and are re-analyzed recursively.
+2. Raw-string guards on the heredoc-cleaned text for destructive/IaC
+   commands (rm -rf /, force-push, gcloud/cdr mutations) — over-blocking is
+   the safe side there, so quoting is deliberately ignored.
+3. shlex tokenization (POSIX, punctuation_chars): quoted prose collapses
+   into single tokens that never equal a tool name, across lines too.
+4. Token walk with a minimal shell grammar: command boundaries are
+   ; && || | & ( ); NAME=VALUE prefixes and wrappers (env/sudo/...) are
+   skipped at command start; redirect operators consume the next token as
+   their operand. Guards: pip/poetry/pipenv, npm/yarn, make (command name,
+   basename-resolved), per-invocation pnpm lockfile gate, and .yml-creation
+   detection (redirect targets, touch/tee args, cp/mv destinations).
+
+If tokenization still fails after heredoc separation, tooling guards fall
+back to the previous line-based quote-strip regex scan — never worse than
+the old implementation. Known accepted long tail: quoted invocations
+(bash -c "npm i") and wrapper forms outside the known set (mise exec -- ...).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import shlex
+import sys
+from pathlib import Path
+
+EXIT_ALLOW = 0
+EXIT_BLOCK = 2
+
+MSG_PIP = (
+    "Python package management is 'uv' only (uv add / uv sync / uv run). "
+    "Do not use pip/poetry/pipenv."
+)
+MSG_NODE = (
+    "Node package management is 'bun' (or 'pnpm' iff pnpm-lock.yaml exists). "
+    "Do not use npm/yarn."
+)
+MSG_MAKE = (
+    "Task automation is 'just' only. Add a recipe to the root justfile "
+    "instead of using make."
+)
+MSG_PNPM = (
+    "'pnpm' is allowed only when pnpm-lock.yaml governs each pnpm "
+    "invocation's target directory (resolved cd/-C/--dir target or cwd, "
+    "searched upward). Use 'bun' instead — or, for a legitimate cross-repo "
+    "call this guard can't resolve, ask the user to run it with the '!' "
+    "prefix."
+)
+MSG_YML = (
+    "creates a '.yml' file via Bash. This project uses '.yaml' exclusively "
+    "(and 'compose.yaml', not docker-compose.*) — write the .yaml name "
+    "instead."
+)
+
+PIP_COMMANDS = {"pip", "pip3", "poetry", "pipenv"}
+NODE_COMMANDS = {"npm", "yarn"}
+WRAPPERS = {"env", "sudo", "time", "nohup", "command", "xargs"}
+INTERPRETERS = {
+    "sh",
+    "bash",
+    "zsh",
+    "dash",
+    "ksh",
+    "python",
+    "python3",
+    "node",
+    "deno",
+    "bun",
+    "ruby",
+    "perl",
+    "uv",
+    "uvx",
+    "npx",
+}
+COMMAND_SEPARATORS = {";", "&&", "||", "|", "&", "(", ")", ";;"}
+YML_CREATION_COMMANDS = {"touch", "tee", "cp", "mv"}
+
+ASSIGNMENT_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*=")
+HEREDOC_OPEN_RE = re.compile(r"<<-?\s*(['\"]?)([A-Za-z_][A-Za-z0-9_]*)\1")
+INTERPRETER_WORD_RE = re.compile(
+    r"(^|[\s;&|(])(" + "|".join(sorted(INTERPRETERS)) + r")\b"
+)
+
+RAW_GUARDS: list[tuple[re.Pattern[str], str]] = [
+    (
+        re.compile(
+            r"rm[\s]+(-[a-zA-Z]*[rR][a-zA-Z]*[\s]+)?(-[a-zA-Z]*f[a-zA-Z]*[\s]+)?/($|[\s])"
+        ),
+        "Refusing 'rm -rf /' (or equivalent root deletion).",
+    ),
+    (
+        re.compile(r"git[\s]+push[\s].*--force([\s]|=).*(main|master)"),
+        "Refusing force-push to main/master. Open a PR; never rewrite shared "
+        "history on the default branch.",
+    ),
+    (
+        re.compile(r"gcloud[\s].*(add-iam-policy-binding|set-iam-policy)"),
+        "IAM changes go through OpenTofu (iam_*.tf) + PR, not gcloud. See "
+        "docs/agents/iac-drift-policy.md.",
+    ),
+    (
+        re.compile(
+            r"gcloud[\s]+(compute|run|sql|secrets)[\s].*"
+            r"(set-machine-type|resize|update|deploy|versions[\s]+add)"
+        ),
+        "This gcloud command mutates IaC-managed infra and will drift from "
+        "tofu. Open an IaC PR. (Read-only debug is fine; emergency rollback "
+        "must be followed by an IaC PR same session.)",
+    ),
+    (
+        re.compile(r"cdr[\s]+workspaces[\s]+(update|edit)"),
+        "Patch the Coder template (coder_parameter), not the running "
+        "workspace. See docs/agents/iac-drift-policy.md.",
+    ),
+]
+
+
+def block(reason: str) -> None:
+    print(f"BLOCKED: {reason}", file=sys.stderr)
+    sys.exit(EXIT_BLOCK)
+
+
+def _basename(token: str) -> str:
+    return token.rsplit("/", 1)[-1]
+
+
+def _is_yml_name(token: str) -> bool:
+    base = _basename(token)
+    return base.endswith(".yml") or base in {"docker-compose.yaml"}
+
+
+def split_heredocs(text: str) -> tuple[str, list[str]]:
+    """Drop data-heredoc bodies; collect interpreter-heredoc bodies as code."""
+    cleaned: list[str] = []
+    code_bodies: list[str] = []
+    body: list[str] = []
+    pending: tuple[str, bool] | None = None  # (delimiter, body_is_code)
+    for line in text.split("\n"):
+        if pending is not None:
+            delimiter, is_code = pending
+            if line.strip() == delimiter:
+                if is_code:
+                    code_bodies.append("\n".join(body))
+                body = []
+                pending = None
+                continue
+            if is_code:
+                body.append(line)
+            continue
+        match = HEREDOC_OPEN_RE.search(line)
+        cleaned.append(line)
+        if match:
+            is_code = INTERPRETER_WORD_RE.search(line) is not None
+            pending = (match.group(2), is_code)
+    if pending is not None and pending[1]:
+        code_bodies.append("\n".join(body))
+    return "\n".join(cleaned), code_bodies
+
+
+def find_pnpm_lock_upward(directory: str) -> bool:
+    try:
+        current = Path(directory).resolve(strict=True)
+    except OSError:
+        return False
+    if not current.is_dir():
+        return False
+    while True:
+        if (current / "pnpm-lock.yaml").is_file():
+            return True
+        if current.parent == current:
+            return False
+        current = current.parent
+
+
+def _resolve_dir(target: str, base: str | None) -> str | None:
+    """Resolve a cd/-C/--dir target; None means unresolvable (fail safe)."""
+    if not target or "$" in target or "`" in target:
+        return None
+    target = os.path.expanduser(target)
+    if os.path.isabs(target):
+        return target
+    if base is None:
+        return None
+    return os.path.join(base, target)
+
+
+class _CommandWalker:
+    """Token walk with the minimal shell grammar from enforcement.md."""
+
+    def __init__(self) -> None:
+        self.effective_dir: str | None = os.getcwd()
+
+    def walk(self, tokens: list[str]) -> None:
+        at_start = True
+        pending_redirect = False
+        name: str | None = None
+        args: list[str] = []
+        for token in tokens:
+            if token and all(ch in "();<>|&" for ch in token):
+                if ">" in token:
+                    pending_redirect = True
+                if token in COMMAND_SEPARATORS:
+                    self._finalize(name, args)
+                    name, args, at_start = None, [], True
+                continue
+            if pending_redirect:
+                pending_redirect = False
+                if _is_yml_name(token):
+                    block(f"'> {token}' {MSG_YML}")
+                continue
+            if at_start:
+                if ASSIGNMENT_RE.match(token):
+                    continue
+                if _basename(token) in WRAPPERS:
+                    continue
+                name = _basename(token)
+                at_start = False
+                continue
+            args.append(token)
+        self._finalize(name, args)
+
+    def _finalize(self, name: str | None, args: list[str]) -> None:
+        if name is None:
+            return
+        if name in PIP_COMMANDS:
+            block(MSG_PIP)
+        if name in NODE_COMMANDS:
+            block(MSG_NODE)
+        if name == "make":
+            block(MSG_MAKE)
+        if name == "cd":
+            target = args[0] if args else "~"
+            self.effective_dir = _resolve_dir(target, self.effective_dir)
+            return
+        if name == "pnpm":
+            self._check_pnpm(args)
+        if name in YML_CREATION_COMMANDS:
+            self._check_yml_creation(name, args)
+
+    def _check_pnpm(self, args: list[str]) -> None:
+        check_dir = self.effective_dir
+        for i, arg in enumerate(args):
+            if arg in {"-C", "--dir"} and i + 1 < len(args):
+                check_dir = _resolve_dir(args[i + 1], self.effective_dir)
+                break
+            if arg.startswith("--dir="):
+                check_dir = _resolve_dir(arg.split("=", 1)[1], self.effective_dir)
+                break
+        if check_dir is None or not find_pnpm_lock_upward(check_dir):
+            block(MSG_PNPM)
+
+    def _check_yml_creation(self, name: str, args: list[str]) -> None:
+        positional = [a for a in args if not a.startswith("-")]
+        if name in {"touch", "tee"}:
+            for arg in positional:
+                if _is_yml_name(arg):
+                    block(f"'{name} {arg}' {MSG_YML}")
+        elif name in {"cp", "mv"} and positional:
+            dest = positional[-1]
+            if _is_yml_name(dest):
+                block(f"'{name} ... {dest}' {MSG_YML}")
+
+
+def _tokenize(text: str) -> list[str]:
+    lexer = shlex.shlex(text, posix=True, punctuation_chars=True)
+    lexer.whitespace_split = True
+    return list(lexer)
+
+
+def _legacy_scan(text: str) -> None:
+    """Pre-parser behavior, used only when tokenization fails."""
+    stripped_lines = []
+    for line in text.split("\n"):
+        line = re.sub(r'"[^"]*"', "", line)
+        line = re.sub(r"'[^']*'", "", line)
+        stripped_lines.append(line)
+    scan = "\n".join(stripped_lines)
+    if re.search(r"(^|[^\w./-])(pip3?|poetry|pipenv)(\s|$)", scan):
+        block(MSG_PIP)
+    if re.search(r"(^|[^\w./-])(npm|yarn)(\s|$)", scan):
+        block(MSG_NODE)
+    if re.search(r"(^|[^\w./-])make(\s|$)", scan):
+        block(MSG_MAKE)
+    if re.search(r"(^|[^\w./-])pnpm(\s|$)", scan) and not find_pnpm_lock_upward(
+        os.getcwd()
+    ):
+        block(MSG_PNPM)
+
+
+def analyze(text: str, depth: int = 0) -> None:
+    if depth > 2:
+        return
+    cleaned, code_bodies = split_heredocs(text)
+    for pattern, reason in RAW_GUARDS:
+        if pattern.search(cleaned):
+            block(reason)
+    try:
+        tokens = _tokenize(cleaned)
+    except ValueError:
+        _legacy_scan(cleaned)
+    else:
+        _CommandWalker().walk(tokens)
+    for body in code_bodies:
+        analyze(body, depth + 1)
+
+
+def main() -> int:
+    try:
+        payload = json.load(sys.stdin)
+    except (json.JSONDecodeError, UnicodeDecodeError):
+        return EXIT_ALLOW
+    command = (payload.get("tool_input") or {}).get("command") or ""
+    if not isinstance(command, str) or not command.strip():
+        return EXIT_ALLOW
+    analyze(command)
+    return EXIT_ALLOW
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/ROOT_AGENTS_hooks_block-prohibited-commands.sh
+++ b/ROOT_AGENTS_hooks_block-prohibited-commands.sh
@@ -1,118 +1,25 @@
 #!/usr/bin/env bash
 # .claude/hooks/block-prohibited-commands.sh
-# PreToolUse hook (matcher: Bash). Enforces the command-level non-negotiables in
-# AGENTS.md and docs/agents/iac-drift-policy.md.
+# PreToolUse hook (matcher: Bash) — thin wrapper. The guard logic lives in the
+# companion Python file (stdlib-only): correct quote/heredoc handling needs a
+# tokenizer, not regexes. See docs/agents/enforcement.md for the semantics.
+#
+# The companion's filename differs between the dotfiles repo root (sync source
+# naming) and a deployed agent home (hooks/), so both are tried.
 #
 # Exit-code contract:
 #   exit 0  -> allow
 #   exit 2  -> BLOCK (stderr -> Claude). exit 1 would NOT block.
 set -euo pipefail
 
-input="$(cat)"
-cmd="$(printf '%s' "$input" | jq -r '.tool_input.command // empty')"
-[ -z "$cmd" ] && exit 0
-
-block() { echo "BLOCKED: $1" >&2; exit 2; }
-
-# --- Package managers ---------------------------------------------------------
-# Tooling-word guards scan with quoted substrings removed, so prose mentions
-# (commit messages, echo strings) don't false-trigger. The flip side — a quoted
-# invocation like `bash -c "npm i"` slips these guards — is accepted long tail:
-# prose rules + review cover it. Destructive/IaC guards below keep scanning the
-# full string (over-blocking is the safe side there).
-scan="$(printf '%s' "$cmd" | sed -E -e 's/"[^"]*"//g' -e "s/'[^']*'//g")"
-
-# Python: uv only.
-if printf '%s' "$scan" | grep -Eq '(^|[^[:alnum:]_./-])(pip3?|poetry|pipenv)([[:space:]]|$)'; then
-  block "Python package management is 'uv' only (uv add / uv sync / uv run). Do not use pip/poetry/pipenv."
-fi
-
-# Node: bun, unless pnpm-lock.yaml exists (then pnpm). Never npm/yarn.
-if printf '%s' "$scan" | grep -Eq '(^|[^[:alnum:]_./-])(npm|yarn)([[:space:]]|$)'; then
-  block "Node package management is 'bun' (or 'pnpm' iff pnpm-lock.yaml exists). Do not use npm/yarn."
-fi
-
-# pnpm: allowed only when a pnpm-lock.yaml governs EACH pnpm invocation's
-# effective directory — the last `cd` target before it in its segment chain,
-# its -C/--dir flag, or the session cwd — searched upward to the filesystem
-# root. Parsing is best-effort; unresolvable targets (variables, subshells)
-# fail safe (block), and the block message offers the `!` escape hatch.
-find_pnpm_lock_upward() {
-  local d
-  d="$(cd "$1" 2>/dev/null && pwd)" || return 1
-  while :; do
-    [ -f "$d/pnpm-lock.yaml" ] && return 0
-    [ "$d" = "/" ] && return 1
-    d="$(dirname "$d")"
-  done
-}
-
-if printf '%s' "$scan" | grep -Eq '(^|[^[:alnum:]_./-])pnpm([[:space:]]|$)'; then
-  segs="$scan"
-  segs="${segs//";"/$'\n'}"
-  segs="${segs//"&&"/$'\n'}"
-  segs="${segs//"||"/$'\n'}"
-  eff_dir="$PWD"
-  pnpm_ok=1
-  while IFS= read -r seg; do
-    seg="$(printf '%s' "$seg" | sed -E 's/^[[:space:](]+//')"
-    case "$seg" in
-      cd|cd\ *)
-        tgt="${seg#cd}"
-        tgt="${tgt# }"
-        tgt="${tgt%%[[:space:]]*}"
-        tgt="${tgt/#\~/$HOME}"
-        case "$tgt" in
-          "" | \$* | \`*) eff_dir="" ;; # empty/variable/substitution: unresolvable
-          /*) eff_dir="$tgt" ;;
-          *) if [ -n "$eff_dir" ]; then eff_dir="$eff_dir/$tgt"; else eff_dir=""; fi ;;
-        esac
-        ;;
-    esac
-    if printf '%s' "$seg" | grep -Eq '(^|[^[:alnum:]_./-])pnpm([[:space:]]|$)'; then
-      if printf '%s' "$seg" | grep -Eq '[[:space:]](-C|--dir)[= ]'; then
-        tdir="$(printf '%s' "$seg" | sed -nE 's/.*[[:space:]](-C|--dir)[= ]([^[:space:]]+).*/\2/p')"
-        case "$tdir" in
-          "" | \$* | \`*) check_dir="" ;;
-          /*) check_dir="$tdir" ;;
-          *) if [ -n "$eff_dir" ]; then check_dir="$eff_dir/$tdir"; else check_dir=""; fi ;;
-        esac
-      else
-        check_dir="$eff_dir"
-      fi
-      if [ -z "$check_dir" ] || ! find_pnpm_lock_upward "$check_dir"; then
-        pnpm_ok=0
-      fi
-    fi
-  done <<<"$segs"
-  if [ "$pnpm_ok" -ne 1 ]; then
-    block "'pnpm' is allowed only when pnpm-lock.yaml governs each pnpm invocation's target directory (resolved cd/-C/--dir target or cwd, searched upward). Use 'bun' instead — or, for a legitimate cross-repo call this guard can't resolve, ask the user to run it with the '!' prefix."
+dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+for candidate in \
+  "$dir/block-prohibited-commands.py" \
+  "$dir/ROOT_AGENTS_hooks_block-prohibited-commands.py"; do
+  if [ -f "$candidate" ]; then
+    exec python3 "$candidate"
   fi
-fi
+done
 
-# Task runner: just only, no make.
-if printf '%s' "$scan" | grep -Eq '(^|[^[:alnum:]_./-])make([[:space:]]|$)'; then
-  block "Task automation is 'just' only. Add a recipe to the root justfile instead of using make."
-fi
-
-# --- Obviously destructive ----------------------------------------------------
-if printf '%s' "$cmd" | grep -Eq 'rm[[:space:]]+(-[a-zA-Z]*[rR][a-zA-Z]*[[:space:]]+)?(-[a-zA-Z]*f[a-zA-Z]*[[:space:]]+)?/($|[[:space:]])'; then
-  block "Refusing 'rm -rf /' (or equivalent root deletion)."
-fi
-if printf '%s' "$cmd" | grep -Eq 'git[[:space:]]+push[[:space:]].*--force([[:space:]]|=).*(main|master)'; then
-  block "Refusing force-push to main/master. Open a PR; never rewrite shared history on the default branch."
-fi
-
-# --- IaC drift (see docs/agents/iac-drift-policy.md) --------------------------
-# These mutate state OpenTofu owns. Read-only verbs (describe/list/get/show) pass.
-if printf '%s' "$cmd" | grep -Eq 'gcloud[[:space:]].*(add-iam-policy-binding|set-iam-policy)'; then
-  block "IAM changes go through OpenTofu (iam_*.tf) + PR, not gcloud. See docs/agents/iac-drift-policy.md."
-fi
-if printf '%s' "$cmd" | grep -Eq 'gcloud[[:space:]]+(compute|run|sql|secrets)[[:space:]].*(set-machine-type|resize|update|deploy|versions[[:space:]]+add)'; then
-  block "This gcloud command mutates IaC-managed infra and will drift from tofu. Open an IaC PR. (Read-only debug is fine; emergency rollback must be followed by an IaC PR same session.)"
-fi
-if printf '%s' "$cmd" | grep -Eq 'cdr[[:space:]]+workspaces[[:space:]]+(update|edit)'; then
-  block "Patch the Coder template (coder_parameter), not the running workspace. See docs/agents/iac-drift-policy.md."
-fi
-
-exit 0
+echo "BLOCKED: companion guard block-prohibited-commands.py not found next to the wrapper (incomplete sync?) — failing closed." >&2
+exit 2

--- a/tests/unit/test_agent_hooks.py
+++ b/tests/unit/test_agent_hooks.py
@@ -24,8 +24,8 @@ EXIT_ALLOW = 0
 EXIT_BLOCK = 2
 
 pytestmark = pytest.mark.skipif(
-    shutil.which("bash") is None or shutil.which("jq") is None,
-    reason="hook needs bash + jq on PATH",
+    shutil.which("bash") is None or shutil.which("python3") is None,
+    reason="hook needs bash + python3 on PATH",
 )
 
 
@@ -148,6 +148,137 @@ def test_make_mention_in_commit_message_is_allowed(unlocked_repo: Path) -> None:
     guard (observed false block)."""
     cmd = 'git commit -m "ci: have the gate make builds reproducible"'
     assert _run_hook(cmd, unlocked_repo) == EXIT_ALLOW
+
+
+# --- Heredocs: data bodies are opaque, interpreter bodies are code -----------
+
+
+def test_heredoc_prose_to_data_sink_is_allowed(tmp_path: Path) -> None:
+    """PR-body style heredoc fed to a data sink is prose, not invocations
+    (observed false block on a multi-line gh pr create body)."""
+    cmd = (
+        "cat <<'EOF' > /tmp/pr-body.md\n"
+        "this prose mentions npm and pnpm and make and even gcloud run deploy\n"
+        "EOF"
+    )
+    assert _run_hook(cmd, tmp_path) == EXIT_ALLOW
+
+
+def test_heredoc_prose_with_unbalanced_quote_is_allowed(tmp_path: Path) -> None:
+    """Prose apostrophes inside a data heredoc must not break parsing."""
+    cmd = "cat <<'EOF'\ndon't use npm here — prose only, isn't it\nEOF"
+    assert _run_hook(cmd, tmp_path) == EXIT_ALLOW
+
+
+def test_heredoc_to_shell_interpreter_is_blocked(tmp_path: Path) -> None:
+    """A heredoc piped into a shell executes — its body is scanned as code."""
+    cmd = "bash <<'EOF'\nnpm install\nEOF"
+    assert _run_hook(cmd, tmp_path) == EXIT_BLOCK
+
+
+# --- .yml creation via Bash ---------------------------------------------------
+
+
+def test_redirect_to_yml_is_blocked(tmp_path: Path) -> None:
+    assert _run_hook("echo hi > notes.yml", tmp_path) == EXIT_BLOCK
+
+
+def test_append_redirect_to_yml_is_blocked(tmp_path: Path) -> None:
+    assert _run_hook("echo hi >> notes.yml", tmp_path) == EXIT_BLOCK
+
+
+def test_touch_yml_is_blocked(tmp_path: Path) -> None:
+    assert _run_hook("touch a.yml", tmp_path) == EXIT_BLOCK
+
+
+def test_tee_yml_is_blocked(tmp_path: Path) -> None:
+    assert _run_hook("printf hi | tee a.yml", tmp_path) == EXIT_BLOCK
+
+
+def test_cp_to_yml_is_blocked(tmp_path: Path) -> None:
+    assert _run_hook("cp a.yaml b.yml", tmp_path) == EXIT_BLOCK
+
+
+def test_mv_to_yml_is_blocked(tmp_path: Path) -> None:
+    assert _run_hook("mv a.yaml c.yml", tmp_path) == EXIT_BLOCK
+
+
+def test_redirect_to_deprecated_compose_name_is_blocked(tmp_path: Path) -> None:
+    assert _run_hook("echo x > docker-compose.yaml", tmp_path) == EXIT_BLOCK
+
+
+def test_touch_compose_yaml_is_allowed(tmp_path: Path) -> None:
+    assert _run_hook("touch compose.yaml", tmp_path) == EXIT_ALLOW
+
+
+def test_reading_yml_is_allowed(tmp_path: Path) -> None:
+    assert _run_hook("cat config.yml", tmp_path) == EXIT_ALLOW
+
+
+def test_cp_yml_to_directory_is_allowed(tmp_path: Path) -> None:
+    """Copying an existing .yml elsewhere (dest is a dir) is not creation."""
+    assert _run_hook("cp foo.yml backup/", tmp_path) == EXIT_ALLOW
+
+
+# --- Minimal shell grammar: prefixes, wrappers, boundaries --------------------
+
+
+def test_assignment_prefix_does_not_hide_command(tmp_path: Path) -> None:
+    assert _run_hook("VAR=x touch a.yml", tmp_path) == EXIT_BLOCK
+
+
+def test_env_wrapper_does_not_hide_command(tmp_path: Path) -> None:
+    assert _run_hook("env FOO=1 touch a.yml", tmp_path) == EXIT_BLOCK
+
+
+def test_command_after_cd_is_scanned(tmp_path: Path) -> None:
+    assert _run_hook("cd sub && touch a.yml", tmp_path) == EXIT_BLOCK
+
+
+def test_xargs_wrapper_does_not_hide_command(tmp_path: Path) -> None:
+    assert _run_hook("echo x | xargs npm install", tmp_path) == EXIT_BLOCK
+
+
+# --- Wrapper contract: deployed layout and fail-closed ------------------------
+
+
+def test_wrapper_resolves_deployed_layout(tmp_path: Path) -> None:
+    """In agent homes the pair is hooks/block-prohibited-commands.{sh,py}."""
+    hooks_dir = tmp_path / "hooks"
+    hooks_dir.mkdir()
+    shutil.copy(HOOK, hooks_dir / "block-prohibited-commands.sh")
+    shutil.copy(
+        HOOK.with_name("ROOT_AGENTS_hooks_block-prohibited-commands.py"),
+        hooks_dir / "block-prohibited-commands.py",
+    )
+    payload = json.dumps({"tool_input": {"command": "npm install"}})
+    result = subprocess.run(
+        ["bash", str(hooks_dir / "block-prohibited-commands.sh")],
+        input=payload,
+        capture_output=True,
+        text=True,
+        cwd=tmp_path,
+        check=False,
+    )
+    assert result.returncode == EXIT_BLOCK
+
+
+def test_wrapper_fails_closed_without_companion(tmp_path: Path) -> None:
+    """A wrapper that cannot find its Python companion must block, loudly."""
+    hooks_dir = tmp_path / "hooks"
+    hooks_dir.mkdir()
+    shutil.copy(HOOK, hooks_dir / "block-prohibited-commands.sh")
+    payload = json.dumps({"tool_input": {"command": "ls"}})
+    result = subprocess.run(
+        ["bash", str(hooks_dir / "block-prohibited-commands.sh")],
+        input=payload,
+        capture_output=True,
+        text=True,
+        cwd=tmp_path,
+        check=False,
+    )
+    assert result.returncode == EXIT_BLOCK
+    assert "failing closed" in result.stderr
 
 
 # --- Destructive / IaC drift ------------------------------------------------


### PR DESCRIPTION
## 概要

#183 で持ち越した 2 クラス（複数行 heredoc prose の誤爆 / Bash 経由 `.yml` 生成のすり抜け）を、見送り条件どおり**パーサ前提**で根治する。`block-prohibited-commands` を stdlib-only Python（shlex + heredoc 行状態機械）に書き換え、`.sh` は thin wrapper 化。設計は `private/plan-agent-instructions-s-plus.md` の Addendum に記録し、codex レビュー（5 指摘: 4 採用・1 棄却、棄却理由も記録）を通した。

## 変更

| commit | type | 内容 |
|---|---|---|
| 7cf8123 | feat(hooks) | Python guard 本体 + wrapper + テスト 40 cases（旧 21 の挙動互換含む） |
| 456a195 | docs(agents) | enforcement spoke をパーサ契約に書き換え |

### 新しい意味論（spoke が正）

- **quoted prose はトークン化で無害化**: 複数行 quote も単一トークンになり、tooling guard のコマンド名一致に絶対かからない。
- **heredoc は受け手判定**: data sink（cat/gh/git 等）行きの本文は全ガードから除外（PR body の prose が gcloud 言及込みで安全に）。interpreter（bash/python 等）行きの本文は実行コードとして再帰走査 — `bash <<EOF` 内の `npm install` は **block**（codex 指摘 1 採用: 一律 strip は実行バイパスになるため）。
- **最小 shell 文法**: command 境界 / `NAME=VALUE` prefix / wrapper（env/sudo/xargs 等）skip / redirect operand 消費を明文化（codex 指摘 2 採用、各ケーステスト付き）。
- **`.yml` 生成検出（T10 本体）**: redirect 先・touch/tee 引数・cp/mv の dest をトークンレベルで block。読み取りと `cp x.yml dir/` は許可。
- **fail 方向**: 解決不能な pnpm target は block（`!` 逃げ道を message に明記）、wrapper の `.py` 欠落は fail closed、tokenize 残余失敗は旧実装相当に fallback（今日より悪くならない下限）。

### 受け入れの根拠

- `uvx pytest tests/unit/` 59 passed（hook 40 + sync 19）
- wrapper 契約を CI-gated unit テストでピン留め: 配布レイアウト名での解決 / `.py` 欠落時 fail closed（codex 指摘 4 を、live 破壊テストの test_sync_agents.py を触らない形で採用）
- `just ci` green / sync preview で `ROOT_AGENTS_hooks_*.py → hooks/*.py` 配布を確認
- jq 依存はこの hook から消滅（stdin JSON は Python が読む）

## 既知の accepted long tail（spoke に明記済み）

- quoted invocation（`bash -c "npm i"`）と未知 wrapper 形（`mise exec -- pnpm`）は素通り — 正直なミスへの安全網という設計上の割り切り。
- quoted 文字列内の IaC 動詞言及（heredoc 外）は raw guard が誤 block し得る — 安全側。長文は heredoc / `-F` / `--body-file` へ。
