### PR TITLE
fix(zsh): adopt bun completions portably in the completions section

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -241,6 +241,11 @@ alias dbtf="$HOME/.local/bin/dbt"
 # CF CLI completions
 [[ -f "$HOME/.config/cf/completions/_cf.zsh" ]] && source "$HOME/.config/cf/completions/_cf.zsh"
 
+# bun completions (the bun installer appends a copy at EOF with the home dir
+# spelled out literally; keep this portable $HOME form here instead — PATH is
+# already prepended in the bun section above)
+[[ -s "$HOME/.bun/_bun" ]] && source "$HOME/.bun/_bun"
+
 # ant (Anthropic CLI) completion — cached, regenerated only when missing
 if _cmd_exists ant; then
     _ant_comp_cache="${XDG_CACHE_HOME:-$HOME/.cache}/zsh/ant_completion.zsh"


### PR DESCRIPTION
bun インストーラが EOF に append した completions 行（ホームディレクトリ直書き = 他マシンでは dead code）を、CF/ant と同じ completions 帯（compinit 後）へ $HOME 形で移設。zsh -n クリーン + interactive shell で _bun 登録を実証済み。installer 直 append クラス（PR #155 の親戚）の回収。