### PR TITLE
ci: SHA-pin test-emulators actions to fix startup_failure

### DIFF
--- a/.github/workflows/test-emulators.yaml
+++ b/.github/workflows/test-emulators.yaml
@@ -29,15 +29,15 @@ jobs:
         working-directory: emulator
 
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
     - name: Set up Python
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
         python-version: '3.14'
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v7
+      uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
 
     - name: Install dependencies (uv sync --frozen)
       run: |


### PR DESCRIPTION
The **Test Emulators** workflow has been `startup_failure` on every run since ~2026-06-10. Root cause: it was the only workflow using mutable tag refs (`actions/checkout@v6`, `actions/setup-python@v6`, `astral-sh/setup-uv@v7`) while this repo requires full-SHA-pinned actions — the policy violation rejects the workflow at startup, so it never ran its `uv sync` / emulator / e2e steps.

Pin all three to the commit SHA behind their current release:
- `actions/checkout` → `de0fac2` (v6.0.2, matching the other workflows)
- `actions/setup-python` → `a309ff8` (v6.2.0)
- `astral-sh/setup-uv` → `37802ad` (v7.6.0)

This makes the workflow start and run for real — which also exercises the ADR 0028 flatt install path (`uv sync --all-extras --frozen` pulling from the flatt mirror). If long-dormant downstream steps (docker / emulator services / e2e) surface failures, those are separate from this startup fix.