### PR TITLE
fix(hooks,plugins): harden force-push guard and auto-loop revert/scope guards

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "hironow's personal Claude Code plugins for autonomous research, design exploration, expedition workflows, and Socratic plan grilling",
-    "version": "1.3.0",
+    "version": "1.3.1",
     "pluginRoot": "./plugins"
   },
   "plugins": [
@@ -14,7 +14,7 @@
       "name": "autoresearch",
       "source": "./plugins/autoresearch",
       "description": "Autonomous experiment loop plugin inspired by karpathy/autoresearch. Iteratively modifies target code, evaluates against fixed metrics, and keeps only improvements via git-based keep/revert cycles.",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "category": "research",
       "tags": [
         "research",
@@ -28,7 +28,7 @@
       "name": "autodesign",
       "source": "./plugins/autodesign",
       "description": "Autonomous web design exploration plugin. Explores design variations under quality constraints using git-based keep/revert cycles with bundled evaluators for a11y, readability, performance, and completeness.",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "category": "design",
       "tags": [
         "design",
@@ -44,7 +44,7 @@
       "name": "autoreview",
       "source": "./plugins/autoreview",
       "description": "Autonomous code review plugin using guardrails/semgrep rules. Scans code, auto-fixes violations, and validates via git-based keep/revert cycles. Supports scan-fix and spec-review modes.",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "category": "review",
       "tags": [
         "review",

--- a/ROOT_AGENTS_hooks_block-prohibited-commands.py
+++ b/ROOT_AGENTS_hooks_block-prohibited-commands.py
@@ -12,16 +12,18 @@ Pipeline (full semantics: docs/agents/enforcement.md):
    bodies fed to interpreters (bash, python, node, ...) are executable code
    and are re-analyzed recursively.
 2. Raw-string guards on the heredoc-cleaned text for destructive/IaC
-   commands (rm -rf /, force-push, gcloud/cdr mutations) — over-blocking is
-   the safe side there, so quoting is deliberately ignored.
+   commands (rm -rf /, gcloud/cdr mutations) — over-blocking is the safe
+   side there, so quoting is deliberately ignored.
 3. shlex tokenization (POSIX, punctuation_chars): quoted prose collapses
    into single tokens that never equal a tool name, across lines too.
 4. Token walk with a minimal shell grammar: command boundaries are
    ; && || | & ( ); NAME=VALUE prefixes and wrappers (env/sudo/...) are
    skipped at command start; redirect operators consume the next token as
    their operand. Guards: pip/poetry/pipenv, npm/yarn, make (command name,
-   basename-resolved), per-invocation pnpm lockfile gate, and .yml-creation
-   detection (redirect targets, touch/tee args, cp/mv destinations).
+   basename-resolved), per-invocation pnpm lockfile gate, force-push to a
+   protected branch (any force flag + a main/master refspec, order- and
+   spelling-independent), and .yml-creation detection (redirect targets,
+   touch/tee args, cp/mv destinations).
 
 If tokenization still fails after heredoc separation, tooling guards fall
 back to the previous line-based quote-strip regex scan — never worse than
@@ -65,6 +67,10 @@ MSG_YML = (
     "(and 'compose.yaml', not docker-compose.*) — write the .yaml name "
     "instead."
 )
+MSG_FORCE_PUSH = (
+    "Refusing force-push to a protected branch (main/master). Open a PR; "
+    "never rewrite shared history on the default branch."
+)
 
 PIP_COMMANDS = {"pip", "pip3", "poetry", "pipenv"}
 NODE_COMMANDS = {"npm", "yarn"}
@@ -88,6 +94,8 @@ INTERPRETERS = {
 }
 COMMAND_SEPARATORS = {";", "&&", "||", "|", "&", "(", ")", ";;"}
 YML_CREATION_COMMANDS = {"touch", "tee", "cp", "mv"}
+PROTECTED_REFS = {"main", "master"}
+FORCE_PUSH_FLAGS = {"-f", "--force", "--force-if-includes"}
 
 ASSIGNMENT_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*=")
 HEREDOC_OPEN_RE = re.compile(r"<<-?\s*(['\"]?)([A-Za-z_][A-Za-z0-9_]*)\1")
@@ -101,11 +109,6 @@ RAW_GUARDS: list[tuple[re.Pattern[str], str]] = [
             r"rm[\s]+(-[a-zA-Z]*[rR][a-zA-Z]*[\s]+)?(-[a-zA-Z]*f[a-zA-Z]*[\s]+)?/($|[\s])"
         ),
         "Refusing 'rm -rf /' (or equivalent root deletion).",
-    ),
-    (
-        re.compile(r"git[\s]+push[\s].*--force([\s]|=).*(main|master)"),
-        "Refusing force-push to main/master. Open a PR; never rewrite shared "
-        "history on the default branch.",
     ),
     (
         re.compile(r"gcloud[\s].*(add-iam-policy-binding|set-iam-policy)"),
@@ -141,6 +144,32 @@ def _basename(token: str) -> str:
 def _is_yml_name(token: str) -> bool:
     base = _basename(token)
     return base.endswith(".yml") or base in {"docker-compose.yaml"}
+
+
+def _is_force_push_flag(token: str) -> bool:
+    """True for any git push flag that rewrites the remote ref."""
+    if token in FORCE_PUSH_FLAGS:
+        return True
+    # --force-with-lease and --force-with-lease=<ref>[:<expect>]
+    return token == "--force-with-lease" or token.startswith("--force-with-lease=")
+
+
+def _targets_protected_ref(args: list[str]) -> bool:
+    """True if any positional refspec pushes to main/master.
+
+    Handles bare branch names (`main`), refspecs (`HEAD:main`,
+    `feature:main`) and fully-qualified refs (`refs/heads/main`). Flags and
+    the remote name are positionals too, but neither resolves to a protected
+    branch, so they are simply not matched.
+    """
+    for arg in args:
+        if arg.startswith("-"):
+            continue
+        dest = arg.rsplit(":", 1)[-1]  # src:dst refspec -> dst
+        dest = dest.rsplit("/", 1)[-1]  # refs/heads/main -> main
+        if dest in PROTECTED_REFS:
+            return True
+    return False
 
 
 def split_heredocs(text: str) -> tuple[str, list[str]]:
@@ -242,6 +271,11 @@ class _CommandWalker:
             block(MSG_NODE)
         if name == "make":
             block(MSG_MAKE)
+        if name == "git" and "push" in args:
+            if any(_is_force_push_flag(a) for a in args) and _targets_protected_ref(
+                args
+            ):
+                block(MSG_FORCE_PUSH)
         if name == "cd":
             target = args[0] if args else "~"
             self.effective_dir = _resolve_dir(target, self.effective_dir)

--- a/plugins/autodesign/.claude-plugin/plugin.json
+++ b/plugins/autodesign/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "autodesign",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Autonomous web design exploration plugin. Iteratively explores design variations under quality constraints using git-based keep/revert cycles, inspired by autoresearch.",
   "author": {
     "name": "hironow"

--- a/plugins/autodesign/agents/designer.md
+++ b/plugins/autodesign/agents/designer.md
@@ -65,6 +65,31 @@ run evaluation, and decide whether to keep or revert the change.
 
 **Exploration Protocol:**
 
+Step 0 - Revert Preflight (MANDATORY before any change):
+
+The keep/revert cycle is only safe on a throwaway design branch. Before
+modifying anything, verify the loop will not destroy real work:
+
+- Confirm the current branch is a design branch:
+
+  ```bash
+  BRANCH=$(git branch --show-current)
+  [[ "$BRANCH" == design/* ]] || { echo "ERROR: not on design/* — aborting" >&2; exit 1; }
+  ```
+
+- Confirm a clean working tree (no unexpected dirty/untracked files that a
+  hard reset would erase):
+
+  ```bash
+  [[ -z "$(git status --porcelain)" ]] || { echo "ERROR: working tree not clean — aborting" >&2; exit 1; }
+  ```
+
+- Record this iteration's baseline commit SHA — run `git rev-parse HEAD` and keep
+  the value. Claude Code shell variables do NOT persist across separate Bash
+  calls, so treat `$base` in later steps as that literal SHA: paste the recorded
+  hash in (or re-record it inside the same Bash call that reverts). Every revert
+  below returns to this recorded baseline — never a blind `HEAD~1`.
+
 Step 1 - Understand State:
 
 - Read design-config.yaml for parameters (target_files, eval_target, evaluators, constraints, axes)
@@ -130,8 +155,11 @@ Step 7 - Record:
 
 Step 8 - Git Action:
 
-- If keep: do nothing (commit stays, branch advances)
-- If discard, constraint_fail, or crash: `git reset --hard HEAD~1`
+- If keep: do nothing (commit stays, branch advances; the new HEAD becomes the
+  next iteration's baseline)
+- If discard, constraint_fail, or crash: `git reset --hard "$base"` (restore the
+  Step 0 baseline; do NOT use `git reset --hard HEAD~1` — a miscounted or
+  multi-commit revert can destroy kept work)
 
 **Exploration Axis Hints:**
 
@@ -166,9 +194,12 @@ Return a concise report:
 
 **Critical Rules:**
 
+- ALWAYS run the Step 0 revert preflight (design-branch + clean-tree check,
+  record `base`) before changing any file
 - NEVER modify files outside the target list
 - NEVER modify the evaluation command or scripts
 - NEVER skip logging to design-results.tsv
 - ALWAYS commit before running evaluation
 - ALWAYS check constraints BEFORE comparing scores
-- ALWAYS revert on failure (git reset --hard HEAD~1)
+- ALWAYS revert on failure with `git reset --hard "$base"` (the recorded
+  iteration baseline — never `HEAD~1`)

--- a/plugins/autodesign/hooks/scripts/check-scope.sh
+++ b/plugins/autodesign/hooks/scripts/check-scope.sh
@@ -20,10 +20,13 @@ while IFS= read -r line; do
     IN_SCOPE=true
     break
   fi
-done < <(sed -n '/^target_files:/,/^[^ ]/p' "$CONFIG" | head -n -1)
+done < <(sed -n '/^target_files:/,/^[^ ]/p' "$CONFIG" | sed '$d')
 if [[ "$IN_SCOPE" == "true" ]]; then
   exit 0
 fi
+# Out of scope: escalate to the user instead of auto-approving. permissionDecision
+# "allow" would BYPASS the normal permission prompt; "ask" surfaces a stray
+# non-target write so it cannot silently invalidate the design loop.
 cat <<'EOF'
-{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"allow","permissionDecisionReason":"WARNING: This file is outside the design target scope."}}
+{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"ask","permissionDecisionReason":"This file is outside the design target scope. Confirm before proceeding."}}
 EOF

--- a/plugins/autodesign/skills/design-loop/SKILL.md
+++ b/plugins/autodesign/skills/design-loop/SKILL.md
@@ -30,7 +30,8 @@ LOOP:
   5. Run evaluation command (with timeout)
   6. Extract composite_score and constraint_violated
   7. IF constraints met AND score improved -> keep commit
-     ELSE -> git reset --hard HEAD~1 (revert)
+     ELSE -> git reset --hard "$base" (revert to the iteration baseline
+             recorded by the designer agent's Step 0 preflight; never HEAD~1)
   8. Log result to design-results.tsv
   9. GOTO 1
 ```

--- a/plugins/autodesign/skills/design-loop/references/decision-logic.md
+++ b/plugins/autodesign/skills/design-loop/references/decision-logic.md
@@ -12,7 +12,7 @@ Experiment completed
 |   |   +-- ANY constraint violated?
 |   |   |   |
 |   |   |   +-- YES: Log "constraint_fail", record which constraint
-|   |   |   |   +-- git reset --hard HEAD~1
+|   |   |   |   +-- git reset --hard "$base"
 |   |   |   |   +-- Record axis+constraint pair for future avoidance
 |   |   |   |
 |   |   |   +-- NO: Compare composite_score with current best
@@ -36,7 +36,7 @@ Experiment completed
 |   |   |       |   |       +-- REVERT if any complexity added
 |   |   |       |   |
 |   |   |       |   +-- NO: Score same or worse
-|   |   |       |       +-- REVERT (git reset --hard HEAD~1)
+|   |   |       |       +-- REVERT (git reset --hard "$base")
 |   |   |       |
 |   |   |       +-- (Log result to design-results.tsv regardless)
 |   |   |
@@ -55,7 +55,7 @@ Experiment completed
 |           |
 |           +-- Fundamental issue?
 |               +-- Log "crash" to design-results.tsv
-|               +-- git reset --hard HEAD~1
+|               +-- git reset --hard "$base"
 |               +-- Move on to next hypothesis
 ```
 
@@ -126,8 +126,13 @@ No additional git operation needed.
 ### Revert (discard or constraint_fail)
 
 ```bash
-git reset --hard HEAD~1
+git reset --hard "$base"   # the iteration baseline from the agent's Step 0 preflight
 ```
+
+`$base` is the commit recorded by the designer agent's Step 0 revert preflight
+(`base=$(git rev-parse HEAD)`), after it verified the branch is `design/*` and
+the tree is clean. Reset to `$base` rather than `HEAD~1` so a miscounted or
+multi-commit revert can never destroy kept work.
 
 ### Crash recovery
 
@@ -140,5 +145,5 @@ git commit --amend -m "design(<axis>): <description> (fix)"
 # Re-run evaluation
 
 # If not fixable
-git reset --hard HEAD~1
+git reset --hard "$base"   # restore the Step 0 baseline
 ```

--- a/plugins/autoresearch/.claude-plugin/plugin.json
+++ b/plugins/autoresearch/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "autoresearch",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Autonomous experiment loop plugin inspired by karpathy/autoresearch. Iteratively modifies target code, evaluates against fixed metrics, and keeps only improvements via git-based keep/revert cycles.",
   "author": {
     "name": "hironow"

--- a/plugins/autoresearch/agents/researcher.md
+++ b/plugins/autoresearch/agents/researcher.md
@@ -65,6 +65,31 @@ code, run evaluation, and decide whether to keep or revert the change.
 
 **Experiment Protocol:**
 
+Step 0 - Revert Preflight (MANDATORY before any change):
+
+The keep/revert cycle is only safe on a throwaway experiment branch. Before
+modifying anything, verify the loop will not destroy real work:
+
+- Confirm the current branch is an experiment branch:
+
+  ```bash
+  BRANCH=$(git branch --show-current)
+  [[ "$BRANCH" == experiment/* ]] || { echo "ERROR: not on experiment/* — aborting" >&2; exit 1; }
+  ```
+
+- Confirm a clean working tree (no unexpected dirty/untracked files that a
+  hard reset would erase):
+
+  ```bash
+  [[ -z "$(git status --porcelain)" ]] || { echo "ERROR: working tree not clean — aborting" >&2; exit 1; }
+  ```
+
+- Record this iteration's baseline commit SHA — run `git rev-parse HEAD` and keep
+  the value. Claude Code shell variables do NOT persist across separate Bash
+  calls, so treat `$base` in later steps as that literal SHA: paste the recorded
+  hash in (or re-record it inside the same Bash call that reverts). Every revert
+  below returns to this recorded baseline — never a blind `HEAD~1`.
+
 Step 1 - Understand State:
 
 - Read experiment-config.yaml for parameters
@@ -118,8 +143,11 @@ Step 7 - Record:
 
 Step 8 - Git Action:
 
-- If keep: do nothing (commit stays, branch advances)
-- If discard or crash: `git reset --hard HEAD~1`
+- If keep: do nothing (commit stays, branch advances; the new HEAD becomes the
+  next iteration's baseline)
+- If discard or crash: `git reset --hard "$base"` (restore the Step 0 baseline;
+  do NOT use `git reset --hard HEAD~1` — a miscounted or multi-commit revert can
+  destroy kept work)
 
 **Error Handling:**
 
@@ -143,8 +171,11 @@ Return a concise report:
 
 **Critical Rules:**
 
+- ALWAYS run the Step 0 revert preflight (experiment-branch + clean-tree check,
+  record `base`) before changing any file
 - NEVER modify files outside the target list
 - NEVER modify the evaluation command or harness
 - NEVER skip logging to results.tsv
 - ALWAYS commit before running evaluation
-- ALWAYS revert on failure (git reset --hard HEAD~1)
+- ALWAYS revert on failure with `git reset --hard "$base"` (the recorded
+  iteration baseline — never `HEAD~1`)

--- a/plugins/autoresearch/hooks/scripts/check-scope.sh
+++ b/plugins/autoresearch/hooks/scripts/check-scope.sh
@@ -6,7 +6,7 @@
 # If target file is outside scope (and not results.tsv/run.log), warns.
 #
 # Input: JSON on stdin with tool_input.file_path
-# Output: empty (default allow) or PreToolUse hookSpecificOutput JSON with permissionDecision=allow + reason
+# Output: empty (default allow) or PreToolUse hookSpecificOutput JSON with permissionDecision=ask + reason
 
 set -euo pipefail
 
@@ -37,7 +37,7 @@ fi
 IN_SCOPE=false
 while IFS= read -r line; do
   # Lines under target_files: that start with "  - "
-  target=$(echo "$line" | sed -n 's/^[[:space:]]*-[[:space:]]*"\?\([^"]*\)"\?$/\1/p')
+  target=$(echo "$line" | sed -n 's/^[[:space:]]*-[[:space:]]*"\{0,1\}\([^"]*\)"\{0,1\}$/\1/p')
   if [[ -n "$target" ]]; then
     # Check if FILE_PATH ends with the target pattern
     if [[ "$FILE_PATH" == *"$target"* ]]; then
@@ -45,12 +45,15 @@ while IFS= read -r line; do
       break
     fi
   fi
-done < <(sed -n '/^target_files:/,/^[^ ]/p' "$CONFIG" | head -n -1)
+done < <(sed -n '/^target_files:/,/^[^ ]/p' "$CONFIG" | sed '$d')
 
 if [[ "$IN_SCOPE" == "true" ]]; then
   exit 0
 fi
 
+# Out of scope: escalate to the user instead of auto-approving. permissionDecision
+# "allow" would BYPASS the normal permission prompt and silently let the edit
+# through; "ask" surfaces it so a stray non-target write cannot invalidate the loop.
 cat <<'EOF'
-{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"allow","permissionDecisionReason":"WARNING: This file is outside the experiment target scope. Modifying non-target files during an experiment loop may invalidate results. Proceed with caution."}}
+{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"ask","permissionDecisionReason":"This file is outside the experiment target scope. Modifying non-target files during an experiment loop may invalidate results. Confirm before proceeding."}}
 EOF

--- a/plugins/autoresearch/skills/research-loop/SKILL.md
+++ b/plugins/autoresearch/skills/research-loop/SKILL.md
@@ -30,7 +30,8 @@ LOOP:
   5. Extract metrics from output
   6. Log result to results.tsv (append-only, git-untracked)
   7. IF metric improved -> keep commit (advance branch)
-     ELSE -> git reset --hard HEAD~1 (revert)
+     ELSE -> git reset --hard "$base" (revert to the iteration baseline
+             recorded by the researcher agent's Step 0 preflight; never HEAD~1)
   8. GOTO 1
 ```
 

--- a/plugins/autoresearch/skills/research-loop/references/decision-logic.md
+++ b/plugins/autoresearch/skills/research-loop/references/decision-logic.md
@@ -28,7 +28,7 @@ Experiment completed
 |   |   |   |       +-- REVERT if any complexity added
 |   |   |   |
 |   |   |   +-- NO: Metric same or worse
-|   |   |       +-- REVERT (git reset --hard HEAD~1)
+|   |   |       +-- REVERT (git reset --hard "$base")
 |   |   |
 |   |   +-- (Log result to results.tsv regardless of decision)
 |   |
@@ -41,7 +41,7 @@ Experiment completed
 |           |
 |           +-- Fundamental issue?
 |               +-- Log "crash" to results.tsv
-|               +-- git reset --hard HEAD~1
+|               +-- git reset --hard "$base"
 |               +-- Move on to next hypothesis
 ```
 
@@ -92,11 +92,14 @@ No additional git operation needed.
 ### Revert (discard)
 
 ```bash
-git reset --hard HEAD~1
+git reset --hard "$base"   # the iteration baseline from the agent's Step 0 preflight
 ```
 
-This removes the last commit and restores the working tree.
-The results.tsv entry preserves the record of what was tried.
+`$base` is the commit recorded by the researcher agent's Step 0 revert preflight
+(`base=$(git rev-parse HEAD)`), after it verified the branch is `experiment/*`
+and the tree is clean. Reset to `$base` rather than `HEAD~1` so a miscounted or
+multi-commit revert can never destroy kept work. The results.tsv entry preserves
+the record of what was tried.
 
 ### Crash recovery
 
@@ -109,7 +112,7 @@ git commit --amend -m "experiment: <description> (fix)"
 # Re-run evaluation
 
 # If not fixable
-git reset --hard HEAD~1
+git reset --hard "$base"   # restore the Step 0 baseline
 ```
 
 ## Metric Extraction Patterns

--- a/plugins/autoreview/.claude-plugin/plugin.json
+++ b/plugins/autoreview/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "autoreview",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Autonomous code review plugin using guardrails/semgrep rules. Iteratively scans code with Semgrep, auto-fixes violations, and validates via git-based keep/revert cycles. Supports scan-fix mode, spec-review mode, and distill-rule for converting findings into reusable Semgrep rules.",
   "author": {
     "name": "hironow"

--- a/plugins/autoreview/agents/reviewer.md
+++ b/plugins/autoreview/agents/reviewer.md
@@ -60,6 +60,31 @@ fix violations, rescan, and decide whether to keep or revert the change.
 
 **Review Protocol:**
 
+Step 0 — Revert Preflight (MANDATORY before any change):
+
+The keep/revert cycle is only safe on a throwaway review branch. Before
+modifying anything, verify the loop will not destroy real work:
+
+- Confirm the current branch is a review branch:
+
+  ```bash
+  BRANCH=$(git branch --show-current)
+  [[ "$BRANCH" == review/* ]] || { echo "ERROR: not on review/* — aborting" >&2; exit 1; }
+  ```
+
+- Confirm a clean working tree (no unexpected dirty/untracked files that a
+  hard reset would erase):
+
+  ```bash
+  [[ -z "$(git status --porcelain)" ]] || { echo "ERROR: working tree not clean — aborting" >&2; exit 1; }
+  ```
+
+- Record this iteration's baseline commit SHA — run `git rev-parse HEAD` and keep
+  the value. Claude Code shell variables do NOT persist across separate Bash
+  calls, so treat `$base` in later steps as that literal SHA: paste the recorded
+  hash in (or re-record it inside the same Bash call that reverts). Every revert
+  below returns to this recorded baseline — never a blind `HEAD~1`.
+
 Step 1 — Understand State:
 
 - Read review-config.yaml for mode, targets, categories, limits
@@ -146,7 +171,8 @@ Append result to review-results.tsv (tab-separated):
 Status values: "keep", "revert", "skip", "crash"
 
 Step 10 — Git Action:
-Before any destructive operation, verify the current branch is a review branch:
+Re-assert the Step 0 preflight invariants before any destructive operation
+(still on `review/*`, `base` recorded for this iteration):
 
 ```bash
 BRANCH=$(git branch --show-current)
@@ -156,8 +182,11 @@ if [[ "$BRANCH" != review/* ]]; then
 fi
 ```
 
-- If keep: commit stays, branch advances
-- If revert: `git reset --hard HEAD~1`
+- If keep: commit stays, branch advances (the new HEAD becomes the next
+  iteration's baseline)
+- If revert: `git reset --hard "$base"` (restore the Step 0 baseline; do NOT use
+  `git reset --hard HEAD~1` — a miscounted or multi-commit revert can destroy
+  kept work)
 - If skip: no git action, move to next category
 
 **Error Handling:**
@@ -183,10 +212,13 @@ Return a concise report:
 
 **Critical Rules:**
 
+- ALWAYS run the Step 0 revert preflight (review-branch + clean-tree check,
+  record `base`) before changing any file
 - NEVER modify files outside target_paths
 - NEVER modify review-config.yaml or evaluation harness
 - NEVER skip logging to review-results.tsv
 - ALWAYS commit before rescanning
-- ALWAYS revert on failure (git reset --hard HEAD~1)
+- ALWAYS revert on failure with `git reset --hard "$base"` (the recorded
+  iteration baseline — never `HEAD~1`)
 - ALWAYS check loop limits before starting work
 - ALWAYS verify no cross-category regressions on keep decisions

--- a/plugins/autoreview/hooks/scripts/check-scope.sh
+++ b/plugins/autoreview/hooks/scripts/check-scope.sh
@@ -7,7 +7,7 @@
 # warns the user.
 #
 # Input: JSON on stdin with tool_input.file_path
-# Output: empty (default allow) or PreToolUse hookSpecificOutput JSON with permissionDecision=allow + reason
+# Output: empty (default allow) or PreToolUse hookSpecificOutput JSON with permissionDecision=ask + reason
 
 set -euo pipefail
 
@@ -37,19 +37,22 @@ fi
 # Extract target_paths from config (simple YAML parsing)
 IN_SCOPE=false
 while IFS= read -r line; do
-  target=$(echo "$line" | sed -n 's/^[[:space:]]*-[[:space:]]*"\?\([^"]*\)"\?$/\1/p')
+  target=$(echo "$line" | sed -n 's/^[[:space:]]*-[[:space:]]*"\{0,1\}\([^"]*\)"\{0,1\}$/\1/p')
   if [[ -n "$target" ]]; then
     if [[ "$FILE_PATH" == *"$target"* ]]; then
       IN_SCOPE=true
       break
     fi
   fi
-done < <(sed -n '/^target_paths:/,/^[^ ]/p' "$CONFIG" | head -n -1)
+done < <(sed -n '/^target_paths:/,/^[^ ]/p' "$CONFIG" | sed '$d')
 
 if [[ "$IN_SCOPE" == "true" ]]; then
   exit 0
 fi
 
+# Out of scope: escalate to the user instead of auto-approving. permissionDecision
+# "allow" would BYPASS the normal permission prompt and silently let the edit
+# through; "ask" surfaces it so a stray non-target write cannot slip into the loop.
 cat <<'EOF'
-{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"allow","permissionDecisionReason":"WARNING: This file is outside the review target scope. Modifying non-target files during a review loop may introduce untracked changes. Proceed with caution."}}
+{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"ask","permissionDecisionReason":"This file is outside the review target scope. Modifying non-target files during a review loop may introduce untracked changes. Confirm before proceeding."}}
 EOF

--- a/plugins/autoreview/skills/review-loop/SKILL.md
+++ b/plugins/autoreview/skills/review-loop/SKILL.md
@@ -80,7 +80,8 @@ Append to review-results.tsv (tab-separated):
 ### 8. Git Action
 
 - **keep**: Commit stays, proceed to next iteration
-- **revert**: `git reset --hard HEAD~1`, try a different approach or skip
+- **revert**: `git reset --hard "$base"` (the iteration baseline recorded by the
+  reviewer agent's Step 0 preflight; never `HEAD~1`), try a different approach or skip
 
 ## Loop Control
 

--- a/tests/unit/test_agent_hooks.py
+++ b/tests/unit/test_agent_hooks.py
@@ -292,6 +292,41 @@ def test_force_push_to_main_is_blocked(tmp_path: Path) -> None:
     assert _run_hook("git push --force origin main", tmp_path) == EXIT_BLOCK
 
 
+@pytest.mark.parametrize(
+    "command",
+    [
+        pytest.param("git push --force origin main", id="long-flag-before-ref"),
+        pytest.param("git push -f origin main", id="short-flag"),
+        pytest.param("git push origin main --force", id="flag-after-ref"),
+        pytest.param("git push --force-with-lease origin main", id="force-with-lease"),
+        pytest.param(
+            "git push --force-if-includes origin main", id="force-if-includes"
+        ),
+        pytest.param("git push --force origin master", id="master-branch"),
+        pytest.param("git push -f origin HEAD:main", id="refspec-dest-main"),
+        pytest.param("git -C /repo push -f origin main", id="git-global-opt"),
+    ],
+)
+def test_force_push_to_protected_branch_is_blocked(
+    command: str, tmp_path: Path
+) -> None:
+    assert _run_hook(command, tmp_path) == EXIT_BLOCK
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        pytest.param("git push -f origin feature", id="force-feature-branch"),
+        pytest.param("git push origin main", id="non-force-to-main"),
+        pytest.param(
+            'git commit -m "git push --force origin main"', id="prose-mention"
+        ),
+    ],
+)
+def test_non_protected_force_push_is_allowed(command: str, tmp_path: Path) -> None:
+    assert _run_hook(command, tmp_path) == EXIT_ALLOW
+
+
 def test_readonly_gcloud_is_allowed(tmp_path: Path) -> None:
     assert _run_hook("gcloud compute instances list", tmp_path) == EXIT_ALLOW
 


### PR DESCRIPTION
## Summary

dotfiles の AI 指示系 (hooks / plugins / skills / rules) を全レビューし、codex の独立レビューで裏取りした安全系 finding (S/A 級) を修正する。レビュー提案全体は `private/reviews/` (gitignored, local-only)。

### H-1: force-push ガードをパーサ方式へ (`c6ed466`)

- 旧 regex は `--force-with-lease` / `--force-if-includes` / 語順違いを素通しし、逆に commit メッセージ中の prose (`commit -m "...push --force...main"`) を誤ブロックしていた
- パーサ側で `git push` の引数を解釈し、force 系フラグ + main/master refspec を語順非依存で block。テスト 12 件追加

### P-2 + P-3: check-scope hook の gate 化と BSD/macOS 移植性 (`e47c051`)

- out-of-scope 編集の `permissionDecision` を `allow` → `ask` に (警告のつもりで自動承認していた)
- GNU-ism を 2 件除去: `head -n -1` → POSIX `sed '$d'`、sed の `\?` → `\{0,1\}`。旧版は **macOS で完全に非機能** だった (fixture E2E で in/out/whitelist を確認)

### P-1 + P-6: keep/revert ループの revert preflight (`d8fa9b6`)

- autoresearch / autodesign / autoreview の 3 agent に統一 preflight: branch 確認 + clean-tree + baseline SHA 記録 → 失敗時は記録した SHA へ reset
- bare な `git reset --hard HEAD~1` を operative 箇所すべてで baseline 方式へ置換 (Bash コール間で shell 変数が永続しない前提も明記)

### chore: plugin version bump (`30b2826`)

autoresearch 0.1.2 / autodesign 0.2.2 / autoreview 0.2.2 / marketplace 1.3.1

## Verification

`just ci` フルパス: shellcheck / markdownlint / ruff / `semgrep --test` 27/27 / `tofu test` / unit 74 passed。check-scope 3 本は macOS 実機で fixture E2E 済み。

## Not in this PR

- `just sync-agents` の実行 (deploy は別途、指示により保留)
- B/C 級 finding (`private/reviews/00-summary.md` に列挙)