### PR TITLE
fix(emulator): skip profiled-service tests when not on the lite stack

### DIFF
--- a/.github/workflows/test-emulators.yaml
+++ b/.github/workflows/test-emulators.yaml
@@ -78,9 +78,11 @@ jobs:
     - name: Wait for services to be ready
       run: bash scripts/wait-for-services.sh --default 90 --a2a 180 --postgres 150
 
-    - name: Test Elasticsearch separately
-      timeout-minutes: 2
-      run: bash scripts/test-elasticsearch.sh
+    # Elasticsearch is behind the `search` capability profile (ADR 0016 / PR #120)
+    # and is not started by the default lite stack, so the standalone ES check is
+    # redundant here -- tests/test_elasticsearch_emulator.py covers it and skips
+    # when the container is absent. scripts/test-elasticsearch.sh stays for manual
+    # use when the search profile is brought up locally.
 
     - name: Run unit/integration tests (non-e2e)
       timeout-minutes: 5

--- a/emulator/tests/test_a2a_inspector.py
+++ b/emulator/tests/test_a2a_inspector.py
@@ -1,6 +1,13 @@
 import pytest
 import docker
 
+from tests.utils.helpers import skip_unless_container_running
+
+
+@pytest.fixture(autouse=True)
+def _require_a2a_inspector():
+    skip_unless_container_running("a2a-inspector")
+
 
 @pytest.mark.asyncio
 async def test_a2a_inspector_container_starts(http_client):

--- a/emulator/tests/test_a2a_inspector_build.py
+++ b/emulator/tests/test_a2a_inspector_build.py
@@ -1,11 +1,16 @@
+import re
 from pathlib import Path
+
+# Match the runtime base on Python 3.12, allowing an optional patch pin
+# (`python:3.12-slim` or `python:3.12.13-slim`); the Dockerfile pins the patch.
+_PY312_SLIM = re.compile(r"^FROM python:3\.12(\.\d+)?-slim\b")
 
 
 def test_a2a_inspector_dockerfile_uses_python_312() -> None:
     dockerfile_lines = Path("a2a-inspector/Dockerfile").read_text().splitlines()
-    assert any(
-        line.strip().startswith("FROM python:3.12-slim") for line in dockerfile_lines
-    ), "Expected runtime stage to base on python:3.12-slim"
+    assert any(_PY312_SLIM.match(line.strip()) for line in dockerfile_lines), (
+        "Expected runtime stage to base on python:3.12(.x)-slim"
+    )
 
 
 def test_docker_compose_uses_local_a2a_inspector_context() -> None:

--- a/emulator/tests/test_bigtable_emulator.py
+++ b/emulator/tests/test_bigtable_emulator.py
@@ -1,6 +1,13 @@
 import pytest
 import docker
 
+from tests.utils.helpers import skip_unless_container_running
+
+
+@pytest.fixture(autouse=True)
+def _require_bigtable():
+    skip_unless_container_running("bigtable-emulator")
+
 
 def test_bigtable_container_starts():
     """Test that the Bigtable emulator container starts and is healthy."""

--- a/emulator/tests/test_elasticsearch_emulator.py
+++ b/emulator/tests/test_elasticsearch_emulator.py
@@ -1,6 +1,13 @@
 import pytest
 import docker
 
+from tests.utils.helpers import skip_unless_container_running
+
+
+@pytest.fixture(autouse=True)
+def _require_elasticsearch():
+    skip_unless_container_running("elasticsearch-emulator")
+
 
 @pytest.mark.asyncio
 async def test_elasticsearch_container_starts(http_client):

--- a/emulator/tests/test_mlflow_emulator.py
+++ b/emulator/tests/test_mlflow_emulator.py
@@ -1,6 +1,13 @@
 import pytest
 import docker
 
+from tests.utils.helpers import skip_unless_container_running
+
+
+@pytest.fixture(autouse=True)
+def _require_mlflow():
+    skip_unless_container_running("mlflow-server")
+
 
 @pytest.mark.asyncio
 async def test_mlflow_container_starts(http_client):

--- a/emulator/tests/test_neo4j_emulator.py
+++ b/emulator/tests/test_neo4j_emulator.py
@@ -1,6 +1,13 @@
 import pytest
 import docker
 
+from tests.utils.helpers import skip_unless_container_running
+
+
+@pytest.fixture(autouse=True)
+def _require_neo4j():
+    skip_unless_container_running("neo4j-emulator")
+
 
 @pytest.mark.asyncio
 async def test_neo4j_container_starts(http_client):

--- a/emulator/tests/test_qdrant_emulator.py
+++ b/emulator/tests/test_qdrant_emulator.py
@@ -1,6 +1,13 @@
 import pytest
 import docker
 
+from tests.utils.helpers import skip_unless_container_running
+
+
+@pytest.fixture(autouse=True)
+def _require_qdrant():
+    skip_unless_container_running("qdrant-emulator")
+
 
 @pytest.mark.asyncio
 async def test_qdrant_container_starts(http_client):

--- a/emulator/tests/utils/helpers.py
+++ b/emulator/tests/utils/helpers.py
@@ -58,3 +58,20 @@ def wait_for_tcp(host: str, port: int, retries: int = 30) -> Result[bool, str]:
             last_error = str(e)
         time.sleep(1)
     return Error(f"TCP endpoint {host}:{port} not accessible: {last_error}")
+
+
+def skip_unless_container_running(name: str) -> None:
+    """pytest.skip the calling test unless a container named `name` is running.
+
+    lite-default (ADR 0016 / PR #120): capability emulators (search/graph/vector/
+    bigtable/inspect/ml) sit behind compose profiles and are NOT started by the
+    default lite stack, so their integration tests must skip rather than fail when
+    the container is absent. Mirrors the e2e `require_services` fixture for the
+    non-e2e suite.
+    """
+    import pytest
+
+    client = docker.from_env()
+    running = {c.name for c in client.containers.list()}
+    if name not in running:
+        pytest.skip(f"required emulator container not running: {name}")


### PR DESCRIPTION
## Problem

Test Emulators went red on main once #197 made it actually run (it had been `startup_failure` for 9 days). Root cause is lite-default drift (ADR 0016 / PR #120): elasticsearch / neo4j / qdrant / bigtable / a2a-inspector / mlflow now sit behind compose **capability profiles** and are not started by the default lite stack, but their non-e2e integration tests still `pytest.fail` when the container is absent. (e2e tests already skip via `require_services`.)

## Fix

- Add `skip_unless_container_running(name)` to `tests/utils/helpers.py` (mirrors the e2e `require_services` skip).
- Add an autouse guard to the **6** profiled-service non-e2e tests so they skip under lite and still run when the full stack is up: elasticsearch / neo4j / qdrant / bigtable / a2a-inspector / mlflow.
- Drop the redundant standalone **Test Elasticsearch separately** workflow step (`test_elasticsearch_emulator.py` covers it and now skips when search isn't up; `scripts/test-elasticsearch.sh` stays for local use).

## Expectation

Test Emulators goes green: `uv sync --frozen` (flatt install) stays ✓, the 6 profiled tests **skip**, and the lite-service tests (firebase/spanner/pgadapter/postgres + functional) run. Validated on the amd64 CI runner (local box is arm64).